### PR TITLE
fix: 통계 키 라벨 수직 중앙 정렬

### DIFF
--- a/src/renderer/components/Key.jsx
+++ b/src/renderer/components/Key.jsx
@@ -615,7 +615,7 @@ export default function DraggableKey({
     const nameElement = (
       <span
         key="label"
-        className="font-bold text-[14px] pointer-events-none select-none"
+        className="font-bold text-[14px] pointer-events-none select-none leading-none"
         style={textStyle}
       >
         {labelText}


### PR DESCRIPTION
## 요약
통계 키 라벨의 정렬이 시각적으로 위로 치우쳐 보이던 문제를 수정했습니다.

## 변경 사항
- 라벨 텍스트의 line-height/정렬 스타일을 조정해 중앙 정렬되도록 보정

## Before / After
before:
<img width="85" height="73" alt="스크린샷 2026-02-09 오후 10 15 03" src="https://github.com/user-attachments/assets/cfc85355-56d3-475e-971b-abc2fa15de0f" />

after:
<img width="85" height="73" alt="스크린샷 2026-02-09 오후 10 15 22" src="https://github.com/user-attachments/assets/4ea01139-c93b-484d-a646-998d6345e9f2" />

## 테스트
- Overlay에서 통계 키 라벨이 컨테이너 중앙에 정렬되는지 확인
