### PR TITLE
feat: 리사이즈 기준점에 고정 옵션 추가

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -266,6 +266,8 @@ impl AppState {
         height: f64,
         anchor: Option<String>,
         content_top_offset: Option<f64>,
+        fixed_position_delta_x: Option<f64>,
+        fixed_position_delta_y: Option<f64>,
     ) -> Result<OverlayBounds> {
         // 오버레이가 이미 열려있을 때만 리사이즈 수행
         // 창이 없으면 에러 반환 (창을 자동으로 생성하지 않음)
@@ -302,7 +304,17 @@ impl AppState {
                 new_x += (size.width - width) / 2.0;
                 new_y += (size.height - height) / 2.0;
             }
+            OverlayResizeAnchor::FixedPosition => {}
             OverlayResizeAnchor::TopLeft => {}
+        }
+
+        if anchor == OverlayResizeAnchor::FixedPosition {
+            if let Some(delta_x) = fixed_position_delta_x.filter(|value| value.is_finite()) {
+                new_x += delta_x;
+            }
+            if let Some(delta_y) = fixed_position_delta_y.filter(|value| value.is_finite()) {
+                new_y += delta_y;
+            }
         }
 
         if let Some(offset) = content_top_offset {
@@ -317,6 +329,7 @@ impl AppState {
                     match anchor {
                         OverlayResizeAnchor::Center => new_y -= delta / 2.0,
                         OverlayResizeAnchor::BottomLeft | OverlayResizeAnchor::BottomRight => {}
+                        OverlayResizeAnchor::FixedPosition => new_y -= delta,
                         _ => new_y -= delta,
                     }
                 }

--- a/src-tauri/src/commands/overlay.rs
+++ b/src-tauri/src/commands/overlay.rs
@@ -15,6 +15,10 @@ pub struct OverlayResizeArgs {
     pub anchor: Option<String>,
     #[serde(default)]
     pub content_top_offset: Option<f64>,
+    #[serde(default)]
+    pub fixed_position_delta_x: Option<f64>,
+    #[serde(default)]
+    pub fixed_position_delta_y: Option<f64>,
 }
 
 #[tauri::command(permission = "dmnote-allow-all")]
@@ -68,6 +72,8 @@ pub fn overlay_resize(
             payload.height,
             payload.anchor,
             payload.content_top_offset,
+            payload.fixed_position_delta_x,
+            payload.fixed_position_delta_y,
         )
         .map_err(|err| err.to_string())
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -565,6 +565,7 @@ pub enum OverlayResizeAnchor {
     BottomLeft,
     BottomRight,
     Center,
+    FixedPosition,
 }
 
 impl Default for OverlayResizeAnchor {
@@ -630,6 +631,7 @@ impl OverlayResizeAnchor {
             OverlayResizeAnchor::BottomLeft => "bottom-left",
             OverlayResizeAnchor::BottomRight => "bottom-right",
             OverlayResizeAnchor::Center => "center",
+            OverlayResizeAnchor::FixedPosition => "fixed-position",
         }
     }
 }
@@ -641,6 +643,7 @@ pub fn overlay_resize_anchor_from_str(value: &str) -> Option<OverlayResizeAnchor
         "bottom-left" => Some(OverlayResizeAnchor::BottomLeft),
         "bottom-right" => Some(OverlayResizeAnchor::BottomRight),
         "center" => Some(OverlayResizeAnchor::Center),
+        "fixed-position" => Some(OverlayResizeAnchor::FixedPosition),
         _ => None,
     }
 }

--- a/src/renderer/api/dmnoteApi.ts
+++ b/src/renderer/api/dmnoteApi.ts
@@ -221,6 +221,8 @@ const api: DMNoteAPI = {
       height: number;
       anchor?: string;
       contentTopOffset?: number;
+      fixedPositionDeltaX?: number;
+      fixedPositionDeltaY?: number;
     }) => invoke<OverlayBounds>("overlay_resize", { payload }),
     onVisibility: (listener: (payload: OverlayVisibilityPayload) => void) =>
       subscribe<OverlayVisibilityPayload>("overlay:visibility", listener),

--- a/src/renderer/components/main/Settings.jsx
+++ b/src/renderer/components/main/Settings.jsx
@@ -89,6 +89,7 @@ export default function Settings({ showAlert, showConfirm }) {
     { value: "top-right", key: "topRight" },
     { value: "bottom-right", key: "bottomRight" },
     { value: "center", key: "center" },
+    { value: "fixed-position", key: "fixedPosition" },
   ];
 
   const ANGLE_OPTIONS = [

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -25,6 +25,7 @@
     "topRight": "Top-Right",
     "bottomRight": "Bottom-Right",
     "center": "Center",
+    "fixedPosition": "Fixed Position",
     "graphicsOption": "Graphics API",
     "renderMode": "Select Rendering Mode",
     "resetData": "Reset Data",

--- a/src/renderer/locales/ko.json
+++ b/src/renderer/locales/ko.json
@@ -25,6 +25,7 @@
     "topRight": "우상단",
     "bottomRight": "우하단",
     "center": "가운데",
+    "fixedPosition": "위치 고정",
     "graphicsOption": "그래픽 렌더링 옵션",
     "renderMode": "렌더링 모드 선택",
     "resetData": "데이터 초기화",

--- a/src/renderer/windows/overlay/App.tsx
+++ b/src/renderer/windows/overlay/App.tsx
@@ -504,6 +504,8 @@ export default function App() {
     height: number;
     anchor: string;
     contentTopOffset: number;
+    minX: number;
+    minY: number;
   } | null>(null);
 
   useEffect(() => {
@@ -515,15 +517,29 @@ export default function App() {
     const totalWidth = keyAreaWidth + PADDING * 2;
     const totalHeight = keyAreaHeight + PADDING * 2 + extraTop;
     const contentTopOffset = extraTop + PADDING;
+    const currentMinX = bounds.minX;
+    const currentMinY = bounds.minY;
 
     // 이전 값과 비교하여 실제로 변경되었을 때만 resize 호출
     const lastParams = lastResizeParams.current;
+    const fixedPositionAnchor = overlayAnchor === "fixed-position";
+    const fixedPositionDeltaX =
+      fixedPositionAnchor && lastParams?.anchor === "fixed-position"
+        ? currentMinX - lastParams.minX
+        : 0;
+    const fixedPositionDeltaY =
+      fixedPositionAnchor && lastParams?.anchor === "fixed-position"
+        ? currentMinY - lastParams.minY
+        : 0;
     if (
       lastParams &&
       Math.abs(lastParams.width - totalWidth) < 0.5 &&
       Math.abs(lastParams.height - totalHeight) < 0.5 &&
       lastParams.anchor === overlayAnchor &&
-      Math.abs(lastParams.contentTopOffset - contentTopOffset) < 0.5
+      Math.abs(lastParams.contentTopOffset - contentTopOffset) < 0.5 &&
+      (!fixedPositionAnchor ||
+        (Math.abs(lastParams.minX - currentMinX) < 0.5 &&
+          Math.abs(lastParams.minY - currentMinY) < 0.5))
     ) {
       return; // 변경사항 없음, resize 건너뛰기
     }
@@ -533,6 +549,8 @@ export default function App() {
       height: totalHeight,
       anchor: overlayAnchor,
       contentTopOffset,
+      minX: currentMinX,
+      minY: currentMinY,
     };
 
     window.api.overlay
@@ -541,6 +559,12 @@ export default function App() {
         height: totalHeight,
         anchor: overlayAnchor,
         contentTopOffset,
+        fixedPositionDeltaX: fixedPositionAnchor
+          ? fixedPositionDeltaX
+          : undefined,
+        fixedPositionDeltaY: fixedPositionAnchor
+          ? fixedPositionDeltaY
+          : undefined,
       })
       .catch((error) => {
         console.error("Failed to resize overlay window", error);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -655,6 +655,8 @@ export interface DMNoteAPI {
       height: number;
       anchor?: string;
       contentTopOffset?: number;
+      fixedPositionDeltaX?: number;
+      fixedPositionDeltaY?: number;
     }): Promise<OverlayBounds>;
     onVisibility(
       listener: (payload: OverlayVisibilityPayload) => void,

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -17,7 +17,8 @@ export type OverlayResizeAnchor =
   | "top-right"
   | "bottom-left"
   | "bottom-right"
-  | "center";
+  | "center"
+  | "fixed-position";
 
 export interface GridSettings {
   alignmentGuides: boolean;


### PR DESCRIPTION
## 배경
키 버튼 위치를 이동할 때,
리사이즈 기준점 옵션에 따라 오버레이의 기준 좌표가 변경되면서
화면상에 보이던 키 버튼의 위치가 함께 밀리는 문제가 있었습니다.

그 결과, 특정 위치에 정밀하게 배치해 둔 키 버튼들이
의도치 않게 이동하여 다시 재배치해야 하는 불편함을 겪었습니다.

기존에도 리사이즈 기준점을
옮길 방향의 반대 방향으로 수동 변경하면서
키 버튼들의 화면상 위치를 유지할 수는 있었지만,
과정이 번거롭고 직관적이지 않았습니다.

## before
<img width="312" height="211" alt="스크린샷 2026-02-14 오후 4 08 53" src="https://github.com/user-attachments/assets/6cf1709f-0eee-4765-a9dd-dbd752076ee7" />

https://github.com/user-attachments/assets/1399e8fc-acd0-42ed-bcb2-3f8de97b780a


## after
<img width="314" height="226" alt="스크린샷 2026-02-14 오후 6 16 30" src="https://github.com/user-attachments/assets/e0f76442-d97f-43cd-8259-55c0510179cb" />

https://github.com/user-attachments/assets/0352c374-5884-4112-ba5e-85e83c2a12fa


## 변경사항
- 리사이즈 기준점 옵션에 `위치 고정 (fixed-position)` 추가
- `fixed-position` 선택 시, 화면상 위치가 유지되는 보정 로직 추가

## 원리 요약
- 키 버튼 이동 시, 레이아웃의 좌표 변화량만큼
   오버레이 창 좌표를 반대로 보정
- 결과적으로 화면상 위치 변화가 상쇄됨
   키 버튼들이 가만히 있는 거처럼 보임

즉, `fixed-position`은 리사이즈는 그대로 적용하되,
화면에 보이는 배치만 고정하는 옵션입니다.

## 이슈
- 키 버튼 이동 시, 짧은 순간 오버레이가 살짝 흔들려 보임
   (해결 방법은 찾지 못함)
