### PR TITLE
fix: 단노트 길이 일관성 유지 시 롱노트가 threshold만큼 짧게 표시되는 버그

### DIFF
--- a/src/renderer/hooks/overlay/useNoteSystem.ts
+++ b/src/renderer/hooks/overlay/useNoteSystem.ts
@@ -431,10 +431,15 @@ export function useNoteSystem({
       noteRef?.startTime ?? state.startTime ?? state.downTime ?? releaseTime;
     const clampedStart = Math.min(releaseTime, baselineStart);
     const holdDurationFromStart = Math.max(0, releaseTime - clampedStart);
+    // delayed mode: 시작 표시가 threshold만큼 지연되므로 실제 입력 유지 시간 기준으로 길이 계산 (종료도 동일하게 지연)
+    const physicalHoldMs =
+      state.useDelay && state.downTime != null
+        ? Math.max(0, releaseTime - state.downTime)
+        : holdDurationFromStart;
     const minLengthMs = computeMinLengthMs();
     const desiredDuration = forceMinLength
       ? minLengthMs
-      : Math.max(minLengthMs, holdDurationFromStart);
+      : Math.max(minLengthMs, physicalHoldMs);
     const safeDuration = Math.max(desiredDuration, 1);
     const targetEndTime = state.startTime + safeDuration;
 


### PR DESCRIPTION
## 개요

**단노트 길이 일관성 유지**를 켠 상태에서 롱노트의 표시 길이가 단노트 구분 시간(threshold)만큼 짧아지는 버그 수정 (#78)

delayed mode는 단/롱노트 구분을 위해 keydown 직후 바로 노트를 만들지 않고 threshold만큼 기다렸다가 생성하는데 (`startTime = downTime + threshold`), 종료 계산은 그 늦춰진 `startTime`부터 keyup까지만 표시 길이로 쓰고 있는 중
그래서 `targetEndTime`이 사실상 `releaseTime`이 돼버려서, 시작만 늦어지고 끝은 안 늦어져 표시 길이가 실제 입력보다 threshold만큼 잘렸습니다.

원인 분석과 해결 방안까지 정리해 주신 @engp114 님의 이슈 제보 기반

## 변경 내용

### 프론트엔드

- `scheduleNoteFinalization()`에서 delayed mode일 때 표시 길이를 실제 입력 유지 시간(`releaseTime - downTime`) 기준으로 계산
- 결과적으로 `targetEndTime = releaseTime + threshold` 시작과 종료가 동일하게 지연돼 노트 전체가 시간 이동되고, 표시 길이 = 실제 입력 길이로 일치
- threshold 전에 키를 뗀 단노트(`forceMinLength`)와 일관성 유지 OFF 경로는 기존 동작 그대로

## 테스트

- delayed mode에서 롱노트 표시 길이가 실제 홀드 시간과 일치하는지 확인 (이슈 첨부 테스트 영상과 동일한 결과)
- threshold 직전 릴리즈(단노트), 같은 키 빠른 재입력, 단노트 최소 길이 클램프 동작 회귀 없음
- `tsc --noEmit` / eslint / prettier 통과

> 수정 후에는 키를 뗀 뒤에도 노트가 threshold만큼 더 자라다 끝나는데, 시작이 늦춰진 만큼 종료도 늦춰진 의도된 동작입니다.