### PR TITLE
fix: 오버레이 창 고정/항상 위 토글 시 오버레이가 사라지는 버그

### DIFF
--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -1181,6 +1181,8 @@ impl AppState {
         let window = window_builder
             .always_on_top(true)
             .skip_taskbar(false)
+            // 첫 표시를 SW_SHOWNOACTIVATE로 처리하도록 tao에 지시 (포커스 미탈취)
+            .focused(false)
             .visible(snapshot.overlay_visible)
             .inner_size(bounds.width, bounds.height)
             .position(bounds.x, bounds.y)
@@ -1210,10 +1212,12 @@ impl AppState {
         }
 
         // Windows 오버레이 창 포커스 수신 방지
+        // set_focusable(false): tao가 FOCUSABLE 플래그로 WS_EX_NOACTIVATE를 추적 적용
+        // (raw SetWindowLongW 적용 시 이후 tao의 스타일 재적용에서 NOACTIVATE가 소실됨)
         #[cfg(target_os = "windows")]
         {
-            if let Err(err) = set_window_no_activate(&window) {
-                log::warn!("failed to set WS_EX_NOACTIVATE for overlay: {err}");
+            if let Err(err) = window.set_focusable(false) {
+                log::warn!("failed to set overlay non-focusable: {err}");
             }
             // 시스템 컨텍스트 메뉴 비활성화
             if let Err(err) = disable_system_context_menu(&window) {
@@ -1818,6 +1822,9 @@ fn show_overlay_window(window: &WebviewWindow, _always_on_top: bool) -> Result<(
         unsafe {
             let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
         }
+        // tao 내부 VISIBLE 플래그 동기화 — raw ShowWindow는 tao 상태를 갱신하지 않아,
+        // 이후 set_always_on_top/set_ignore_cursor_events 호출 시 tao가 창을 숨겨버림
+        window.show()?;
         Ok(())
     }
     #[cfg(target_os = "macos")]
@@ -1837,21 +1844,9 @@ fn show_overlay_window(window: &WebviewWindow, _always_on_top: bool) -> Result<(
 }
 
 fn hide_overlay_window(window: &WebviewWindow) -> Result<()> {
-    #[cfg(target_os = "windows")]
-    {
-        use windows::Win32::UI::WindowsAndMessaging::{ShowWindow, SW_HIDE};
-
-        let hwnd = window.hwnd()?;
-        unsafe {
-            let _ = ShowWindow(hwnd, SW_HIDE);
-        }
-        Ok(())
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        window.hide()?;
-        Ok(())
-    }
+    // tao API 사용으로 내부 VISIBLE 플래그와 실제 창 상태 일치 유지
+    window.hide()?;
+    Ok(())
 }
 
 /// macOS 전체화면 Space에서도 오버레이가 보이도록 NSWindow 동작을 보정
@@ -1890,20 +1885,6 @@ fn apply_macos_overlay_fullscreen_behavior_inner(window: &WebviewWindow, always_
             log::warn!("macOS overlay: failed to get NSWindow handle: {err}");
         }
     }
-}
-
-#[cfg(target_os = "windows")]
-fn set_window_no_activate(window: &WebviewWindow) -> Result<()> {
-    use windows::Win32::UI::WindowsAndMessaging::{
-        GetWindowLongW, SetWindowLongW, GWL_EXSTYLE, WS_EX_NOACTIVATE,
-    };
-
-    let hwnd = window.hwnd()?;
-    unsafe {
-        let ex_style = GetWindowLongW(hwnd, GWL_EXSTYLE);
-        SetWindowLongW(hwnd, GWL_EXSTYLE, ex_style | WS_EX_NOACTIVATE.0 as i32);
-    }
-    Ok(())
 }
 
 /// 드래그 가능한 영역에서 시스템 컨텍스트 메뉴(이전 크기, 이동, 최소화 등)가 표시되지 않도록 설정


### PR DESCRIPTION
## 개요

설정에서 **오버레이 창 고정**이나 **항상 위에 표시**를 토글하면 오버레이 창이 꺼져버리는 버그 수정

Windows에서 오버레이 show/hide를 raw `ShowWindow`로 처리하고 있어서 tao 내부 VISIBLE 플래그가 실제 창 상태와 어긋나는 중
tao는 윈도우 플래그가 하나라도 바뀌면 내부 상태 기준으로 창 상태를 통째로 재적용하는데(`apply_diff`), 이때 내부 VISIBLE이 false면 무조건 `SW_HIDE`를 호출하는 문제가 있어요.
그래서 "숨김으로 생성됐다가 raw로 표시된" 창(= 앱 시작 시 오버레이가 꺼져 있다가 나중에 켠 세션)에서 `set_ignore_cursor_events`/`set_always_on_top`이 불리는 순간 창이 증발
앱 시작부터 오버레이가 켜져 있으면 플래그가 일치해서 멀쩡한 거였고 글로벌 단축키로 토글해도 동일하게 발생하는 문제였습니다.

같은 메커니즘으로 raw `SetWindowLongW`로 적용한 `WS_EX_NOACTIVATE`도 tao가 모르는 상태라 스타일 재적용 때 소실되고 토글 한 번 후부터 오버레이가 클릭 시 포커스를 뺏는 잠재 버그도 같이 있었습니다.

raw `ShowWindow` 우회가 들어온 92109f1(1.3.0)부터 있던 문제

## 변경 내용

### 백엔드

- `show_overlay_window`: raw `ShowWindow(SW_SHOWNOACTIVATE)` 직후 `window.show()` 호출로 tao 내부 VISIBLE 플래그 동기화
- `hide_overlay_window`: raw `SW_HIDE` → tao `window.hide()`로 교체 (숨김은 포커스 우려가 없어 우회 자체가 불필요)
- raw `set_window_no_activate` 제거 → `window.set_focusable(false)`로 대체 — tao가 FOCUSABLE 플래그로 `WS_EX_NOACTIVATE`를 추적해서 스타일 재적용에도 보존
- 오버레이 빌더에 `.focused(false)` 추가 tao의 첫 표시가 `SW_SHOWNOACTIVATE`로 처리되도록 변경

macOS는 원래 tao API 경로를 쓰고 있어서 변경 안 했어용

## 테스트

- 오버레이를 끈 상태로 앱 시작 → 오버레이 켜기 → 창 고정/항상 위 토글 시 오버레이 유지 (기존 100% 재현 경로)
- 토글 후 오버레이 클릭 시 포커스 미탈취 (NOACTIVATE 보존)
- 오버레이 숨김/재표시 반복, 글로벌 단축키 토글 회귀 없음
- `cargo check` / `cargo clippy` / `cargo fmt` 통과