### PR TITLE
fix: handle macOS keypad key labels

### DIFF
--- a/src-tauri/src/keyboard/daemon/macos.rs
+++ b/src-tauri/src/keyboard/daemon/macos.rs
@@ -216,7 +216,7 @@ fn labels_from_key_name(name: &str) -> Vec<String> {
         }
     }
 
-    let numpad_prefixes = ["numpad", "num_pad"];
+    let numpad_prefixes = ["numpad", "num_pad", "kp"];
     for prefix in numpad_prefixes {
         if let Some(rest) = name_lower.strip_prefix(prefix) {
             if rest.len() == 1 && rest.chars().all(|c| c.is_ascii_digit()) {
@@ -224,11 +224,11 @@ fn labels_from_key_name(name: &str) -> Vec<String> {
                 return labels;
             }
             let numpad_label = match rest {
-                "add" => Some("NUMPAD PLUS"),
-                "subtract" => Some("NUMPAD MINUS"),
+                "add" | "plus" => Some("NUMPAD PLUS"),
+                "subtract" | "minus" => Some("NUMPAD MINUS"),
                 "multiply" => Some("NUMPAD MULTIPLY"),
                 "divide" => Some("NUMPAD DIVIDE"),
-                "decimal" => Some("NUMPAD DELETE"),
+                "decimal" | "delete" => Some("NUMPAD DELETE"),
                 "enter" | "return" => Some("NUMPAD RETURN"),
                 _ => None,
             };
@@ -242,7 +242,45 @@ fn labels_from_key_name(name: &str) -> Vec<String> {
     labels
 }
 
+fn mac_virtual_keycode_labels(key: rdev::Key) -> Option<Vec<String>> {
+    let rdev::Key::Unknown(code) = key else {
+        return None;
+    };
+
+    let label = match code {
+        65 => "NUMPAD DELETE",
+        67 => "NUMPAD MULTIPLY",
+        69 => "NUMPAD PLUS",
+        71 => "NUM LOCK",
+        75 => "NUMPAD DIVIDE",
+        76 => "NUMPAD RETURN",
+        78 => "NUMPAD MINUS",
+        82 => "NUMPAD 0",
+        83 => "NUMPAD 1",
+        84 => "NUMPAD 2",
+        85 => "NUMPAD 3",
+        86 => "NUMPAD 4",
+        87 => "NUMPAD 5",
+        88 => "NUMPAD 6",
+        89 => "NUMPAD 7",
+        91 => "NUMPAD 8",
+        92 => "NUMPAD 9",
+        114 => "INS",
+        115 => "HOME",
+        116 => "PAGE UP",
+        117 => "DELETE",
+        119 => "END",
+        121 => "PAGE DOWN",
+        _ => return None,
+    };
+
+    Some(vec![label.to_string()])
+}
+
 fn mac_key_labels(key: rdev::Key, name_hint: Option<&str>) -> Vec<String> {
+    if let Some(labels) = mac_virtual_keycode_labels(key) {
+        return labels;
+    }
     if let Some(name) = name_hint {
         if let Some(labels) = labels_from_name_hint(name) {
             return labels;


### PR DESCRIPTION
**Title**  
macOS 넘버패드 및 일부 특수 키 입력 처리 수정

**Body**  
## 요약

- macOS에서 넘버패드 키가 눌린 상태로 남는 문제를 수정했습니다.
- `PageDown`, `PageUp`, `Home`, `End` 등 일부 키가 입력으로 인식되지 않는 문제를 수정했습니다.
- `rdev`가 macOS에서 `Unknown(code)`으로 전달하는 키를 앱의 기존 global key 라벨로 매핑하도록 보완했습니다.

## 문제

macOS에서 일부 넘버패드/특수 키는 `rdev` 이벤트에서 명확한 키 이름 대신 `Unknown(code)` 형태로 전달됩니다.

기존 구현은 press 이벤트에서만 `event.name` 힌트로 라벨을 만들 수 있었고, release 이벤트에서는 같은 라벨을 만들지 못하는 경우가 있었습니다. 이 때문에 넘버패드 키를 눌렀을 때 press는 처리되지만 release가 처리되지 않아 키가 계속 눌린 상태처럼 남았습니다.

또한 `PageDown` 같은 일부 키는 라벨 매핑이 없어 press 이벤트도 앱에서 처리되지 않았습니다.

## 수정 내용

- macOS virtual keycode 기반 fallback 매핑을 추가했습니다.
- 넘버패드 숫자/연산 키와 일부 navigation 키를 기존 global key 라벨과 맞춰 매핑했습니다.
- `Kp1`, `KpPlus`, `KpReturn` 등 `rdev`의 keypad key 이름도 `NUMPAD ...` 라벨로 처리되도록 보완했습니다.