### PR TITLE
feat: 노트 크기·테두리 두께 등 수치 값 소수 입력 지원

### DIFF
--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1812,3 +1812,51 @@ pub struct SettingsPatch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub obs_mode_enabled: Option<bool>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::KeyPosition;
+
+    // 필수 필드만 채운 최소 KeyPosition JSON. 시각 px 필드는 호출부에서 주입
+    fn key_position_json(visual_px: &str) -> String {
+        format!(
+            r##"{{
+                "dx": 0.0, "dy": 0.0, "width": 60.0, "height": 60.0,
+                "count": 0, "noteColor": "#FFFFFF", "noteOpacity": 80,
+                {visual_px}
+            }}"##
+        )
+    }
+
+    // 기존 정수 저장값이 f64 필드로 그대로 역직렬화되는지 (하위 호환)
+    #[test]
+    fn visual_px_fields_accept_integer_json() {
+        let json =
+            key_position_json(r#""noteWidth": 100, "noteBorderRadius": 8, "noteGlowSize": 20"#);
+        let pos: KeyPosition = serde_json::from_str(&json).unwrap();
+        assert_eq!(pos.note_width, Some(100.0));
+        assert_eq!(pos.note_border_radius, Some(8.0));
+        assert_eq!(pos.note_glow_size, 20.0);
+    }
+
+    // 소수 저장값이 정상 역직렬화되는지
+    #[test]
+    fn visual_px_fields_accept_decimal_json() {
+        let json = key_position_json(
+            r#""noteWidth": 100.5, "noteBorderRadius": 8.5, "noteGlowSize": 20.5"#,
+        );
+        let pos: KeyPosition = serde_json::from_str(&json).unwrap();
+        assert_eq!(pos.note_width, Some(100.5));
+        assert_eq!(pos.note_border_radius, Some(8.5));
+        assert_eq!(pos.note_glow_size, 20.5);
+    }
+
+    // note_glow_size 미지정 시 기본값(20.0) 적용
+    #[test]
+    fn note_glow_size_defaults_to_20() {
+        let json = key_position_json(r#""noteWidth": null"#);
+        let pos: KeyPosition = serde_json::from_str(&json).unwrap();
+        assert_eq!(pos.note_glow_size, 20.0);
+        assert_eq!(pos.note_width, None);
+    }
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -206,10 +206,10 @@ pub struct KeyPosition {
     pub note_color: NoteColor,
     pub note_opacity: u32,
     #[serde(default)]
-    pub note_border_radius: Option<u32>,
+    pub note_border_radius: Option<f64>,
     /// 노트 넓이(px). None이면 키 width를 사용(자동).
     #[serde(default)]
-    pub note_width: Option<u32>,
+    pub note_width: Option<f64>,
     /// 노트 정렬 (left/center/right). 기본값 center.
     #[serde(default)]
     pub note_alignment: NoteAlignment,
@@ -218,7 +218,7 @@ pub struct KeyPosition {
     #[serde(default = "default_note_glow_enabled")]
     pub note_glow_enabled: bool,
     #[serde(default = "default_note_glow_size")]
-    pub note_glow_size: u32,
+    pub note_glow_size: f64,
     #[serde(default = "default_note_glow_opacity")]
     pub note_glow_opacity: u32,
     #[serde(default)]
@@ -760,8 +760,8 @@ fn default_note_effect_enabled() -> bool {
 fn default_note_glow_enabled() -> bool {
     false
 }
-fn default_note_glow_size() -> u32 {
-    20
+fn default_note_glow_size() -> f64 {
+    20.0
 }
 fn default_note_glow_opacity() -> u32 {
     70

--- a/src-tauri/src/state/migration.rs
+++ b/src-tauri/src/state/migration.rs
@@ -329,7 +329,7 @@ pub(crate) fn normalize_state(mut data: AppStoreData) -> AppStoreData {
     if let Some(legacy_border_radius) = data.note_settings.border_radius.take() {
         for positions in data.key_positions.values_mut() {
             for pos in positions.iter_mut() {
-                pos.note_border_radius = Some(legacy_border_radius);
+                pos.note_border_radius = Some(legacy_border_radius as f64);
             }
         }
     }

--- a/src/renderer/components/main/Grid/PropertiesPanel/PropertyInputs.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/PropertyInputs.tsx
@@ -300,16 +300,61 @@ export const OptionalNumberInput: React.FC<OptionalNumberInputProps> = ({
   width = '54px',
   placeholder,
   allowNegative = false,
+  allowDecimal = false,
+  decimalScale = 1,
   isMixed = false,
   mixedPlaceholder = 'Mixed',
 }) => {
   const hasSuffix = !!suffix;
+  const resolvedDecimalScale = allowDecimal
+    ? Math.max(0, Math.floor(decimalScale))
+    : 0;
+  const supportsDecimal = resolvedDecimalScale > 0;
+  const inputMode = supportsDecimal ? 'decimal' : 'numeric';
+
+  const normalizePrecision = (num: number): number => {
+    if (!supportsDecimal) return num;
+    return Number(num.toFixed(resolvedDecimalScale));
+  };
+
+  // 숫자/부호/소수점만 남기고, 부호는 맨 앞에 하나, 소수점도 하나만 유지
+  const sanitizeInput = (raw: string): string => {
+    const pattern = supportsDecimal
+      ? allowNegative
+        ? /[^0-9.-]/g
+        : /[^0-9.]/g
+      : allowNegative
+      ? /[^0-9-]/g
+      : /[^0-9]/g;
+    let sanitized = raw.replace(pattern, '');
+
+    if (allowNegative) {
+      const isNegative = sanitized.startsWith('-');
+      sanitized = sanitized.replace(/-/g, '');
+      if (isNegative) sanitized = `-${sanitized}`;
+    }
+
+    if (!supportsDecimal) return sanitized;
+
+    const sign = sanitized.startsWith('-') ? '-' : '';
+    const unsigned = sign ? sanitized.slice(1) : sanitized;
+    const dotIndex = unsigned.indexOf('.');
+    if (dotIndex === -1) return `${sign}${unsigned}`;
+
+    const integerPart = unsigned.slice(0, dotIndex);
+    const fractionalPart = unsigned
+      .slice(dotIndex + 1)
+      .replace(/\./g, '')
+      .slice(0, resolvedDecimalScale);
+    return `${sign}${integerPart}.${fractionalPart}`;
+  };
 
   const getDisplayValue = (val: number, focused: boolean): string => {
+    const normalized = normalizePrecision(val);
     if (hasSuffix && !focused) {
-      return `${val}${suffix}`;
+      return `${normalized}${suffix}`;
     }
-    return String(val);
+    return String(normalized);
   };
 
   const [localValue, setLocalValue] = useState<string>(() => {
@@ -349,23 +394,22 @@ export const OptionalNumberInput: React.FC<OptionalNumberInputProps> = ({
     if (e.ctrlKey || e.metaKey) return;
     if (/^[0-9]$/.test(e.key)) return;
     if (allowNegative && e.key === '-') return;
+    if (supportsDecimal && (e.key === '.' || e.key === 'Decimal')) return;
 
     e.preventDefault();
   };
 
-  const numericPattern = allowNegative ? /[^0-9-]/g : /[^0-9]/g;
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const raw = e.target.value.replace(numericPattern, '');
-    // 마이너스는 맨 앞에만 허용
-    const newValue = allowNegative
-      ? (raw.startsWith('-') ? '-' : '') + raw.replace(/-/g, '')
-      : raw;
+    const newValue = sanitizeInput(e.target.value);
     setLocalValue(newValue);
     setHasUserInput(true);
 
-    if (newValue === '' || newValue === '-') {
+    // 빈 값만 unset, 부호·소수점만 남은 중간 상태는 commit하지 않고 입력 유지
+    if (newValue === '') {
       onChange(undefined);
+      return;
+    }
+    if (newValue === '-' || newValue === '.' || newValue === '-.') {
       return;
     }
 
@@ -373,7 +417,7 @@ export const OptionalNumberInput: React.FC<OptionalNumberInputProps> = ({
     if (!Number.isFinite(numValue)) return;
 
     const clamped = Math.min(Math.max(numValue, min), max);
-    onChange(clamped);
+    onChange(normalizePrecision(clamped));
   };
 
   const handleFocus = () => {
@@ -388,9 +432,7 @@ export const OptionalNumberInput: React.FC<OptionalNumberInputProps> = ({
 
   const handleBlur = () => {
     setIsFocused(false);
-    const cleaned = allowNegative
-      ? localValue.replace(/[^0-9-]/g, '')
-      : localValue.replace(/[^0-9]/g, '');
+    const cleaned = sanitizeInput(localValue);
 
     // Mixed 상태에서 사용자 입력이 없었으면 Mixed 유지
     if (isMixed && !hasUserInput) {
@@ -400,7 +442,13 @@ export const OptionalNumberInput: React.FC<OptionalNumberInputProps> = ({
       return;
     }
 
-    if (cleaned === '' || cleaned === '-' || isNaN(Number(cleaned))) {
+    if (
+      cleaned === '' ||
+      cleaned === '-' ||
+      cleaned === '.' ||
+      cleaned === '-.' ||
+      isNaN(Number(cleaned))
+    ) {
       setLocalValue('');
       onChange(undefined);
       setHasUserInput(false);
@@ -409,7 +457,7 @@ export const OptionalNumberInput: React.FC<OptionalNumberInputProps> = ({
     }
 
     const numValue = Number(cleaned);
-    const clamped = Math.min(Math.max(numValue, min), max);
+    const clamped = normalizePrecision(Math.min(Math.max(numValue, min), max));
     setLocalValue(getDisplayValue(clamped, false));
     onChange(clamped);
     setHasUserInput(false);
@@ -443,7 +491,7 @@ export const OptionalNumberInput: React.FC<OptionalNumberInputProps> = ({
         )}
         <input
           type="text"
-          inputMode="numeric"
+          inputMode={inputMode}
           value={localValue}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
@@ -464,7 +512,7 @@ export const OptionalNumberInput: React.FC<OptionalNumberInputProps> = ({
     return (
       <input
         type="text"
-        inputMode="numeric"
+        inputMode={inputMode}
         value={localValue}
         onChange={handleChange}
         onKeyDown={handleKeyDown}
@@ -482,7 +530,7 @@ export const OptionalNumberInput: React.FC<OptionalNumberInputProps> = ({
   return (
     <input
       type="text"
-      inputMode="numeric"
+      inputMode={inputMode}
       value={localValue}
       onChange={handleChange}
       onKeyDown={handleKeyDown}

--- a/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchNoteTabContent.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchNoteTabContent.tsx
@@ -116,28 +116,28 @@ const BatchNoteTabContent: React.FC<BatchNoteTabContentProps> = ({
       {/* 오프셋 */}
       <PropertyRow label={t('keySetting.noteOffset') || '오프셋'}>
         <OptionalNumberInput
-          value={
-            getMixedValue((pos) => pos.noteOffsetX, 0).value || undefined
-          }
+          value={getMixedValue((pos) => pos.noteOffsetX, 0).value || undefined}
           onChange={(value) =>
             handleBatchStyleChangeComplete('noteOffsetX', value)
           }
           prefix="X"
           allowNegative
+          allowDecimal
+          decimalScale={1}
           min={NOTE_SETTINGS_CONSTRAINTS.noteOffsetX.min}
           max={NOTE_SETTINGS_CONSTRAINTS.noteOffsetX.max}
           placeholder="0"
           isMixed={getMixedValue((pos) => pos.noteOffsetX, 0).isMixed}
         />
         <OptionalNumberInput
-          value={
-            getMixedValue((pos) => pos.noteOffsetY, 0).value || undefined
-          }
+          value={getMixedValue((pos) => pos.noteOffsetY, 0).value || undefined}
           onChange={(value) =>
             handleBatchStyleChangeComplete('noteOffsetY', value)
           }
           prefix="Y"
           allowNegative
+          allowDecimal
+          decimalScale={1}
           min={NOTE_SETTINGS_CONSTRAINTS.noteOffsetY.min}
           max={NOTE_SETTINGS_CONSTRAINTS.noteOffsetY.max}
           placeholder="0"
@@ -154,6 +154,8 @@ const BatchNoteTabContent: React.FC<BatchNoteTabContentProps> = ({
           }
           suffix="px"
           min={1}
+          allowDecimal
+          decimalScale={1}
           placeholder="Auto"
           isMixed={noteWidthMixed.isMixed}
         />
@@ -332,6 +334,8 @@ const BatchNoteTabContent: React.FC<BatchNoteTabContentProps> = ({
           suffix="px"
           min={NOTE_SETTINGS_CONSTRAINTS.noteBorderWidth.min}
           max={NOTE_SETTINGS_CONSTRAINTS.noteBorderWidth.max}
+          allowDecimal
+          decimalScale={1}
           isMixed={
             getMixedValue(
               (pos) => pos.noteBorderWidth,
@@ -356,6 +360,8 @@ const BatchNoteTabContent: React.FC<BatchNoteTabContentProps> = ({
           suffix="px"
           min={NOTE_SETTINGS_CONSTRAINTS.borderRadius.min}
           max={NOTE_SETTINGS_CONSTRAINTS.borderRadius.max}
+          allowDecimal
+          decimalScale={1}
           isMixed={
             getMixedValue(
               (pos) => pos.noteBorderRadius,
@@ -410,6 +416,8 @@ const BatchNoteTabContent: React.FC<BatchNoteTabContentProps> = ({
           suffix="px"
           min={0}
           max={50}
+          allowDecimal
+          decimalScale={1}
           isMixed={getMixedValue((pos) => pos.noteGlowSize, 20).isMixed}
         />
       </PropertyRow>

--- a/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchStyleTabContent.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchStyleTabContent.tsx
@@ -630,6 +630,8 @@ const BatchStyleTabContent: React.FC<BatchStyleTabContentProps> = ({
           suffix="px"
           min={0}
           max={20}
+          allowDecimal
+          decimalScale={1}
         />
       </PropertyRow>
 
@@ -646,6 +648,8 @@ const BatchStyleTabContent: React.FC<BatchStyleTabContentProps> = ({
           suffix="px"
           min={0}
           max={100}
+          allowDecimal
+          decimalScale={1}
         />
       </PropertyRow>
 
@@ -722,6 +726,8 @@ const BatchStyleTabContent: React.FC<BatchStyleTabContentProps> = ({
               suffix="px"
               min={8}
               max={72}
+              allowDecimal
+              decimalScale={1}
             />
           </PropertyRow>
 

--- a/src/renderer/components/main/Grid/PropertiesPanel/single/NoteTabContent.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/single/NoteTabContent.tsx
@@ -462,6 +462,8 @@ const NoteTabContent: React.FC<NoteTabContentProps> = ({
           onChange={(value) => handleStyleChangeComplete('noteOffsetX', value)}
           prefix="X"
           allowNegative
+          allowDecimal
+          decimalScale={1}
           min={NOTE_SETTINGS_CONSTRAINTS.noteOffsetX.min}
           max={NOTE_SETTINGS_CONSTRAINTS.noteOffsetX.max}
           placeholder="0"
@@ -471,6 +473,8 @@ const NoteTabContent: React.FC<NoteTabContentProps> = ({
           onChange={(value) => handleStyleChangeComplete('noteOffsetY', value)}
           prefix="Y"
           allowNegative
+          allowDecimal
+          decimalScale={1}
           min={NOTE_SETTINGS_CONSTRAINTS.noteOffsetY.min}
           max={NOTE_SETTINGS_CONSTRAINTS.noteOffsetY.max}
           placeholder="0"
@@ -484,7 +488,9 @@ const NoteTabContent: React.FC<NoteTabContentProps> = ({
           onChange={(value) => handleStyleChangeComplete('noteWidth', value)}
           suffix="px"
           min={1}
-          placeholder={`${Math.round(keyPosition.width)}px`}
+          allowDecimal
+          decimalScale={1}
+          placeholder={`${keyPosition.width}px`}
         />
       </PropertyRow>
 
@@ -642,6 +648,8 @@ const NoteTabContent: React.FC<NoteTabContentProps> = ({
           suffix="px"
           min={NOTE_SETTINGS_CONSTRAINTS.noteBorderWidth.min}
           max={NOTE_SETTINGS_CONSTRAINTS.noteBorderWidth.max}
+          allowDecimal
+          decimalScale={1}
         />
       </PropertyRow>
 
@@ -658,6 +666,8 @@ const NoteTabContent: React.FC<NoteTabContentProps> = ({
           suffix="px"
           min={NOTE_SETTINGS_CONSTRAINTS.borderRadius.min}
           max={NOTE_SETTINGS_CONSTRAINTS.borderRadius.max}
+          allowDecimal
+          decimalScale={1}
         />
       </PropertyRow>
 
@@ -701,6 +711,8 @@ const NoteTabContent: React.FC<NoteTabContentProps> = ({
           suffix="px"
           min={0}
           max={50}
+          allowDecimal
+          decimalScale={1}
         />
       </PropertyRow>
 

--- a/src/renderer/components/main/Grid/PropertiesPanel/single/StyleTabContent.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/single/StyleTabContent.tsx
@@ -526,6 +526,8 @@ const StyleTabContent: React.FC<StyleTabContentInternalProps> = ({
           suffix="px"
           min={0}
           max={20}
+          allowDecimal
+          decimalScale={1}
         />
       </PropertyRow>
 
@@ -537,6 +539,8 @@ const StyleTabContent: React.FC<StyleTabContentInternalProps> = ({
           suffix="px"
           min={0}
           max={100}
+          allowDecimal
+          decimalScale={1}
         />
       </PropertyRow>
 
@@ -595,6 +599,8 @@ const StyleTabContent: React.FC<StyleTabContentInternalProps> = ({
           suffix="px"
           min={8}
           max={72}
+          allowDecimal
+          decimalScale={1}
         />
       </PropertyRow>
 

--- a/src/renderer/components/main/Grid/PropertiesPanel/types.ts
+++ b/src/renderer/components/main/Grid/PropertiesPanel/types.ts
@@ -63,6 +63,8 @@ export interface OptionalNumberInputProps {
   width?: string;
   placeholder?: string;
   allowNegative?: boolean;
+  allowDecimal?: boolean;
+  decimalScale?: number;
   isMixed?: boolean;
   mixedPlaceholder?: string;
 }

--- a/src/renderer/components/main/Modal/content/settings/NoteTabContent.tsx
+++ b/src/renderer/components/main/Modal/content/settings/NoteTabContent.tsx
@@ -222,17 +222,30 @@ const NoteTabContent = forwardRef<NoteTabContentRef, NoteTabContentProps>(
       }
     };
 
-    // 글로우 크기 핸들러
+    // 글로우 크기 핸들러 (소수 0.1 단위 허용)
+    const sanitizeGlowSize = (raw: string): string => {
+      const cleaned = raw.replace(/[^0-9.]/g, '');
+      const dotIndex = cleaned.indexOf('.');
+      if (dotIndex === -1) return cleaned;
+      return (
+        cleaned.slice(0, dotIndex + 1) +
+        cleaned
+          .slice(dotIndex + 1)
+          .replace(/\./g, '')
+          .slice(0, 1)
+      );
+    };
+
     const handleGlowSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = e.target.value.replace(/[^0-9]/g, '');
+      const newValue = sanitizeGlowSize(e.target.value);
       setState((prev) => ({ ...prev, displayGlowSize: newValue }));
     };
 
     const handleGlowSizeBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-      const parsed = parseInt(e.target.value.replace(/[^0-9]/g, ''), 10);
+      const parsed = parseFloat(sanitizeGlowSize(e.target.value));
       const clamped = Number.isNaN(parsed)
         ? 20
-        : Math.min(Math.max(parsed, 0), 50);
+        : Number(Math.min(Math.max(parsed, 0), 50).toFixed(1));
       setState((prev) => ({
         ...prev,
         glowSize: clamped,
@@ -391,6 +404,7 @@ const NoteTabContent = forwardRef<NoteTabContentRef, NoteTabContentProps>(
             </p>
             <input
               type="text"
+              inputMode="decimal"
               disabled={!state.glowEnabled}
               value={state.displayGlowSize}
               onChange={handleGlowSizeChange}

--- a/src/renderer/hooks/shared/useLayoutComputation.ts
+++ b/src/renderer/hooks/shared/useLayoutComputation.ts
@@ -80,7 +80,7 @@ export function computeLayout(input: LayoutInput) {
         const keyWidth = pos.width;
         const desiredNoteWidth =
           typeof pos.noteWidth === 'number' && Number.isFinite(pos.noteWidth)
-            ? Math.max(1, Math.round(pos.noteWidth))
+            ? Math.max(1, pos.noteWidth)
             : keyWidth;
         const noteAlign = pos.noteAlignment ?? 'center';
         const alignOff =
@@ -200,7 +200,7 @@ export function computeLayout(input: LayoutInput) {
       const desiredNoteWidth =
         typeof position.noteWidth === 'number' &&
         Number.isFinite(position.noteWidth)
-          ? Math.max(1, Math.round(position.noteWidth))
+          ? Math.max(1, position.noteWidth)
           : keyWidth;
       const noteAlign = position.noteAlignment ?? 'center';
       const noteAlignOffsetX =

--- a/src/types/key/keys.test.ts
+++ b/src/types/key/keys.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { keyPositionSchema } from './keys';
+
+describe('keyPositionSchema 시각 px 필드 소수 허용', () => {
+  it('noteWidth 소수 허용', () => {
+    expect(keyPositionSchema.shape.noteWidth.parse(100.5)).toBe(100.5);
+    expect(keyPositionSchema.shape.noteWidth.parse(100)).toBe(100);
+  });
+
+  it('noteBorderRadius 소수 허용', () => {
+    expect(keyPositionSchema.shape.noteBorderRadius.parse(8.5)).toBe(8.5);
+  });
+
+  it('noteGlowSize 소수 허용', () => {
+    expect(keyPositionSchema.shape.noteGlowSize.parse(20.5)).toBe(20.5);
+  });
+
+  it('noteBorderWidth 소수 허용', () => {
+    expect(keyPositionSchema.shape.noteBorderWidth.parse(2.5)).toBe(2.5);
+  });
+
+  // 정수 유지 필드는 여전히 소수를 거부해야 한다
+  it('noteOpacity는 소수 거부(정수 유지)', () => {
+    expect(() => keyPositionSchema.shape.noteOpacity.parse(80.5)).toThrow();
+  });
+});

--- a/src/types/key/keys.ts
+++ b/src/types/key/keys.ts
@@ -249,12 +249,11 @@ export const keyPositionSchema = z.object({
   // 노트 모서리 반경 (키별 설정, 없으면 기본값 사용)
   noteBorderRadius: z
     .number()
-    .int()
     .min(NOTE_SETTINGS_CONSTRAINTS.borderRadius.min)
     .max(NOTE_SETTINGS_CONSTRAINTS.borderRadius.max)
     .optional(),
   // 노트 넓이(px). 비어있으면 해당 키 width를 사용(자동)
-  noteWidth: z.number().int().positive().optional(),
+  noteWidth: z.number().positive().optional(),
   // 노트 정렬 (left/center/right). 기본값 center.
   noteAlignment: z
     .enum(['left', 'center', 'right'])
@@ -262,7 +261,7 @@ export const keyPositionSchema = z.object({
     .default('center'),
   noteEffectEnabled: z.boolean().optional().default(true),
   noteGlowEnabled: z.boolean().optional().default(false),
-  noteGlowSize: z.number().int().min(0).max(50).optional().default(20),
+  noteGlowSize: z.number().min(0).max(50).optional().default(20),
   noteGlowOpacity: z.number().int().min(0).max(100).optional().default(70),
   // 그라디언트용 글로우 투명도(Top/Bottom). 없으면 noteGlowOpacity를 사용.
   noteGlowOpacityTop: z.number().int().min(0).max(100).optional(),


### PR DESCRIPTION
## 요약
- 노트 시각 px 필드(`noteWidth`, `noteBorderRadius`, `noteGlowSize`)를 정수 전용에서 소수(f64) 지원으로 확장
- `OptionalNumberInput`에 `allowDecimal`/`decimalScale` prop 추가 (소수점 1자리, `inputMode="decimal"`)
- 단일/일괄 속성 패널과 설정 모달의 해당 필드에 소수 입력 적용
- 레이아웃 계산의 `Math.round` 제거로 소수 px 그대로 반영 (키 지오메트리는 기존부터 f64)
- 기존 정수 저장값 하위 호환 serde 테스트 및 zod 스키마 테스트 추가

## 검증
- `npx tsc --noEmit` 통과
- `npm test` 75개 통과 (신규 keys.test.ts 포함)
- `npm run lint` 통과
- `cargo test` 12개 통과, `cargo clippy` 클린
- master 병합 결과 기준으로 위 검증 수행 (충돌 없음, 양측 수정 파일 7개 의미 충돌 검토 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)