### PR TITLE
feat: 여러 키 매핑 지원

### DIFF
--- a/docs/content/en/api-reference/app/page.mdx
+++ b/docs/content/en/api-reference/app/page.mdx
@@ -22,13 +22,18 @@ Returns app bootstrap data (settings, keys, presets, etc.)
 const bootstrap = await dmn.app.bootstrap();
 
 // Bootstrap properties
-console.log(bootstrap.selectedKeyType); // 'keyboard' | 'mouse'
+console.log(bootstrap.selectedKeyType); // current layout mode ID (e.g. '4key')
 console.log(bootstrap.settings); // app settings object
-console.log(bootstrap.keys.keyboard); // key mapping
+console.log(bootstrap.keys['4key']); // key mapping (KeySlot union entries)
 console.log(bootstrap.keyCounters); // counter state
 console.log(bootstrap.keyCountersSessionId); // counter stream session
 console.log(bootstrap.keyCountersRevision); // counter snapshot revision
 ```
+
+`bootstrap.keys` carries the same `KeySlot` union
+(`string | MultiKeySlot`) as `dmn.keys.get()`. Consumers that assume plain
+string slots should handle both shapes - see the
+[Keys API](/docs/api-reference/keys).
 
 `keyCountersRevision` is a read-only, monotonically increasing watermark for
 the returned `keyCounters` snapshot. It is intended for ordering bootstrap

--- a/docs/content/en/api-reference/editor/page.mdx
+++ b/docs/content/en/api-reference/editor/page.mdx
@@ -44,6 +44,14 @@ type EditorPatchV1 = {
 Each field included in an `EditorPatchV1` is the complete canonical value of
 that top-level collection. It is not an item-level diff.
 
+<Callout type="warning">
+  Since the multi-key update, `keys` entries in `EditorDocumentV1` (returned by
+  `get()`) and in `EditorPatchV1` (delivered by `onCommitted()`) use the
+  `KeySlot` union (`string | MultiKeySlot`), not plain strings. See the
+  [Keys API](/docs/api-reference/keys) for the slot shape and canonical
+  identifier rules.
+</Callout>
+
 ## Read the Current Document
 
 ### `dmn.editor.get(): Promise<EditorGetResult>`
@@ -87,6 +95,8 @@ interface EditorCommitRequest {
   mutationId: string;
   gestureId?: string;
   gestureIds?: string[];
+  // Declares multi-key slot support for commits that include `keys`
+  multiKey?: boolean;
   changes: EditorPatchV1;
 }
 
@@ -136,6 +146,7 @@ collections in the same commit. Their mode sets and lengths must match.
 await dmn.editor.commit({
   baseRevision,
   mutationId: crypto.randomUUID(),
+  multiKey: true,
   changes: {
     schemaVersion: 1,
     keys: nextKeys,
@@ -147,6 +158,11 @@ await dmn.editor.commit({
 A same-shape edit, such as changing a key label or a position property, may
 update only its own collection. A shape-changing `keys`-only or
 `keyPositions`-only request is rejected with `PAIRED_UPDATE_REQUIRED`.
+
+A commit that includes `keys` must also declare `multiKey: true` whenever the
+current mappings contain at least one multi-key slot. An undeclared write is
+rejected with `MULTI_KEY_UNSUPPORTED` (non-retryable) so that a plugin unaware
+of multi-key slots cannot destroy them by round-tripping mappings.
 
 When using the compatibility `dmn.keys` API, call
 `dmn.keys.updateWithPositions(keys, keyPositions)` for these structural
@@ -160,11 +176,15 @@ the human-readable `message`.
 ```typescript
 type EditorCommitErrorCode =
   | 'REVISION_CONFLICT'
+  | 'PLUGIN_REVISION_CONFLICT'
   | 'VALIDATION_FAILED'
   | 'TOO_MANY_GESTURE_IDS'
   | 'INVALID_GESTURE_ID'
   | 'PAIRED_UPDATE_REQUIRED'
+  | 'MULTI_KEY_UNSUPPORTED'
   | 'MUTATION_ID_REUSED'
+  | 'HISTORY_IN_PROGRESS'
+  | 'HISTORY_EPOCH_CONFLICT'
   | 'IO_ERROR';
 
 interface EditorCommitError {
@@ -174,6 +194,7 @@ interface EditorCommitError {
     currentRevision?: number;
     validationCode?: string;
     field?: string;
+    currentHistoryEpoch?: number;
   };
   retryable: boolean;
 }
@@ -182,15 +203,19 @@ interface EditorCommitError {
 | Code                     | Meaning                                                                   | `retryable` |
 | ------------------------ | ------------------------------------------------------------------------- | ----------- |
 | `REVISION_CONFLICT`      | `baseRevision` is stale; read, reconcile, and commit again                | `true`      |
+| `PLUGIN_REVISION_CONFLICT` | The plugin-scoped revision is stale; read, reconcile, and commit again  | `true`      |
 | `VALIDATION_FAILED`      | The completed document violates an editor validation rule                 | `false`     |
 | `TOO_MANY_GESTURE_IDS`   | `gestureIds` exceeds 32 entries or the combined unique set exceeds 32 IDs | `false`     |
 | `INVALID_GESTURE_ID`     | A gesture ID is not a UUID within the 64-byte limit                       | `false`     |
 | `PAIRED_UPDATE_REQUIRED` | A structural key change omitted its paired collection                     | `false`     |
+| `MULTI_KEY_UNSUPPORTED`  | A `keys` write did not declare `multiKey` while multi-key slots exist     | `false`     |
 | `MUTATION_ID_REUSED`     | The same mutation ID was used for a different request                     | `false`     |
 | `IO_ERROR`               | The document could not be persisted                                       | `true`      |
+| `HISTORY_IN_PROGRESS`    | An undo/redo barrier is in progress; retry after it settles               | `true`      |
+| `HISTORY_EPOCH_CONFLICT` | The observed history epoch is stale; re-read and commit again             | `true`      |
 
-`details.currentRevision`, `details.validationCode`, or `details.field` is
-included when it applies to the error.
+`details.currentRevision`, `details.validationCode`, `details.field`, or
+`details.currentHistoryEpoch` is included when it applies to the error.
 
 ## Subscribe to Committed Changes
 
@@ -208,6 +233,7 @@ interface EditorCommittedV1 {
   gestureIds?: string[];
   origin?: string;
   changedFields: EditorField[];
+  // patch.keys uses the KeySlot union (string | MultiKeySlot)
   patch: EditorPatchV1;
 }
 

--- a/docs/content/en/api-reference/keys/page.mdx
+++ b/docs/content/en/api-reference/keys/page.mdx
@@ -30,7 +30,8 @@ interface KeyStateEvent {
   // Recover the real input time with `performance.now() - eventAgeMs`.
   eventAgeMs?: number;
   // UP events only. Physical hold duration (ms) measured by the input
-  // daemon at capture time - immune to delivery latency and jitter.
+  // daemon when the same physical input produced canonical DOWN and UP.
+  // Omitted when those transitions came from different or unknown inputs.
   holdDurationMs?: number;
 }
 
@@ -38,6 +39,11 @@ const unsub = dmn.keys.onKeyState(({ key, state, mode }) => {
   console.log(`[${mode}] ${key} → ${state}`);
 });
 ```
+
+`holdDurationMs` is delivery-latency independent when present. A canonical slot
+can remain active across overlapping devices or member keys, so consumers that
+need its full active duration must also track the matching canonical `DOWN` and
+`UP` timestamps when this optional field is absent.
 
 The returned function also exposes a `ready` promise that resolves once the
 subscription is actually registered with the backend. Events fired before

--- a/docs/content/en/api-reference/keys/page.mdx
+++ b/docs/content/en/api-reference/keys/page.mdx
@@ -159,13 +159,30 @@ const unsub = dmn.keys.onModeChanged(({ mode }) => {
 Returns the key mappings for all modes.
 
 ```typescript
-type KeyMappings = Record<string, string[]>;
+type SlotMatch = 'all' | 'any';
+
+// A slot is either a single key string, or a multi-key binding:
+// - match: 'any' — the slot activates when any member key is pressed
+// - match: 'all' — the slot activates while all member keys are held together
+interface MultiKeySlot {
+  keys: string[]; // 2 to 8 member keys
+  match: SlotMatch;
+}
+
+type KeySlot = string | MultiKeySlot;
+type KeyMappings = Record<string, KeySlot[]>;
 
 const mappings = await dmn.keys.get();
 console.log(mappings['4key']);
 ```
 
-### `dmn.keys.update(mappings: KeyMappings): Promise<KeyMappings>`
+<Callout type="warning">
+  Since the multi-key update, a slot value can be an object (`MultiKeySlot`),
+  not just a string. Plugins that assume every slot is a string should be
+  updated before handling mappings that contain multi-key slots.
+</Callout>
+
+### `dmn.keys.update(mappings: KeyMappings, options?): Promise<KeyMappings>`
 
 Replaces the key mappings and returns the committed value.
 
@@ -174,6 +191,21 @@ const mappings = await dmn.keys.get();
 mappings['4key'][0] = 'KeyS';
 const committed = await dmn.keys.update(mappings);
 ```
+
+To write mappings while the current configuration contains multi-key slots,
+declare multi-key support explicitly:
+
+```typescript
+const committed = await dmn.keys.update(mappings, { multiKey: true });
+```
+
+Without the declaration, a write is rejected with the
+`MULTI_KEY_UNSUPPORTED` error code (non-retryable) whenever the current
+mappings contain at least one multi-key slot. This fail-closed gate protects
+user configurations from being destroyed by plugins that round-trip mappings
+without preserving multi-key slots. The same rule applies to
+`updateWithPositions()` and to `dmn.editor.commit()` requests that include
+`keys` (declare via `multiKey: true` on the commit request).
 
 ### `dmn.keys.getPositions(): Promise<KeyPositions>`
 

--- a/docs/content/en/api-reference/keys/page.mdx
+++ b/docs/content/en/api-reference/keys/page.mdx
@@ -22,9 +22,10 @@ Subscribes to state changes for registered keys.
 
 ```typescript
 interface KeyStateEvent {
-  key: string; // e.g., 'KeyA', 'MouseLeft'
+  // Canonical slot identifier, e.g. 'A', 'MOUSE1', 'F|NUMPAD 4'
+  key: string;
   state: 'UP' | 'DOWN';
-  mode: 'keyboard' | 'mouse';
+  mode: string; // current layout mode ID (e.g. '4key')
   // Elapsed time (ms) between input capture and event emit.
   // Recover the real input time with `performance.now() - eventAgeMs`.
   eventAgeMs?: number;
@@ -40,7 +41,7 @@ const unsub = dmn.keys.onKeyState(({ key, state, mode }) => {
 
 The returned function also exposes a `ready` promise that resolves once the
 subscription is actually registered with the backend. Events fired before
-`ready` resolves may not be delivered — await it when you need a guaranteed
+`ready` resolves may not be delivered, so await it when you need a guaranteed
 starting point (e.g. before requesting a snapshot):
 
 ```typescript
@@ -74,7 +75,7 @@ Subscribes to all raw input events (including unregistered keys).
 ```typescript
 interface RawInputEvent {
   device: 'keyboard' | 'mouse' | 'gamepad' | 'unknown';
-  label: string; // e.g., 'A', 'LButton', 'HIDB:1ccf:101c:9:3'
+  label: string; // e.g., 'A', 'MOUSE1', 'HIDB:1ccf:101c:9:3'
   labels: string[]; // all candidate labels for this event
   state: 'DOWN' | 'UP';
 }
@@ -97,6 +98,7 @@ labels in the form `HIDB:vid:pid:usagePage:usage`. See the
 Returns the current cumulative key counter snapshot.
 
 ```typescript
+// Inner map keys are canonical slot identifiers
 type KeyCounters = Record<string, Record<string, number>>;
 
 const counters = await dmn.keys.getCounters();
@@ -112,7 +114,7 @@ Subscribes to counter changes.
 ```typescript
 interface CounterEvent {
   mode: string;
-  key: string;
+  key: string; // canonical slot identifier
   count: number;
   sessionId: string;
   revision: number;
@@ -138,11 +140,11 @@ reconciling a bootstrap snapshot with live events.
 
 ### `dmn.keys.onModeChanged(callback): Unsubscribe`
 
-Subscribes to input mode changes (keyboard/mouse).
+Subscribes to layout mode changes (`keys:mode-changed`).
 
 ```typescript
 interface ModeEvent {
-  mode: 'keyboard' | 'mouse';
+  mode: string; // current layout mode ID (e.g. '4key')
 }
 
 const unsub = dmn.keys.onModeChanged(({ mode }) => {
@@ -162,8 +164,8 @@ Returns the key mappings for all modes.
 type SlotMatch = 'all' | 'any';
 
 // A slot is either a single key string, or a multi-key binding:
-// - match: 'any' — the slot activates when any member key is pressed
-// - match: 'all' — the slot activates while all member keys are held together
+// - match: 'any': the slot activates when any member key is pressed
+// - match: 'all': the slot activates while all member keys are held together
 interface MultiKeySlot {
   keys: string[]; // 2 to 8 member keys
   match: SlotMatch;
@@ -182,13 +184,42 @@ console.log(mappings['4key']);
   updated before handling mappings that contain multi-key slots.
 </Callout>
 
+### Canonical slot identifiers
+
+Event and counter surfaces identify a slot by its canonical string:
+
+- A single-key slot is its key string, unchanged (e.g. `"D"`).
+- A `match: 'all'` slot joins its members with `+` in member order
+  (e.g. `"LEFT CTRL+Z"`).
+- A `match: 'any'` slot joins its members with `|` (e.g. `"F|NUMPAD 4"`).
+
+Canonical strings are for generation and equality comparison only. Do not
+parse them back into members; read the slot objects from `get()` instead.
+The display label of an `any` slot joins members with `/` (e.g. `Z/B`), which
+is a UI convention separate from the canonical `|`. Switching a slot between
+`all` and `any` changes its canonical identifier, so existing counters do not
+carry over between the two forms.
+
+Canonical identifiers appear in `onKeyState().key`, counter map keys
+(`getCounters()`, `onCounterChanged`, `onCountersChanged`),
+`resetSingleCounter(mode, key)`, and UI anchor and key menu `keyCode` values.
+Mapping surfaces (`get()`, `update()`, `onChanged`, editor documents, preset
+snapshots) carry the `KeySlot` union instead.
+
+Hand-crafted legacy data may contain a single-key slot whose string itself
+includes `+` or `|` (for example the one string `"A+B"`). Such a slot is
+preserved losslessly but is inert: no daemon input can activate it. It can
+cosmetically share a canonical identifier, and therefore a counter bucket,
+with a real multi-key slot; where both exist, note effects resolve to the
+real multi-key slot.
+
 ### `dmn.keys.update(mappings: KeyMappings, options?): Promise<KeyMappings>`
 
 Replaces the key mappings and returns the committed value.
 
 ```typescript
 const mappings = await dmn.keys.get();
-mappings['4key'][0] = 'KeyS';
+mappings['4key'][0] = 'S';
 const committed = await dmn.keys.update(mappings);
 ```
 
@@ -226,7 +257,7 @@ interface KeyPosition {
   activeBackgroundColor?: string;
   borderColor?: string;
   activeBorderColor?: string;
-  borderWidth?: number; // px, defaults to 1 when unset — 0 disables the border
+  borderWidth?: number; // px, defaults to 1 when unset. 0 disables the border
   backgroundGradient?: GradientSpec | null;
   activeBackgroundGradient?: GradientSpec | null;
   borderGradient?: GradientSpec | null;
@@ -243,7 +274,7 @@ interface KeyCounterSettings {
 }
 
 interface GradientSpec {
-  angle: number; // 0 (inclusive) to 360 (exclusive) — 360 normalizes to 0; CSS semantics (0 = up, clockwise)
+  angle: number; // 0 (inclusive) to 360 (exclusive). 360 normalizes to 0; CSS semantics (0 = up, clockwise)
   stops: { color: string; pos: number }[]; // 2–8 stops, pos 0–1 ascending
 }
 
@@ -285,7 +316,7 @@ const committed = await dmn.keys.updatePositions(positions);
   additions, removals, and reordering.
 </Callout>
 
-### `dmn.keys.updateWithPositions(mappings, positions): Promise<KeysWithPositionsResult>`
+### `dmn.keys.updateWithPositions(mappings, positions, options?): Promise<KeysWithPositionsResult>`
 
 Updates key mappings and their index-coupled positions in one atomic commit.
 The two values must have matching mode sets and array lengths. The committed
@@ -298,8 +329,15 @@ interface KeysWithPositionsResult {
   positions: KeyPositions;
 }
 
-const result = await dmn.keys.updateWithPositions(mappings, positions);
+const result = await dmn.keys.updateWithPositions(mappings, positions, {
+  multiKey: true,
+});
 ```
+
+The third `options` argument takes the same `{ multiKey?: boolean }`
+declaration as `update()`. Without it, the write is rejected with
+`MULTI_KEY_UNSUPPORTED` whenever the current mappings contain a multi-key
+slot.
 
 ### `dmn.keys.onChanged(callback): Unsubscribe`
 
@@ -333,29 +371,6 @@ const unsubscribe = dmn.keys.onPositionsChanged((positions) => {
 ## Custom Tab
 
 <Callout type="warning">Main window only.</Callout>
-
-### `dmn.keys.registerCustomTab(options): Unsubscribe`
-
-Registers a custom tab in the key settings panel.
-
-```typescript
-interface CustomTabOptions {
-  id: string;
-  label: string;
-  content: (container: HTMLElement) => void | (() => void);
-}
-
-const unsub = dmn.keys.registerCustomTab({
-  id: 'my-tab',
-  label: 'My Tab',
-  content: (container) => {
-    container.innerHTML = `<div>Custom tab content</div>`;
-    return () => {
-      /* cleanup */
-    };
-  },
-});
-```
 
 ### `dmn.keys.customTabs.restore(customTabs, selectedKeyType): Promise<void>`
 

--- a/docs/content/en/api-reference/presets/page.mdx
+++ b/docs/content/en/api-reference/presets/page.mdx
@@ -9,69 +9,56 @@ Save and load complete configuration presets.
 
 ## Preset Operations
 
-### `dmn.presets.save(name: string): Promise<void>`
+All preset operations open a native file dialog. They take no arguments and
+resolve with a `PresetOperationResult`.
 
-Saves current configuration as a preset.
-
-```javascript
-await dmn.presets.save("My Gaming Setup");
+```typescript
+type PresetOperationResult = { success: boolean; error?: string };
 ```
 
-### `dmn.presets.load(name: string): Promise<void>`
+### `dmn.presets.save(): Promise<PresetOperationResult>`
 
-Loads a preset by name.
+Saves the current configuration to a preset file. Opens a file save dialog.
 
 ```javascript
-await dmn.presets.load("My Gaming Setup");
+const result = await dmn.presets.save();
+if (result.success) {
+  console.log("Preset saved");
+} else {
+  console.error("Save failed:", result.error);
+}
 ```
 
-### `dmn.presets.delete(name: string): Promise<void>`
+### `dmn.presets.load(): Promise<PresetOperationResult>`
 
-Deletes a preset.
+Loads a preset file and applies it to the current configuration. Opens a file
+picker dialog.
 
 ```javascript
-await dmn.presets.delete("My Gaming Setup");
+const result = await dmn.presets.load();
+if (result.success) {
+  console.log("Preset loaded");
+} else {
+  console.error("Load failed:", result.error);
+}
 ```
 
-### `dmn.presets.list(): Promise<string[]>`
+### `dmn.presets.saveTab(): Promise<PresetOperationResult>`
 
-Returns list of all preset names.
+Saves only the currently selected tab (its key mappings and layout) as a tab
+preset file. Opens a file save dialog.
 
 ```javascript
-const presets = await dmn.presets.list();
-console.log(presets); // ['Default', 'Gaming', 'Streaming', ...]
+const result = await dmn.presets.saveTab();
 ```
 
-### `dmn.presets.export(name: string): Promise<string>`
+### `dmn.presets.loadTab(): Promise<PresetOperationResult>`
 
-Exports a preset as JSON string.
-
-```javascript
-const json = await dmn.presets.export("My Gaming Setup");
-console.log(json);
-```
-
-### `dmn.presets.import(json: string): Promise<void>`
-
-Imports a preset from JSON string.
+Loads a tab preset file into the currently selected tab. Opens a file picker
+dialog.
 
 ```javascript
-const json = `{ "name": "Imported", ... }`;
-await dmn.presets.import(json);
-```
-
----
-
-## Change Events
-
-### `dmn.presets.onChanged(callback): Unsubscribe`
-
-Subscribes to preset list changes.
-
-```javascript
-const unsub = dmn.presets.onChanged((presets) => {
-  console.log("Presets changed:", presets);
-});
+const result = await dmn.presets.loadTab();
 ```
 
 ---
@@ -84,10 +71,12 @@ Subscribes to preset load completions. Receives the full snapshot of applied dat
 
 ```typescript
 interface PresetSnapshot {
+  // Entries use the KeySlot union (string | MultiKeySlot)
   keys: KeyMappings;
   positions: KeyPositions;
   statPositions: StatItemPositions;
   graphPositions: GraphItemPositions;
+  knobPositions: KnobItemPositions;
   customTabs: CustomTab[];
   selectedKeyType: string;
   tabNoteOverrides: TabNoteOverrides;
@@ -105,55 +94,43 @@ const unsub = dmn.presets.onSnapshot((snapshot) => {
 </Callout>
 
 ---
-
 ## Example Usage
 
 ```javascript
-// Preset manager panel
-dmn.plugin.defineElement({
-  name: "Preset Manager",
-  maxInstances: 1,
+// @id preset-manager
 
-  template: (state, settings, { html }) => {
-    const presets = state.presets ?? [];
-    return html`
-      <div>
-        <h3>Presets</h3>
-        <ul>
-          ${presets.map(
-            (name) => html`
-              <li>
-                <span>${name}</span>
-                <button @click=${() => dmn.presets.load(name)}>Load</button>
-                <button @click=${() => dmn.presets.delete(name)}>Delete</button>
-              </li>
-            `,
-          )}
-        </ul>
-        <button
-          @click=${() => {
-            const name = prompt("Preset name:");
-            if (name) dmn.presets.save(name);
-          }}
-        >
-          Save Current
-        </button>
-      </div>
-    `;
+if (dmn.window.type !== "main") return;
+
+// Save preset menu item
+dmn.ui.contextMenu.addGridMenuItem({
+  id: "save-preset",
+  label: "Save Preset",
+  onClick: async () => {
+    const result = await dmn.presets.save();
+    if (result.success) {
+      await dmn.ui.dialog.alert("Preset saved!");
+    }
   },
+});
 
-  onMount: ({ setState }) => {
-    // Load initial list
-    dmn.presets.list().then((presets) => {
-      setState({ presets });
-    });
-
-    // Watch changes
-    const unsub = dmn.presets.onChanged((presets) => {
-      setState({ presets });
-    });
-
-    return () => unsub();
+// Load preset menu item
+dmn.ui.contextMenu.addGridMenuItem({
+  id: "load-preset",
+  label: "Load Preset",
+  onClick: async () => {
+    const confirmed = await dmn.ui.dialog.confirm(
+      "This will overwrite the current configuration. Continue?"
+    );
+    if (confirmed) {
+      const result = await dmn.presets.load();
+      if (result.success) {
+        await dmn.ui.dialog.alert("Preset loaded!");
+      }
+    }
   },
+});
+
+dmn.plugin.registerCleanup(() => {
+  dmn.ui.contextMenu.clearMyMenuItems();
 });
 ```

--- a/docs/content/en/declarative-api/page.mdx
+++ b/docs/content/en/declarative-api/page.mdx
@@ -537,6 +537,12 @@ onMount: ({ onHook, setState }) => {
 },
 ```
 
+The `"key"` hook receives the same canonical payload as
+`dmn.keys.onKeyState`. On `UP`, `holdDurationMs` is present only when the same
+physical input produced both canonical transitions; otherwise it is omitted.
+Track the matching canonical `DOWN` and `UP` timestamps when the full active
+duration is required.
+
 ### Settings Change Detection (onSettingsChange)
 
 Use this when you need to react to settings changes immediately.

--- a/docs/content/en/ui-api/page.mdx
+++ b/docs/content/en/ui-api/page.mdx
@@ -32,7 +32,7 @@ const menuId = dmn.ui.contextMenu.addKeyMenuItem({
 
 | Property   | Type        | Description             |
 | ---------- | ----------- | ----------------------- |
-| `keyCode`  | string      | Key code (e.g., "KeyD") |
+| `keyCode`  | string      | Canonical slot identifier (e.g. "D", "LEFT CTRL+Z", "F\|NUMPAD 4") |
 | `index`    | number      | Key index               |
 | `position` | KeyPosition | Key position info       |
 | `mode`     | string      | Current key mode        |
@@ -184,6 +184,26 @@ dmn.ui.displayElement.add({
 | `query(selector)`                   | Find element (including Shadow DOM) |
 | `update(config)`                    | Update metadata                     |
 | `remove()`                          | Remove element                      |
+
+### Anchor
+
+Pins an element to a specific key:
+
+```javascript
+dmn.ui.displayElement.add({
+  html: `<div>→</div>`,
+  position: { x: 0, y: 0 },
+  anchor: {
+    keyCode: "D",
+    offset: { x: 70, y: 0 },
+  },
+});
+```
+
+`anchor.keyCode` is a canonical slot identifier. For a multi-key slot, use its
+canonical string (e.g. `"LEFT CTRL+Z"` for `match: 'all'`, `"F|NUMPAD 4"`
+for `match: 'any'`). See
+[Canonical slot identifiers](/docs/api-reference/keys#canonical-slot-identifiers).
 
 ## Dialog
 

--- a/docs/content/ko/api-reference/app/page.mdx
+++ b/docs/content/ko/api-reference/app/page.mdx
@@ -19,7 +19,7 @@ description: 앱 부팅, 재시작, 윈도우 제어 API
 ```typescript
 interface BootstrapPayload {
   settings: SettingsState;
-  keys: KeyMappings;
+  keys: KeyMappings; // KeySlot union(string | MultiKeySlot) 항목
   positions: KeyPositions;
   customTabs: CustomTab[];
   selectedKeyType: string;
@@ -34,6 +34,10 @@ interface BootstrapPayload {
   keyCountersRevision: number;
 }
 ```
+
+`keys`는 `dmn.keys.get()`과 같은 `KeySlot` union(`string | MultiKeySlot`)을
+전달합니다. 슬롯을 순수 문자열로 가정하는 소비자는 두 형태를 모두 처리해야
+합니다. [Keys API](/docs/api-reference/keys)를 참고하세요.
 
 `keyCountersRevision`은 반환된 `keyCounters` 스냅샷의 순서를 나타내는 읽기
 전용 단조 증가 watermark입니다. 같은 `keyCountersSessionId` 안에서 bootstrap

--- a/docs/content/ko/api-reference/editor/page.mdx
+++ b/docs/content/ko/api-reference/editor/page.mdx
@@ -44,6 +44,13 @@ type EditorPatchV1 = {
 `EditorPatchV1`에 포함한 각 필드는 해당 최상위 컬렉션의 canonical 전체
 값입니다. 항목 하나만 표현하는 diff가 아닙니다.
 
+<Callout type="warning">
+  멀티 키 업데이트부터 `get()`이 반환하는 `EditorDocumentV1`의 `keys`와
+  `onCommitted()`가 전달하는 `EditorPatchV1`의 `keys`는 순수 문자열이 아니라
+  `KeySlot` union(`string | MultiKeySlot`)을 사용합니다. 슬롯 형태와 canonical
+  식별자 규칙은 [Keys API](/docs/api-reference/keys)를 참고하세요.
+</Callout>
+
 ## 현재 문서 조회
 
 ### `dmn.editor.get(): Promise<EditorGetResult>`
@@ -86,6 +93,8 @@ interface EditorCommitRequest {
   mutationId: string;
   gestureId?: string;
   gestureIds?: string[];
+  // keys를 포함한 커밋의 멀티 키 슬롯 지원 선언
+  multiKey?: boolean;
   changes: EditorPatchV1;
 }
 
@@ -133,6 +142,7 @@ ID를 다른 요청에 재사용하면 거절됩니다.
 await dmn.editor.commit({
   baseRevision,
   mutationId: crypto.randomUUID(),
+  multiKey: true,
   changes: {
     schemaVersion: 1,
     keys: nextKeys,
@@ -144,6 +154,11 @@ await dmn.editor.commit({
 키 이름이나 위치 속성처럼 구조와 길이가 그대로인 변경은 해당 컬렉션 하나만
 갱신해도 됩니다. 구조를 바꾸면서 `keys` 또는 `keyPositions` 하나만 제출하면
 `PAIRED_UPDATE_REQUIRED`로 거절됩니다.
+
+현재 매핑에 멀티 키 슬롯이 하나라도 있으면 `keys`를 포함한 커밋은 요청에
+`multiKey: true`를 함께 선언해야 합니다. 선언 없는 쓰기는
+`MULTI_KEY_UNSUPPORTED`(재시도 불가)로 거절됩니다. 멀티 키 슬롯을 모르는
+플러그인이 매핑을 왕복시키며 파괴하는 것을 막는 fail-closed 게이트입니다.
 
 호환용 `dmn.keys` API를 사용할 때 이런 구조 변경은
 `dmn.keys.updateWithPositions(keys, keyPositions)`로 제출하세요. `update()`와
@@ -157,11 +172,15 @@ await dmn.editor.commit({
 ```typescript
 type EditorCommitErrorCode =
   | 'REVISION_CONFLICT'
+  | 'PLUGIN_REVISION_CONFLICT'
   | 'VALIDATION_FAILED'
   | 'TOO_MANY_GESTURE_IDS'
   | 'INVALID_GESTURE_ID'
   | 'PAIRED_UPDATE_REQUIRED'
+  | 'MULTI_KEY_UNSUPPORTED'
   | 'MUTATION_ID_REUSED'
+  | 'HISTORY_IN_PROGRESS'
+  | 'HISTORY_EPOCH_CONFLICT'
   | 'IO_ERROR';
 
 interface EditorCommitError {
@@ -171,6 +190,7 @@ interface EditorCommitError {
     currentRevision?: number;
     validationCode?: string;
     field?: string;
+    currentHistoryEpoch?: number;
   };
   retryable: boolean;
 }
@@ -179,15 +199,19 @@ interface EditorCommitError {
 | 코드                     | 의미                                                      | `retryable` |
 | ------------------------ | --------------------------------------------------------- | ----------- |
 | `REVISION_CONFLICT`      | `baseRevision`이 오래됨. 다시 조회·조정한 뒤 커밋         | `true`      |
+| `PLUGIN_REVISION_CONFLICT` | 플러그인 범위 revision이 오래됨. 다시 조회한 뒤 커밋    | `true`      |
 | `VALIDATION_FAILED`      | 완성된 문서가 에디터 검증 규칙을 위반함                   | `false`     |
 | `TOO_MANY_GESTURE_IDS`   | `gestureIds`가 32개를 넘거나 합친 고유 ID가 32개를 초과함 | `false`     |
 | `INVALID_GESTURE_ID`     | gesture ID가 UUID가 아니거나 64바이트를 초과함            | `false`     |
 | `PAIRED_UPDATE_REQUIRED` | 키 구조 변경에 짝 컬렉션이 빠짐                           | `false`     |
+| `MULTI_KEY_UNSUPPORTED`  | 멀티 키 슬롯이 있는데 `multiKey` 선언 없이 `keys`를 씀    | `false`     |
 | `MUTATION_ID_REUSED`     | 같은 mutation ID를 다른 요청에 재사용함                   | `false`     |
 | `IO_ERROR`               | 문서를 디스크에 저장하지 못함                             | `true`      |
+| `HISTORY_IN_PROGRESS`    | undo/redo 진행 중. 끝난 뒤 재시도                         | `true`      |
+| `HISTORY_EPOCH_CONFLICT` | 관측한 history epoch이 오래됨. 다시 조회한 뒤 커밋        | `true`      |
 
 오류에 해당할 때 `details.currentRevision`, `details.validationCode`,
-`details.field`가 함께 제공됩니다.
+`details.field`, `details.currentHistoryEpoch`가 함께 제공됩니다.
 
 ## 커밋된 변경 구독
 
@@ -205,6 +229,7 @@ interface EditorCommittedV1 {
   gestureIds?: string[];
   origin?: string;
   changedFields: EditorField[];
+  // patch.keys는 KeySlot union(string | MultiKeySlot)
   patch: EditorPatchV1;
 }
 

--- a/docs/content/ko/api-reference/keys/page.mdx
+++ b/docs/content/ko/api-reference/keys/page.mdx
@@ -27,8 +27,8 @@ description: 키 매핑, 이벤트, 커스텀 탭 API
 type SlotMatch = 'all' | 'any';
 
 // 슬롯은 단일 키 문자열 또는 멀티 키 바인딩입니다:
-// - match: 'any' — 멤버 키 중 하나만 눌러도 슬롯 활성 (택일)
-// - match: 'all' — 멤버 키를 전부 동시에 눌러야 슬롯 활성 (동시)
+// - match: 'any': 멤버 키 중 하나만 눌러도 슬롯 활성 (택일)
+// - match: 'all': 멤버 키를 전부 동시에 눌러야 슬롯 활성 (동시)
 interface MultiKeySlot {
   keys: string[]; // 멤버 키 2~8개
   match: SlotMatch;
@@ -36,7 +36,7 @@ interface MultiKeySlot {
 
 type KeySlot = string | MultiKeySlot;
 type KeyMappings = Record<string, KeySlot[]>;
-// { "4key": ["KeyD", { keys: ["KeyF", "Numpad4"], match: "any" }, ...], ... }
+// { "4key": ["D", { keys: ["F", "NUMPAD 4"], match: "any" }, ...], ... }
 ```
 
 ```javascript
@@ -50,13 +50,39 @@ console.log('4key 매핑:', mappings['4key']);
   매핑을 다루기 전에 업데이트가 필요합니다.
 </Callout>
 
+### canonical 슬롯 식별자
+
+이벤트·카운터 표면은 슬롯을 canonical 문자열로 식별합니다:
+
+- 단일 키 슬롯은 키 문자열 그대로입니다 (예: `"D"`).
+- `match: 'all'` 슬롯은 멤버를 순서대로 `+`로 결합합니다
+  (예: `"LEFT CTRL+Z"`).
+- `match: 'any'` 슬롯은 멤버를 `|`로 결합합니다 (예: `"F|NUMPAD 4"`).
+
+canonical 문자열은 생성과 동등 비교 전용입니다. 멤버로 되파싱하지 말고 슬롯
+객체는 `get()`에서 읽으세요. `any` 슬롯의 표시 라벨은 `/`로 결합되는데(예:
+`Z/B`) 이는 canonical `|`와 별개인 UI 관례입니다. 슬롯을 `all`과 `any` 사이에서
+전환하면 canonical 식별자가 바뀌므로 기존 카운터는 이어지지 않습니다.
+
+canonical 식별자가 쓰이는 표면: `onKeyState()`의 `key`, 카운터 맵 키
+(`getCounters()`, `onCounterChanged`, `onCountersChanged`),
+`resetSingleCounter(mode, key)`, UI 앵커·키 메뉴의 `keyCode`. 매핑 표면
+(`get()`, `update()`, `onChanged`, 에디터 문서, 프리셋 스냅샷)은 반대로
+`KeySlot` union을 그대로 전달합니다.
+
+수제 레거시 데이터에는 문자열 자체에 `+`나 `|`가 포함된 단일 키 슬롯(예: 한
+문자열 `"A+B"`)이 있을 수 있습니다. 이런 슬롯은 무손실로 보존되지만 데몬
+입력으로 활성화될 수 없는 inert 슬롯입니다. 실제 멀티 키 슬롯과 canonical
+식별자(그리고 카운터 버킷)를 겉보기로 공유할 수 있으며, 둘이 공존하면 노트
+이펙트는 실제 멀티 키 슬롯을 우선합니다.
+
 ### update(mappings, options?)
 
 키 매핑을 업데이트합니다.
 
 ```javascript
 const current = await dmn.keys.get();
-current['4key'] = ['KeyS', 'KeyD', 'KeyJ', 'KeyK'];
+current['4key'] = ['S', 'D', 'J', 'K'];
 await dmn.keys.update(current);
 ```
 
@@ -104,7 +130,7 @@ interface KeyPosition {
   activeBackgroundColor?: string;
   borderColor?: string;
   activeBorderColor?: string;
-  borderWidth?: number; // px, 미지정 시 기본 1 — 0이면 테두리 없음
+  borderWidth?: number; // px, 미지정 시 기본 1. 0이면 테두리 없음
   backgroundGradient?: GradientSpec | null;
   activeBackgroundGradient?: GradientSpec | null;
   borderGradient?: GradientSpec | null;
@@ -121,7 +147,7 @@ interface KeyCounterSettings {
 }
 
 interface GradientSpec {
-  angle: number; // 0 이상 360 미만 — 360은 0으로 정규화 (CSS 기준, 0 = 위·시계 방향)
+  angle: number; // 0 이상 360 미만. 360은 0으로 정규화 (CSS 기준, 0 = 위·시계 방향)
   stops: { color: string; pos: number }[]; // 2–8개, pos는 0–1 오름차순
 }
 
@@ -160,7 +186,7 @@ current['4key'][0].dx = 100;
 await dmn.keys.updatePositions(current);
 ```
 
-### updateWithPositions(mappings, positions)
+### updateWithPositions(mappings, positions, options?)
 
 키 매핑과 인덱스로 결합된 위치 정보를 한 번의 원자적 커밋으로 갱신합니다.
 두 값의 모드 집합과 모드별 배열 길이는 같아야 합니다. 키를 추가·삭제·재정렬할
@@ -173,8 +199,14 @@ interface KeysWithPositionsResult {
   positions: KeyPositions;
 }
 
-const result = await dmn.keys.updateWithPositions(mappings, positions);
+const result = await dmn.keys.updateWithPositions(mappings, positions, {
+  multiKey: true,
+});
 ```
+
+세 번째 `options` 인자는 `update()`와 같은 `{ multiKey?: boolean }` 선언을
+받습니다. 선언 없이 쓰면 현재 매핑에 멀티 키 슬롯이 있을 때
+`MULTI_KEY_UNSUPPORTED`로 거절됩니다.
 
 ## 모드 관리
 
@@ -207,7 +239,8 @@ const reset = await dmn.keys.resetAll();
 
 ### getCounters()
 
-현재 누적 키 카운터 스냅샷을 조회합니다.
+현재 누적 키 카운터 스냅샷을 조회합니다. 내부 맵의 키는 canonical 슬롯
+식별자입니다.
 
 ```javascript
 const counters = await dmn.keys.getCounters();
@@ -220,7 +253,7 @@ console.log('4key 카운터:', counters['4key']);
 
 ```javascript
 await dmn.keys.setCounters({
-  '4key': { KeyD: 100, KeyF: 200, KeyJ: 150, KeyK: 180 },
+  '4key': { D: 100, F: 200, J: 150, K: 180 },
 });
 ```
 
@@ -245,7 +278,7 @@ await dmn.keys.resetCountersMode('4key');
 특정 모드의 특정 키 카운트만 초기화합니다.
 
 ```javascript
-await dmn.keys.resetSingleCounter('4key', 'KeyD');
+await dmn.keys.resetSingleCounter('4key', 'D');
 ```
 
 ## 이벤트 구독
@@ -258,7 +291,7 @@ await dmn.keys.resetSingleCounter('4key', 'KeyD');
 
 ```typescript
 interface KeyStatePayload {
-  key: string; // 키 코드 (예: "KeyD")
+  key: string; // canonical 슬롯 식별자 (예: "D", "F|NUMPAD 4")
   state: string; // "DOWN" | "UP"
   mode: string; // 현재 모드
   // 입력 수신~emit 경과 시간(ms).
@@ -311,7 +344,7 @@ dmn.keys.onKeysReset(({ reason }) => {
 ```typescript
 interface RawInputPayload {
   device: 'keyboard' | 'mouse' | 'gamepad' | 'unknown';
-  label: string; // "KeyD", "MOUSE1", "HIDB:1ccf:101c:9:3" 등
+  label: string; // "D", "MOUSE1", "HIDB:1ccf:101c:9:3" 등
   labels: string[]; // 모든 레이블 목록
   state: string; // "DOWN" | "UP"
 }
@@ -361,7 +394,8 @@ const unsub = dmn.keys.onPositionsChanged((positions) => {
 
 ### onModeChanged(listener)
 
-키 모드 변경 이벤트를 구독합니다.
+레이아웃 모드 변경 이벤트(`keys:mode-changed`)를 구독합니다. `mode`는 `'4key'`
+같은 현재 레이아웃 모드 ID입니다.
 
 ```javascript
 const unsub = dmn.keys.onModeChanged(({ mode }) => {

--- a/docs/content/ko/api-reference/keys/page.mdx
+++ b/docs/content/ko/api-reference/keys/page.mdx
@@ -297,11 +297,17 @@ interface KeyStatePayload {
   // 입력 수신~emit 경과 시간(ms).
   // `performance.now() - eventAgeMs`로 실제 입력 시각 복원
   eventAgeMs?: number;
-  // UP 이벤트 한정. 입력 데몬이 캡처 시점에 측정한 물리 눌림
-  // 지속 시간(ms) - 전달 지연·지터의 영향을 받지 않음
+  // UP 이벤트 한정. 같은 물리 입력이 canonical DOWN과 UP을 만든 경우
+  // 입력 데몬이 측정한 물리 눌림 지속 시간(ms). source가 다르거나
+  // 불명확하면 생략됨
   holdDurationMs?: number;
 }
 ```
+
+`holdDurationMs`가 있으면 전달 지연·지터의 영향을 받지 않습니다. canonical
+슬롯은 여러 장치나 멤버 키의 겹친 입력 동안 계속 활성일 수 있으므로, 이 선택적
+필드가 없을 때 전체 활성 시간이 필요한 소비자는 같은 canonical의 `DOWN`과 `UP`
+시각을 직접 추적해야 합니다.
 
 ```javascript
 const unsub = dmn.keys.onKeyState(({ key, state, mode }) => {

--- a/docs/content/ko/api-reference/keys/page.mdx
+++ b/docs/content/ko/api-reference/keys/page.mdx
@@ -24,8 +24,19 @@ description: 키 매핑, 이벤트, 커스텀 탭 API
 모든 키 모드의 키 매핑을 조회합니다.
 
 ```typescript
-type KeyMappings = Record<string, string[]>;
-// { "4key": ["KeyD", "KeyF", "KeyJ", "KeyK"], ... }
+type SlotMatch = 'all' | 'any';
+
+// 슬롯은 단일 키 문자열 또는 멀티 키 바인딩입니다:
+// - match: 'any' — 멤버 키 중 하나만 눌러도 슬롯 활성 (택일)
+// - match: 'all' — 멤버 키를 전부 동시에 눌러야 슬롯 활성 (동시)
+interface MultiKeySlot {
+  keys: string[]; // 멤버 키 2~8개
+  match: SlotMatch;
+}
+
+type KeySlot = string | MultiKeySlot;
+type KeyMappings = Record<string, KeySlot[]>;
+// { "4key": ["KeyD", { keys: ["KeyF", "Numpad4"], match: "any" }, ...], ... }
 ```
 
 ```javascript
@@ -33,7 +44,13 @@ const mappings = await dmn.keys.get();
 console.log('4key 매핑:', mappings['4key']);
 ```
 
-### update(mappings)
+<Callout type="warning">
+  멀티 키 업데이트 이후 슬롯 값은 문자열뿐 아니라 객체(`MultiKeySlot`)일 수
+  있습니다. 모든 슬롯이 문자열이라고 가정하는 플러그인은 멀티 키 슬롯이 포함된
+  매핑을 다루기 전에 업데이트가 필요합니다.
+</Callout>
+
+### update(mappings, options?)
 
 키 매핑을 업데이트합니다.
 
@@ -42,6 +59,20 @@ const current = await dmn.keys.get();
 current['4key'] = ['KeyS', 'KeyD', 'KeyJ', 'KeyK'];
 await dmn.keys.update(current);
 ```
+
+현재 설정에 멀티 키 슬롯이 존재하는 상태에서 매핑을 쓰려면 멀티 키 지원을
+명시적으로 선언해야 합니다:
+
+```javascript
+await dmn.keys.update(current, { multiKey: true });
+```
+
+선언 없이 쓰면 현재 매핑에 멀티 키 슬롯이 하나라도 있을 때
+`MULTI_KEY_UNSUPPORTED` 오류 코드(비 retryable)로 거절됩니다. 멀티 키 슬롯을
+보존하지 않는 플러그인의 왕복 쓰기가 사용자 설정을 파괴하는 것을 막는
+fail-closed 게이트입니다. 같은 규칙이 `updateWithPositions()`와, `keys`를
+포함한 `dmn.editor.commit()` 요청(커밋 요청의 `multiKey: true`로 선언)에도
+적용됩니다.
 
 ### getPositions()
 

--- a/docs/content/ko/api-reference/presets/page.mdx
+++ b/docs/content/ko/api-reference/presets/page.mdx
@@ -37,6 +37,26 @@ if (result.success) {
 }
 ```
 
+## 탭 프리셋
+
+### saveTab()
+
+현재 선택된 탭(키 매핑·레이아웃)만 탭 프리셋 파일로 저장합니다. 파일 저장
+다이얼로그가 열립니다.
+
+```javascript
+const result = await dmn.presets.saveTab();
+```
+
+### loadTab()
+
+탭 프리셋 파일을 현재 선택된 탭에 불러옵니다. 파일 선택 다이얼로그가
+열립니다.
+
+```javascript
+const result = await dmn.presets.loadTab();
+```
+
 ## 사용 예제
 
 ### 컨텍스트 메뉴에서 프리셋 관리
@@ -88,10 +108,12 @@ dmn.plugin.registerCleanup(() => {
 
 ```typescript
 interface PresetSnapshot {
+  // 항목은 KeySlot union(string | MultiKeySlot)
   keys: KeyMappings;
   positions: KeyPositions;
   statPositions: StatItemPositions;
   graphPositions: GraphItemPositions;
+  knobPositions: KnobItemPositions;
   customTabs: CustomTab[];
   selectedKeyType: string;
   tabNoteOverrides: TabNoteOverrides;

--- a/docs/content/ko/declarative-api/page.mdx
+++ b/docs/content/ko/declarative-api/page.mdx
@@ -535,6 +535,11 @@ onMount: ({ onHook, setState }) => {
 },
 ```
 
+`"key"` 훅은 `dmn.keys.onKeyState`와 같은 canonical payload를 받습니다. `UP`의
+`holdDurationMs`는 같은 물리 입력이 canonical 전환 양쪽을 만든 경우에만 포함되고,
+그 외에는 생략됩니다. 전체 활성 시간이 필요하면 같은 canonical의 `DOWN`과 `UP`
+시각을 직접 추적하세요.
+
 ### 설정 변경 감지 (onSettingsChange)
 
 설정 변경에 즉시 반응해야 할 때 사용합니다.

--- a/docs/content/ko/ui-api/page.mdx
+++ b/docs/content/ko/ui-api/page.mdx
@@ -32,7 +32,7 @@ const menuId = dmn.ui.contextMenu.addKeyMenuItem({
 
 | 속성       | 타입        | 설명                 |
 | ---------- | ----------- | -------------------- |
-| `keyCode`  | string      | 키 코드 (예: "KeyD") |
+| `keyCode`  | string      | canonical 슬롯 식별자 (예: "D", "LEFT CTRL+Z", "F\|NUMPAD 4") |
 | `index`    | number      | 키 인덱스            |
 | `position` | KeyPosition | 키 위치 정보         |
 | `mode`     | string      | 현재 키 모드         |
@@ -193,11 +193,17 @@ dmn.ui.displayElement.add({
   html: `<div>→</div>`,
   position: { x: 0, y: 0 },
   anchor: {
-    keyCode: "KeyD",
+    keyCode: "D",
     offset: { x: 70, y: 0 },
   },
 });
 ```
+
+`anchor.keyCode`는 canonical 슬롯 식별자입니다. 멀티 키 슬롯에는 canonical
+문자열을 사용하세요 (`match: 'all'`은 `"LEFT CTRL+Z"`, `match: 'any'`는
+`"F|NUMPAD 4"` 형태).
+[canonical 슬롯 식별자](/docs/api-reference/keys#canonical-슬롯-식별자)를
+참고하세요.
 
 ### Shadow DOM
 

--- a/docs/obs-mode-design.md
+++ b/docs/obs-mode-design.md
@@ -57,7 +57,7 @@
 
 ```json
 {
-  "v": 1,
+  "v": 2,
   "type": "key_event",
   "seq": 10241,
   "ts": 1741339200123,
@@ -98,11 +98,11 @@
 #### hello (C→S) ✅
 ```json
 {
-  "v": 1,
+  "v": 2,
   "type": "hello",
   "payload": {
     "client": "obs-browser",
-    "protocol": 1,
+    "protocol": 2,
     "appVersion": "1.5.2",
     "resumeFromSeq": 0,
     "token": "<세션 토큰>"
@@ -116,7 +116,7 @@
 #### snapshot (S→C) ✅
 ```json
 {
-  "v": 1,
+  "v": 2,
   "type": "snapshot",
   "seq": 10,
   "payload": {
@@ -137,7 +137,7 @@
 #### tauri_event (S→C) ✅
 ```json
 {
-  "v": 1,
+  "v": 2,
   "type": "tauri_event",
   "seq": 11,
   "payload": {
@@ -760,14 +760,14 @@ async function bootstrap() {
 
 ```json
 // C→S
-{ "v": 1, "type": "invoke_request", "seq": 42,
+{ "v": 2, "type": "invoke_request", "seq": 42,
   "payload": { "requestId": "rpc_xxx", "command": "settings_get", "args": {} } }
 
 // S→C
-{ "v": 1, "type": "invoke_response", "seq": 43,
+{ "v": 2, "type": "invoke_response", "seq": 43,
   "payload": { "requestId": "rpc_xxx", "result": { ... } } }
 // 에러 시
-{ "v": 1, "type": "invoke_response", "seq": 43,
+{ "v": 2, "type": "invoke_response", "seq": 43,
   "payload": { "requestId": "rpc_xxx", "error": "Not found" } }
 ```
 
@@ -775,7 +775,7 @@ async function bootstrap() {
 
 ```json
 // S→C — 백엔드의 모든 Tauri emit을 WS로 전달
-{ "v": 1, "type": "tauri_event", "seq": 44,
+{ "v": 2, "type": "tauri_event", "seq": 44,
   "payload": { "event": "keys:counter", "data": { "mode": "4key", "key": "A", "count": 42 } } }
 ```
 

--- a/docs/pr-114-merge-plan.md
+++ b/docs/pr-114-merge-plan.md
@@ -1,0 +1,276 @@
+# PR #114 병합 준비 계획
+
+> 작성일: 2026-08-07
+> 최종 업데이트: 2026-08-07 — 물리 입력 refcount 및 공개 API 계약 검토 반영
+> 대상 PR: [#114 feat: 여러 키 매핑 지원](https://github.com/DmNote-App/DmNote/pull/114)
+> 검토 기준: PR head `4c3c824`, `master` `68c6987`
+> 상태: **구현·자동 검증 완료 — Windows 11 실기 검증 대기**
+
+---
+
+## 1. 목적
+
+PR #114의 여러 키 매핑 기능을 최신 `master`에 안전하게 통합한다. 다음 조건을 모두 만족해야 병합 가능 상태로 전환한다.
+
+1. 단일·다중 키 슬롯의 노트 홀드 시간이 물리 장치 수와 키 해제 순서에 무관하게 canonical 슬롯의 실제 활성 시간을 반영한다.
+2. 최신 `master`와의 충돌을 해소하면서 오버레이 레이아웃의 참조 안정성 최적화를 보존한다.
+3. Rust·TypeScript 자동 검증과 Windows 11 실기 검증을 모두 통과한다.
+4. OBS 프로토콜, 플러그인 capability, 기존 store·프리셋 호환성을 회귀시키지 않는다.
+
+## 2. 현재 상태
+
+### 확인된 병합 차단 사항
+
+| 항목                | 현재 상태                                                 | 영향                                                                  |
+| ------------------- | --------------------------------------------------------- | --------------------------------------------------------------------- |
+| canonical 홀드 시간 | canonical `UP`에 마지막 물리 키의 `hold_duration_ms` 전달 | 다중 슬롯 또는 같은 라벨의 복수 장치 입력에서 지연 노트 길이가 달라짐 |
+| 최신 `master` 통합  | GitHub `CONFLICTING / DIRTY`                              | 현재 상태로 병합 불가                                                 |
+| 오버레이 충돌       | `src/renderer/windows/overlay/App.tsx` 충돌               | 잘못 해결하면 레이아웃 memoization 무효화                             |
+| Windows 검증        | 실제 Windows 빌드·입력 검증 결과 없음                     | 변경된 Raw Input 경로의 플랫폼 회귀 가능성 미확인                     |
+| GitHub 상태 검사    | 등록된 status check 없음                                  | 저장소 외부에서 병합 게이트가 강제되지 않음                           |
+
+### 검토 중 통과한 항목
+
+- PR head 기준 TypeScript 타입 검사, lint, format check, 프로덕션 빌드 통과
+- PR head 기준 프론트엔드 테스트 746개 통과
+- PR head 기준 `cargo check`, `cargo clippy --all-targets -- -D warnings` 통과
+- PR head 기준 Rust 테스트 438개 통과, 6개 ignored
+- 최신 `master` 임시 통합본 기준 프론트엔드 테스트 770개 및 프로덕션 빌드 통과
+- 최신 `master` 임시 통합본 기준 Rust 테스트 438개 통과, 6개 ignored
+
+위 결과는 현재 코드의 기본 건전성을 보여주지만, 아래 필수 수정과 Windows 실기 검증을 대체하지 않는다.
+
+`holdDurationMs`는 앱 내부에서 **지연 노트가 활성화된 경로의 길이 정책에만** 사용된다. 비지연 노트는 `displayTime` 기준으로 즉시 종료하므로 이 오류의 시각적 영향은 지연 노트에서 발생한다. 다만 동일 필드가 `dmn.keys.onKeyState`와 플러그인 `onHook('key')`에도 공개되므로, 외부 플러그인에 대해서는 지연 노트 설정과 무관한 API 계약 문제다.
+
+## 3. 구현 결정
+
+### 3.1 canonical 슬롯 홀드 시간 정책
+
+노트 홀드 시간은 **canonical 슬롯이 비활성에서 활성으로 전환된 시각부터 다시 비활성으로 전환된 시각까지**로 정의한다.
+
+- authoritative 물리 홀드의 사용 여부는 슬롯이 단일인지 다중인지로 판정하지 않는다.
+- canonical `DOWN`을 만든 물리 입력과 canonical `UP`을 만든 물리 입력이 동일할 때만 해당 물리 입력의 데몬 `hold_duration_ms`를 신뢰한다.
+- 두 transition의 물리 source가 다르거나 activation source를 알 수 없으면 `UP` payload의 `holdDurationMs`를 생략하고, 프론트가 canonical `DOWN`·`UP`의 보정된 물리 시각 차이를 사용한다.
+- `KeyboardState`는 active canonical별 activation source physical ID를 명시적으로 추적한다. `SlotEvent`는 app state가 문자열을 재해석하지 않도록 물리 hold 사용 가능 여부를 전달한다.
+- 모드·매핑 재구성처럼 canonical active 상태는 복구되지만 activation source를 확정할 수 없는 경로에서는 보수적으로 source unknown으로 처리하고 물리 hold를 전달하지 않는다.
+
+이 방식은 같은 라벨을 내는 키보드 두 대의 겹친 입력과 다중 슬롯을 같은 규칙으로 처리하며, 백엔드에 별도 시계를 중복 관리하지 않고 기존 프론트엔드 fallback을 재사용한다. 향후 canonical 홀드 시간을 백엔드에서 직접 제공해야 한다면 별도 필드와 명확한 wire contract로 확장한다.
+
+fallback은 비클램프 `physDownTime`·`physReleaseTime` 차이를 사용하되, 입력 시계 이상으로 비정상적으로 부풀지 않도록 상한 방어를 추가한다. 고정된 전체 홀드 상한으로 정상적인 장시간 입력을 자르지 않고, 독립적으로 관측한 display 경과 시간에 명명된 clock-skew 허용치를 더한 값을 상한으로 사용한다. 경계값과 장시간 홀드를 테스트해 정상 입력의 길이는 보존한다.
+
+### 3.2 공개 API timing 계약
+
+`holdDurationMs`는 선택적 필드라는 타입 정의를 유지하되, en/ko 문서의 의미를 실제 payload 정책과 맞춘다.
+
+- canonical `DOWN`과 `UP`의 물리 source가 같을 때만 데몬 측정값이 제공된다.
+- source가 다르거나 불명확하면 `UP` 이벤트에서도 필드가 생략될 수 있다.
+- 플러그인이 canonical 홀드를 계산해야 하면 같은 canonical의 `DOWN`·`UP` 시각을 직접 추적해야 한다.
+- `dmn.keys.onKeyState`와 `onHook('key')`가 동일한 payload 정책을 사용함을 명시한다.
+- “전달 지연과 지터에 항상 영향받지 않는다”는 단정은 조건부 설명으로 교체한다.
+
+### 3.3 오버레이 참조 안정성 정책
+
+충돌 해결 후 다음 값은 `currentSlots`가 실제로 변경될 때만 새 참조를 생성해야 한다.
+
+- `currentKeys`
+- `currentKeyLabels`
+- `currentValidKeySignature`
+
+`currentSlots: KeySlot[]`의 빈 fallback은 모듈 상수 `EMPTY_SLICE`를 사용하고, 세 파생 값은 `useMemo`에서 함께 계산한다. PR 쪽의 단순 `map()` 구현만 선택해서는 안 된다.
+
+## 4. 작업 단계
+
+### 1단계 — 최신 master 통합
+
+1. `feature/multi-key-binding`에 최신 `origin/master`를 통합한다.
+2. 충돌 범위가 예상한 `src/renderer/windows/overlay/App.tsx` 한 곳인지 확인한다.
+3. 충돌은 `currentSlots`와 파생 canonical 값 계산 블록에서 해결하고, 자동 병합된 최신 layout 코드는 그대로 보존한다.
+   - `keyMappings[selectedKeyType] ?? EMPTY_SLICE`
+   - `useMemo([currentSlots])` 기반 canonical 키·표시 라벨·signature 계산
+   - 최신 `master`의 plugin layout projection과 `computeLayout` memoization
+   - PR의 `slotCanonical`, `slotDisplayName`, `validKeySignature` 사용
+4. 충돌 마커와 불필요한 중복 import가 남지 않았는지 확인한다.
+
+완료 기준:
+
+- GitHub가 PR을 `MERGEABLE`로 판정한다.
+- unrelated 렌더에서 `currentKeys`와 `currentKeyLabels` 참조가 유지된다.
+- 탭 또는 키 매핑 변경 시에는 새 canonical projection이 계산된다.
+
+### 2단계 — canonical 홀드 시간 정정
+
+예상 수정 파일:
+
+| 파일                                                           | 작업                                                                                  |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `src-tauri/src/keyboard/manager.rs`                            | active canonical의 activation physical ID 추적 및 `SlotEvent`에 source 일치 여부 추가 |
+| `src-tauri/src/state/app_state.rs`                             | source가 같은 canonical `UP`에만 `message.hold_duration_ms` 전달                      |
+| `src/renderer/hooks/overlay/useNoteSystem.ts`                  | canonical fallback hold의 clock-skew 상한 방어 추가                                   |
+| `src/renderer/hooks/overlay/useNoteSystem.test.tsx`            | authoritative 값 부재·비정상 시각·상한 경계 회귀 테스트 보강                          |
+| `src/renderer/hooks/overlay/useNoteSystem.continuity.test.tsx` | 지연 노트 길이 연속성에서 optional hold 계약 검증                                     |
+| `src/renderer/windows/overlay/App.test.tsx`                    | optional `holdDurationMs` 전달과 canonical timing 복원 계약 검증                      |
+| `docs/content/en/api-reference/keys/page.mdx`                  | `dmn.keys.onKeyState`의 조건부 `holdDurationMs` 의미 반영                             |
+| `docs/content/ko/api-reference/keys/page.mdx`                  | 영문과 동일한 keys API 계약 반영                                                      |
+| `docs/content/en/declarative-api/page.mdx`                     | `onHook('key')`의 optional hold payload 계약 반영                                     |
+| `docs/content/ko/declarative-api/page.mdx`                     | 영문과 동일한 hook 계약 반영                                                          |
+| 관련 Rust 테스트 모듈                                          | activation source identity와 payload timing 정책 검증                                 |
+
+필수 테스트 시나리오:
+
+| 슬롯                | 입력 순서                                   | 기대 결과                                                       |
+| ------------------- | ------------------------------------------- | --------------------------------------------------------------- |
+| 단일 `A`·장치 1대   | kb1 A down → kb1 A up                       | source가 같으므로 기존 데몬 홀드 시간 유지                      |
+| 단일 `A`·장치 2대   | kb1 down → kb2 down → kb1 up → kb2 up       | kb1 down부터 kb2 up까지 canonical 활성, kb2 물리 홀드 사용 금지 |
+| 단일 `A`·장치 2대   | kb1 down → kb2 down → kb2 up → kb1 up       | source가 같으므로 kb1 데몬 홀드가 canonical 구간과 일치         |
+| 동시 `A+B`          | A down → B down → A up → B up               | B down부터 A up까지를 canonical 홀드로 판정                     |
+| 동시 `A+B`          | B down → A down → B up → A up               | A down부터 B up까지를 canonical 홀드로 판정                     |
+| 개별 `A\|B`         | A down → B down → A up → B up               | A down부터 B up까지 슬롯 활성 유지, B 물리 홀드 시간 사용 금지  |
+| 개별 `A\|B`         | B down → A down → B up → A up               | B down부터 A up까지 슬롯 활성 유지, A 물리 홀드 시간 사용 금지  |
+| 멀티 슬롯 중복 매핑 | 같은 canonical을 참조하는 슬롯 존재         | `DOWN`·`UP` 쌍과 홀드 계산이 중복되거나 분리되지 않음           |
+| 반복 down           | 같은 physical ID로 auto-repeat down         | `match_and_register`가 `None`을 반환하고 refcount·timing 불변   |
+| unmatched up        | 선행 down 없는 release                      | 잘못된 홀드 시간이 만들어지지 않음                              |
+| source unknown      | active 입력 중 모드·매핑 재구성             | 물리 hold를 신뢰하지 않고 canonical fallback 사용               |
+| 비정상 event age    | phys 시각 차가 display 경과보다 과도하게 큼 | clock-skew 허용 상한으로 제한                                   |
+| 장시간 정상 hold    | 정상 monotonic 시계에서 장시간 유지         | 고정 시간 상한으로 잘리지 않고 실제 canonical 구간 유지         |
+
+완료 기준:
+
+- 물리 장치 수와 멤버 키의 누름·해제 순서를 바꿔도 실제 canonical 활성 구간이 계산된다.
+- 단일 물리 입력의 기존 authoritative 홀드는 유지하되, 같은 라벨의 복수 물리 입력에서는 마지막 해제 키의 hold를 잘못 사용하지 않는다.
+- 프론트에서 `NaN`, 음수 또는 누락된 timing 값에 대한 기존 방어가 유지된다.
+- fallback hold는 비정상 clock skew에 대한 상한을 가지며 정상적인 장시간 hold는 보존한다.
+
+### 3단계 — 자동 검증
+
+프론트엔드:
+
+```bash
+npm ci
+npx tsc --noEmit
+npm run lint
+npm run format
+npm test -- --reporter=dot
+npm run build
+```
+
+확인 사항:
+
+- `npm run format` 이후 의도적인 `eslint-disable` 및 `'use no memo'`가 변경되지 않았는지 diff 확인
+- 오버레이 테스트에 unrelated store 갱신 시 레이아웃 재계산을 유발하지 않는 참조 안정성 검증 추가
+- 키 매핑 변경과 탭 전환 시 예약 타이머 및 눌림 signal 정합성 테스트 유지
+
+백엔드:
+
+```bash
+cd src-tauri
+cargo check
+cargo clippy --all-targets -- -D warnings
+cargo fmt --check
+cargo test
+```
+
+확인 사항:
+
+- ignored 테스트 수가 기준선보다 의도 없이 증가하지 않음
+- 커맨드 추가·삭제가 있다면 빌드 후 `permissions/dmnote-allow-all.json` 갱신 여부 확인
+- wire payload 변경이 있다면 직렬화 호환 테스트 추가
+
+### 4단계 — Windows 11 실기 검증
+
+PR이 변경한 Windows Raw Input 및 HID 경로는 실제 Windows 11 환경에서 확인한다. macOS의 MSVC cross compile 결과로 대체하지 않는다.
+
+빌드 확인:
+
+- Windows 11에서 `cargo check`, `cargo clippy --all-targets -- -D warnings`
+- Windows 11에서 `npm run tauri:build`
+- 키보드·마우스·HID feature가 활성화된 실제 프로덕션 바이너리 실행
+
+입력 확인:
+
+1. 키보드 단일 키 down/up 및 auto-repeat
+2. 서로 다른 물리 키보드에서 같은 라벨을 `kb1 down → kb2 down → kb1 up → kb2 up` 순서로 입력하고, 지연 노트 ON 상태에서 kb1 down부터 kb2 up까지의 길이가 반영되는지 확인
+3. 마우스 버튼이 포함된 개별·동시 매핑
+4. `A+B`, `A|B`의 모든 누름·해제 순서
+5. 매핑 중 멤버 키가 이미 눌린 상태에서 설정 또는 탭 전환
+6. 입력 장치 분리·재연결 후 stuck active 상태가 남지 않는지 확인
+7. 키음이 물리 down당 한 번만 재생되고 슬롯 중복 매핑으로 중복되지 않는지 확인
+8. 카운터와 오버레이 active 상태가 canonical 식별자로 일치하는지 확인
+9. 지연 노트 ON 및 최소 길이 설정에서 단일·개별·동시 슬롯의 실제 canonical 홀드 길이가 표시되는지 확인
+
+각 실패는 입력 순서, 장치 종류, 슬롯 JSON, 기대값과 실제값을 함께 기록한다.
+
+### 5단계 — 호환성 회귀 검증
+
+#### Store·프리셋
+
+- 기존 문자열 슬롯 store를 무손실 로드·저장
+- `all`·`any` 다중 슬롯을 저장한 뒤 재시작하여 동일하게 복원
+- 손상된 멀티 슬롯을 인덱스 제거 없이 제자리 기본값으로 복구
+- 구버전 프리셋 import 후 현재 매핑·position 인덱스 결합 유지
+- 다운그레이드 projection에서 멀티 슬롯만 제자리 빈 슬롯으로 대체
+
+#### 플러그인
+
+- `multiKey` capability를 선언한 플러그인의 keys 읽기·쓰기 성공
+- capability가 없는 플러그인이 멀티 슬롯을 파괴적으로 덮어쓰려 할 때 `MULTI_KEY_UNSUPPORTED` 반환
+- 단일 슬롯만 있는 문서에 대한 기존 플러그인 쓰기 동작 유지
+- 오류 코드가 en/ko API 문서와 실제 응답에 동일하게 표기
+- `dmn.keys.onKeyState`와 `onHook('key')`에서 source가 같은 `UP`에는 `holdDurationMs`가 있고, source가 다르거나 불명확한 `UP`에는 필드가 생략됨
+- optional `holdDurationMs`가 없어도 기존 플러그인 이벤트 전달과 callback 실행이 유지됨
+
+#### OBS
+
+- 프로토콜 v2 앱과 v2 OBS 오버레이 연결 성공
+- 구버전 OBS 페이지는 명확한 버전 불일치로 거부
+- 브라우저 소스 새로고침 후 정상 복구
+- `keys:state`의 canonical 키와 snapshot의 key mapping이 일치
+- 개별·동시 슬롯의 active 전환과 노트 timing이 로컬 오버레이와 동일
+
+### 6단계 — 최종 감사 및 병합 승인
+
+1. PR 전체 diff를 최신 `master` 기준으로 다시 검토한다.
+2. 자동 포맷이 기능과 무관한 대규모 diff를 만들지 않았는지 확인한다.
+3. API·이벤트·오류 코드 변경이 있다면 `docs/content/en/`과 `docs/content/ko/`를 함께 갱신한다.
+4. GitHub status check가 없다면 위 명령의 결과와 Windows 실기 결과를 PR 댓글에 남긴다.
+5. 아래 수용 기준을 모두 충족한 뒤 승인한다.
+
+## 5. 최종 수용 기준
+
+- [ ] GitHub 기준 충돌 없이 병합 가능
+- [ ] 최신 `master`의 오버레이 memoization 및 stable reference 유지
+- [ ] 한 물리 입력으로 누른 단일 슬롯의 authoritative 홀드 시간 회귀 없음
+- [ ] 같은 라벨의 복수 물리 입력은 첫 canonical `DOWN`부터 마지막 `UP`까지 계산됨
+- [ ] `all` 슬롯의 canonical 홀드 시간이 누름·해제 순서와 무관하게 정확함
+- [ ] `any` 슬롯의 겹친 입력 구간이 하나의 canonical 활성 구간으로 계산됨
+- [ ] fallback hold의 clock-skew 상한 및 정상 장시간 hold 보존 테스트 통과
+- [ ] 프론트엔드 타입·lint·format·전체 테스트·프로덕션 빌드 통과
+- [ ] Rust check·clippy·format·전체 테스트 통과
+- [ ] Windows 11 프로덕션 빌드 및 실제 Raw Input 검증 통과
+- [ ] OBS v2 연결·버전 거부·새로고침 복구 검증 통과
+- [ ] 플러그인 capability 게이트, 오류 코드 및 optional `holdDurationMs` 계약 검증 통과
+- [ ] legacy store·프리셋·다운그레이드 호환성 검증 통과
+- [ ] 필요한 en/ko 문서가 함께 갱신됨
+
+## 6. 범위 밖 항목
+
+다음 작업은 PR #114 병합을 위해 새로 확장하지 않는다.
+
+- 다중 키 문법 또는 match mode 추가
+- 새로운 노트 timing wire protocol 설계
+- 키 카운터 정책 변경
+- OBS v2 이후의 추가 프로토콜 기능
+- 플러그인 capability 체계 전반의 재설계
+- 오버레이 레이아웃 엔진의 추가 성능 개선
+
+범위 밖 문제가 병합 차단 수준으로 발견되면 이 PR에 섞지 않고 별도 이슈로 분리하되, 데이터 손실·입력 오동작·호환성 파괴에 해당하면 병합은 계속 보류한다.
+
+## 7. 권장 작업 단위
+
+리뷰 가능성을 위해 다음 단위로 커밋을 분리한다.
+
+1. `merge: master 충돌 해결` — 최신 layout 안정성 보존
+2. `fix: canonical 홀드 source 판정 정정`
+3. `test: 물리 입력 중첩과 키 순서 회귀 테스트 보강`
+4. `docs: 키 이벤트 홀드 시간 계약 정정`
+
+커밋 제목의 conventional prefix와 기술 용어는 유지하고, 나머지는 프로젝트 규칙에 따라 한글로 작성한다.

--- a/docs/release-notes-multi-key.md
+++ b/docs/release-notes-multi-key.md
@@ -1,0 +1,48 @@
+# 멀티 키 매핑 릴리스 노트 초안
+
+상태: **초안**. 외부 노출 카피이므로 릴리스 시 유저 승인 후 실제 릴리스 노트에 반영한다.
+근거: 멀티 키 매핑 내부 계약 v4의 다운그레이드 안내·플러그인 체인지로그 요구 (내부 작업 문서, 저장소 미추적).
+
+## 한국어 초안
+
+### 새 기능
+
+- 한 슬롯에 여러 키를 매핑할 수 있습니다. 개별(any)은 멤버 키 중 하나만 눌러도, 동시(all)는 전부 함께 눌러야 반응합니다.
+
+### 이전 버전으로 되돌릴 때 (다운그레이드 안내)
+
+- 멀티 키 슬롯이 저장된 상태에서 이전 버전을 실행하면 해당 슬롯은 빈 슬롯으로 표시됩니다 (키 배치와 순서는 유지).
+- 이전 버전이 처음 실행될 때 원본 설정 파일이 `store.json.bak`으로 자동 보존됩니다 (앱 데이터 폴더).
+- 복원 방법: 다시 새 버전으로 업데이트한 뒤, 앱을 종료한 상태에서 `store.json.bak`을 `store.json`으로 되돌리면 멀티 키 슬롯이 복구됩니다. 이후 다른 복구가 겹쳐 `store.json.bak`이 갱신된 경우에는 최초 원본을 보존하는 `store.json.pre-migration.bak`을 사용하세요.
+
+### OBS 오버레이 사용자
+
+- 업데이트 후 이미 열려 있던 OBS 브라우저 소스는 연결이 거부됩니다 (프로토콜 v2). 브라우저 소스를 새로고침하거나 OBS를 재시작하면 정상 동작합니다.
+
+### 플러그인 개발자
+
+- `dmn.keys.get()` 등 키 매핑을 읽는 모든 표면(`app.bootstrap`, `editor.get`, 프리셋 스냅샷 포함)이 이제 문자열 또는 멀티 키 객체(`KeySlot` union)를 전달합니다. 슬롯을 순수 문자열로 가정하는 플러그인은 업데이트가 필요합니다.
+- 현재 매핑에 멀티 키 슬롯이 있으면 `keys` 쓰기에 `multiKey: true` 선언이 필요합니다. 선언 없는 쓰기는 `MULTI_KEY_UNSUPPORTED`로 거절됩니다 (사용자 설정 보호).
+- 이벤트·카운터 표면은 canonical 식별자(단일 키는 그대로, all은 `+` 조인, any는 `|` 조인)를 사용합니다. 자세한 내용은 Keys API 문서의 "canonical 슬롯 식별자" 절 참고.
+
+## English draft
+
+### New
+
+- A single slot can now bind multiple keys. An `any` slot activates when any member key is pressed; an `all` slot activates while all member keys are held together.
+
+### Rolling back to an older version (downgrade notes)
+
+- If multi-key slots are saved and you run an older version, those slots appear as unassigned (key layout and order are preserved).
+- On its first launch the older version automatically preserves your original settings file as `store.json.bak` in the app data folder.
+- To restore: update back to the new version, quit the app, and replace `store.json` with `store.json.bak`. Your multi-key slots will be recovered. If a later repair has since refreshed `store.json.bak`, use `store.json.pre-migration.bak`, which preserves the first original.
+
+### OBS overlay users
+
+- Browser sources that were already open before the update are rejected by the new app (protocol v2). Refresh the browser source or restart OBS to reconnect.
+
+### Plugin developers
+
+- Every surface that reads key mappings (`dmn.keys.get()`, `app.bootstrap`, `editor.get`, preset snapshots) now carries the `KeySlot` union (`string | MultiKeySlot`). Plugins that assume plain string slots need an update.
+- Writing `keys` while the current mappings contain a multi-key slot requires declaring `multiKey: true`; undeclared writes are rejected with `MULTI_KEY_UNSUPPORTED` to protect user configurations.
+- Event and counter surfaces use canonical identifiers (single keys unchanged, `all` joined with `+`, `any` joined with `|`). See the "Canonical slot identifiers" section of the Keys API docs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@codemirror/view": "^6.39.12",
         "@floating-ui/react": "^0.27.16",
         "@lezer/highlight": "^1.2.3",
-        "@tauri-apps/api": "~2.9.0",
+        "@tauri-apps/api": "~2.11.0",
         "htm": "^3.1.1",
         "lenis": "^1.3.15",
         "ogl": "^1.0.11",
@@ -167,7 +167,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -632,7 +631,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -681,7 +679,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2195,7 +2192,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -2266,9 +2262,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.1.tgz",
-      "integrity": "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+      "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -2575,7 +2571,6 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2586,7 +2581,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2636,7 +2630,6 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -3006,7 +2999,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3344,7 +3336,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3903,7 +3894,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4790,7 +4780,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4831,7 +4820,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -5600,7 +5588,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -5807,7 +5794,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5817,7 +5803,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5970,7 +5955,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6667,7 +6651,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6764,7 +6747,6 @@
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -6782,7 +6764,6 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -6873,7 +6854,6 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -7221,7 +7201,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@codemirror/view": "^6.39.12",
     "@floating-ui/react": "^0.27.16",
     "@lezer/highlight": "^1.2.3",
-    "@tauri-apps/api": "~2.9.0",
+    "@tauri-apps/api": "~2.11.0",
     "htm": "^3.1.1",
     "lenis": "^1.3.15",
     "ogl": "^1.0.11",

--- a/src-tauri/src/commands/keys/keys.rs
+++ b/src-tauri/src/commands/keys/keys.rs
@@ -54,7 +54,7 @@ fn zeroed_counters(keys: &KeyMappings) -> KeyCounters {
         .map(|(mode, mode_keys)| {
             (
                 mode.clone(),
-                mode_keys.iter().map(|key| (key.clone(), 0)).collect(),
+                mode_keys.iter().map(|key| (key.canonical(), 0)).collect(),
             )
         })
         .collect()
@@ -151,7 +151,10 @@ fn reset_mode_data(store: &mut AppStoreData, mode: &str, kind: ModeResetKind) {
     let mode_keys = store.keys.get(mode).cloned().unwrap_or_default();
     store.key_counters.insert(
         mode.to_string(),
-        mode_keys.into_iter().map(|key| (key, 0)).collect(),
+        mode_keys
+            .into_iter()
+            .map(|key| (key.canonical(), 0))
+            .collect(),
     );
 }
 
@@ -943,8 +946,8 @@ mod tests {
         defaults::{default_keys, default_positions},
         keyboard::KeyboardManager,
         models::{
-            AppStoreData, CustomTab, GraphPosition, GraphStatType, GraphType, KnobPosition,
-            LayerGroupDef, StatPosition, StatType, TabCss, TabNoteSettings,
+            AppStoreData, CustomTab, GraphPosition, GraphStatType, GraphType, KeySlot,
+            KnobPosition, LayerGroupDef, StatPosition, StatType, TabCss, TabNoteSettings,
         },
     };
     use std::cell::Cell;
@@ -974,7 +977,7 @@ mod tests {
         };
         store
             .keys
-            .insert(TARGET_TAB.to_string(), vec!["KeyD".to_string()]);
+            .insert(TARGET_TAB.to_string(), vec![KeySlot::from("KeyD")]);
         store
             .key_positions
             .insert(TARGET_TAB.to_string(), vec![position.clone()]);
@@ -1103,7 +1106,7 @@ mod tests {
         };
         store
             .keys
-            .insert("ghost-mode".to_string(), vec!["KeyA".to_string()]);
+            .insert("ghost-mode".to_string(), vec![KeySlot::from("KeyA")]);
         let keyboard = KeyboardManager::new(store.keys.clone(), "8key");
         let commit_calls = Cell::new(0);
         let emit_calls = Cell::new(0);

--- a/src-tauri/src/commands/keys/sound.rs
+++ b/src-tauri/src/commands/keys/sound.rs
@@ -1293,8 +1293,7 @@ mod tests {
         let mut data = AppStoreData::default();
         data.sound_library
             .insert(path_key.to_string(), Default::default());
-        data.keys
-            .insert("4key".to_string(), vec!["KeyA".to_string()]);
+        data.keys.insert("4key".to_string(), vec!["KeyA".into()]);
         data.key_positions
             .insert("4key".to_string(), vec![position_with_sound(path_key)]);
         data.stat_positions.insert(

--- a/src-tauri/src/commands/media/counter_animation.rs
+++ b/src-tauri/src/commands/media/counter_animation.rs
@@ -409,9 +409,7 @@ mod tests {
 
     fn counter_store(key_bound: bool, stat_bound: bool, graph_bound: bool) -> AppStoreData {
         let mut store = AppStoreData::default();
-        store
-            .keys
-            .insert(MODE.to_string(), vec!["KeyA".to_string()]);
+        store.keys.insert(MODE.to_string(), vec!["KeyA".into()]);
         store
             .key_positions
             .insert(MODE.to_string(), vec![position(key_bound)]);

--- a/src-tauri/src/commands/preset/load.rs
+++ b/src-tauri/src/commands/preset/load.rs
@@ -1672,7 +1672,10 @@ mod tests {
 }"#;
         std::fs::write(&source_path, valid_source).unwrap();
         let parsed = read_preset_file(&source_path).unwrap();
-        assert_eq!(parsed.keys.as_ref().unwrap()["custom"], ["Q"]);
+        assert_eq!(
+            parsed.keys.as_ref().unwrap()["custom"],
+            [KeySlot::from("Q")]
+        );
         assert_eq!(parsed.key_positions.as_ref().unwrap()["custom"][0].dx, 12.5);
         assert_eq!(
             parsed.custom_js.as_ref().unwrap().plugins[0].id,
@@ -2255,7 +2258,7 @@ mod tests {
         assert_eq!(store.keys["5key"], untouched_keys);
         assert_eq!(store.key_positions["5key"], untouched_positions);
         assert_eq!(store.key_positions["4key"][0].dx, 777.0);
-        assert_eq!(store.keys["4key"][0], "Imported");
+        assert_eq!(store.keys["4key"][0], KeySlot::from("Imported"));
         assert_eq!(store.keys["4key"].len(), store.key_positions["4key"].len());
     }
 

--- a/src-tauri/src/commands/preset/load.rs
+++ b/src-tauri/src/commands/preset/load.rs
@@ -18,11 +18,11 @@ use crate::{
     defaults::{default_keys, default_positions},
     errors::{CmdResult, CommandError},
     models::{
-        AppStoreData, CustomCss, CustomCssPatch, CustomJs, CustomJsPatch, EditorCommitOrigin,
-        EditorField, FontSettings, FontType, GradientSpec, GraphPositions, KeyMappings,
-        KeyPosition, KeyPositions, KnobPositions, LayerGroups, NoteSettings, NoteSettingsPatch,
-        SettingsPatchInput, StatPositions, TabCss, TabCssOverrides, TabNoteSettings,
-        SHADOW_BLUR_MAX, SHADOW_BLUR_MIN, SHADOW_OFFSET_MAX, SHADOW_OFFSET_MIN,
+        normalize_key_mappings, AppStoreData, CustomCss, CustomCssPatch, CustomJs, CustomJsPatch,
+        EditorCommitOrigin, EditorField, FontSettings, FontType, GradientSpec, GraphPositions,
+        KeyMappings, KeyPosition, KeyPositions, KeySlot, KnobPositions, LayerGroups, NoteSettings,
+        NoteSettingsPatch, SettingsPatchInput, StatPositions, TabCss, TabCssOverrides,
+        TabNoteSettings, SHADOW_BLUR_MAX, SHADOW_BLUR_MIN, SHADOW_OFFSET_MAX, SHADOW_OFFSET_MIN,
     },
     services::settings::apply_patch_to_store,
     state::AppState,
@@ -235,6 +235,7 @@ pub fn preset_load(
     let resolved_settings = resolve_full_preset_settings(&mut preset, &current);
 
     let mut keys = preset.keys.unwrap_or_else(|| default_keys().clone());
+    normalize_key_mappings(&mut keys);
     let mut positions = preset
         .key_positions
         .unwrap_or_else(|| default_positions().clone());
@@ -497,7 +498,8 @@ pub fn preset_load_tab(
         .store
         .with_state(|store| (store.selected_key_type.clone(), store.font_settings.clone()));
 
-    let imported_keys = keys.unwrap_or_default();
+    let mut imported_keys = keys.unwrap_or_default();
+    normalize_key_mappings(&mut imported_keys);
     let source_tab_id = choose_tab_preset_source_tab(
         &imported_keys,
         selected_key_type.as_deref(),
@@ -867,9 +869,9 @@ fn choose_tab_preset_source_tab(
     Err(CommandError::msg("tab-preset-ambiguous-source"))
 }
 
-fn align_imported_key_pair(keys: &mut Vec<String>, positions: &mut Vec<KeyPosition>) {
+fn align_imported_key_pair(keys: &mut Vec<KeySlot>, positions: &mut Vec<KeyPosition>) {
     if keys.len() < positions.len() {
-        keys.resize(positions.len(), String::new());
+        keys.resize(positions.len(), KeySlot::default());
     } else if positions.len() < keys.len() {
         positions.resize(keys.len(), KeyPosition::default());
     }
@@ -891,7 +893,7 @@ fn align_imported_key_collections(keys: &mut KeyMappings, positions: &mut KeyPos
 fn merge_tab_preset_key_pair(
     store: &mut AppStoreData,
     current_tab_id: &str,
-    mut keys: Vec<String>,
+    mut keys: Vec<KeySlot>,
     imported_positions: Option<Vec<KeyPosition>>,
 ) {
     let mut positions = imported_positions.unwrap_or_else(|| {
@@ -2039,6 +2041,39 @@ mod tests {
     }
 
     #[test]
+    fn legacy_and_multi_key_preset_slots_share_the_normalization_path() {
+        let preset: PresetFile = serde_json::from_value(serde_json::json!({
+            "keys": {
+                "4key": [
+                    "Q",
+                    { "keys": ["A", "B"], "match": "any" },
+                    { "keys": ["Z"], "match": "all" }
+                ]
+            }
+        }))
+        .unwrap();
+        let keys = preset.keys.unwrap();
+
+        assert_eq!(keys["4key"][0], KeySlot::Single("Q".to_string()));
+        assert_eq!(
+            keys["4key"][1],
+            KeySlot::Multi {
+                keys: vec!["A".to_string(), "B".to_string()],
+                match_mode: crate::models::SlotMatch::Any,
+            }
+        );
+        assert_eq!(keys["4key"][2], KeySlot::Single("Z".to_string()));
+        assert_eq!(
+            serde_json::to_value(keys).unwrap()["4key"],
+            serde_json::json!([
+                "Q",
+                { "keys": ["A", "B"], "match": "any" },
+                "Z"
+            ])
+        );
+    }
+
+    #[test]
     fn tauri_161_literal_imports_its_plugin_list_exactly() {
         let mut current = AppStoreData::default();
         current.custom_js.plugins.push(JsPlugin {
@@ -2139,8 +2174,8 @@ mod tests {
     #[test]
     fn historical_full_preset_without_groups_starts_each_imported_mode_ungrouped() {
         let keys = KeyMappings::from([
-            ("4key".to_string(), vec!["A".to_string()]),
-            ("custom-old".to_string(), vec!["B".to_string()]),
+            ("4key".to_string(), vec![KeySlot::from("A")]),
+            ("custom-old".to_string(), vec![KeySlot::from("B")]),
         ]);
 
         let groups = resolve_full_preset_layer_groups(None, &keys);
@@ -2215,7 +2250,7 @@ mod tests {
         let untouched_keys = store.keys["5key"].clone();
         let untouched_positions = store.key_positions["5key"].clone();
 
-        merge_tab_preset_key_pair(&mut store, "4key", vec!["Imported".to_string()], None);
+        merge_tab_preset_key_pair(&mut store, "4key", vec![KeySlot::from("Imported")], None);
 
         assert_eq!(store.keys["5key"], untouched_keys);
         assert_eq!(store.key_positions["5key"], untouched_positions);
@@ -2227,8 +2262,8 @@ mod tests {
     #[test]
     fn preset_import_alignment_repairs_each_mode_without_dropping_values() {
         let mut keys = KeyMappings::from([
-            ("keys-only".to_string(), vec!["A".to_string()]),
-            ("positions-long".to_string(), vec!["B".to_string()]),
+            ("keys-only".to_string(), vec![KeySlot::from("A")]),
+            ("positions-long".to_string(), vec![KeySlot::from("B")]),
         ]);
         let mut positions = KeyPositions::from([
             (
@@ -2246,11 +2281,14 @@ mod tests {
 
         align_imported_key_collections(&mut keys, &mut positions);
 
-        assert_eq!(keys["keys-only"], vec!["A".to_string()]);
+        assert_eq!(keys["keys-only"], vec![KeySlot::from("A")]);
         assert_eq!(positions["keys-only"], vec![KeyPosition::default()]);
-        assert_eq!(keys["positions-only"], vec![String::new()]);
+        assert_eq!(keys["positions-only"], vec![KeySlot::default()]);
         assert_eq!(positions["positions-only"][0].dx, 123.0);
-        assert_eq!(keys["positions-long"], vec!["B".to_string(), String::new()]);
+        assert_eq!(
+            keys["positions-long"],
+            vec![KeySlot::from("B"), KeySlot::default()]
+        );
         assert_eq!(
             keys["positions-long"].len(),
             positions["positions-long"].len()

--- a/src-tauri/src/commands/preset/mod.rs
+++ b/src-tauri/src/commands/preset/mod.rs
@@ -243,7 +243,7 @@ mod tests {
     // file URL 경로 테스트가 유닉스 전용이라 Windows에선 미사용 경고 방지
     #[cfg(not(target_os = "windows"))]
     use super::local_source_path_from_image_ref;
-    use crate::models::{KeyCounterColor, NoteColor};
+    use crate::models::{KeyCounterColor, KeySlot, NoteColor};
     use serde::Deserialize;
     use serde_json::json;
 
@@ -383,7 +383,10 @@ mod tests {
         }))
         .expect("1.3.0 preset must deserialize");
 
-        assert_eq!(tauri_130.keys.as_ref().unwrap()["custom-130"], ["Q"]);
+        assert_eq!(
+            tauri_130.keys.as_ref().unwrap()["custom-130"],
+            vec![KeySlot::from("Q")]
+        );
         let old_position = &tauri_130.key_positions.as_ref().unwrap()["custom-130"][0];
         assert_eq!(old_position.dx, 12.5);
         assert_eq!(old_position.dy, -3.0);
@@ -437,7 +440,10 @@ mod tests {
         for (version, fixture) in transition_fixtures {
             let preset: PresetFile = serde_json::from_value(fixture)
                 .unwrap_or_else(|error| panic!("{version} preset must deserialize: {error}"));
-            assert_eq!(preset.keys.as_ref().unwrap()["4key"], vec!["Q"]);
+            assert_eq!(
+                preset.keys.as_ref().unwrap()["4key"],
+                vec![KeySlot::from("Q")]
+            );
         }
 
         let tauri_161: PresetFile = serde_json::from_value(json!({
@@ -530,7 +536,10 @@ mod tests {
         }))
         .expect("1.6.1 preset must deserialize");
 
-        assert_eq!(tauri_161.keys.as_ref().unwrap()["custom-161"], ["W"]);
+        assert_eq!(
+            tauri_161.keys.as_ref().unwrap()["custom-161"],
+            [KeySlot::from("W")]
+        );
         let position_161 = &tauri_161.key_positions.as_ref().unwrap()["custom-161"][0];
         assert_eq!(position_161.group_id.as_deref(), Some("historic-group"));
         assert_eq!(

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -9,6 +9,7 @@ pub enum EditorCommitErrorCode {
     TooManyGestureIds,
     InvalidGestureId,
     PairedUpdateRequired,
+    MultiKeyUnsupported,
     MutationIdReused,
     HistoryInProgress,
     HistoryEpochConflict,
@@ -101,6 +102,15 @@ impl EditorCommitError {
                 field: Some(field),
                 ..EditorCommitErrorDetails::default()
             }),
+            retryable: false,
+        }
+    }
+
+    pub fn multi_key_unsupported() -> Self {
+        Self {
+            error_code: EditorCommitErrorCode::MultiKeyUnsupported,
+            message: "multi-key mappings require an explicit multiKey capability".to_string(),
+            details: None,
             retryable: false,
         }
     }

--- a/src-tauri/src/ipc.rs
+++ b/src-tauri/src/ipc.rs
@@ -36,6 +36,9 @@ pub struct HookMessage {
     pub state: HookKeyState,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
+    pub physical_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub vk_code: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -162,6 +165,7 @@ mod tests {
 
         assert_eq!(message.hold_duration_ms, None);
         assert_eq!(message.input_ts_ms, None);
+        assert_eq!(message.physical_id, None);
     }
 
     #[test]
@@ -170,6 +174,7 @@ mod tests {
             device: InputDeviceKind::Keyboard,
             labels: vec!["A".to_string()],
             state: HookKeyState::Down,
+            physical_id: None,
             vk_code: None,
             scan_code: None,
             flags: None,
@@ -188,6 +193,7 @@ mod tests {
             device: InputDeviceKind::Keyboard,
             labels: vec!["A".to_string()],
             state: HookKeyState::Up,
+            physical_id: Some("keyboard:test".to_string()),
             vk_code: None,
             scan_code: None,
             flags: None,
@@ -198,5 +204,6 @@ mod tests {
         let value = serde_json::to_value(message).unwrap();
         assert_eq!(value["hold_duration_ms"], 12.5);
         assert_eq!(value["input_ts_ms"], 1_500.25);
+        assert_eq!(value["physical_id"], "keyboard:test");
     }
 }

--- a/src-tauri/src/keyboard/daemon/macos.rs
+++ b/src-tauri/src/keyboard/daemon/macos.rs
@@ -9,6 +9,15 @@ enum MacPhysicalInputId {
     MouseButton(rdev::Button),
 }
 
+impl MacPhysicalInputId {
+    fn opaque(self) -> String {
+        match self {
+            Self::Keyboard(key) => format!("macos:keyboard:{key:?}"),
+            Self::MouseButton(button) => format!("macos:mouse:{button:?}"),
+        }
+    }
+}
+
 fn mac_keyboard_physical_id(key: rdev::Key) -> MacPhysicalInputId {
     MacPhysicalInputId::Keyboard(key)
 }
@@ -382,13 +391,14 @@ fn run_macos_listen(output: super::OutputSender) -> Result<()> {
                 if labels.is_empty() {
                     return;
                 }
-                let labels =
-                    hold_tracker.press(mac_keyboard_physical_id(key), captured.instant, labels);
+                let physical_id = mac_keyboard_physical_id(key);
+                let labels = hold_tracker.press(physical_id, captured.instant, labels);
 
                 let message = HookMessage {
                     device: InputDeviceKind::Keyboard,
                     labels,
                     state: HookKeyState::Down,
+                    physical_id: Some(physical_id.opaque()),
                     vk_code: None,
                     scan_code: None,
                     flags: None,
@@ -401,8 +411,9 @@ fn run_macos_listen(output: super::OutputSender) -> Result<()> {
                 let key_name = format!("{:?}", key).to_ascii_lowercase();
                 let _ = hotkey_state.update(&key_name, false);
 
+                let physical_id = mac_keyboard_physical_id(key);
                 let release = hold_tracker.release(
-                    mac_keyboard_physical_id(key),
+                    physical_id,
                     captured.instant,
                     mac_key_labels(key, event.name.as_deref()),
                 );
@@ -414,6 +425,7 @@ fn run_macos_listen(output: super::OutputSender) -> Result<()> {
                     device: InputDeviceKind::Keyboard,
                     labels: release.labels,
                     state: HookKeyState::Up,
+                    physical_id: Some(physical_id.opaque()),
                     vk_code: None,
                     scan_code: None,
                     flags: None,
@@ -424,15 +436,13 @@ fn run_macos_listen(output: super::OutputSender) -> Result<()> {
             }
             EventType::ButtonPress(button) => {
                 if let Some(label) = mac_mouse_label(button) {
-                    let labels = hold_tracker.press(
-                        mac_mouse_physical_id(button),
-                        captured.instant,
-                        vec![label],
-                    );
+                    let physical_id = mac_mouse_physical_id(button);
+                    let labels = hold_tracker.press(physical_id, captured.instant, vec![label]);
                     output.send(super::DaemonOutput::Hook(HookMessage {
                         device: InputDeviceKind::Mouse,
                         labels,
                         state: HookKeyState::Down,
+                        physical_id: Some(physical_id.opaque()),
                         vk_code: None,
                         scan_code: None,
                         flags: None,
@@ -443,15 +453,13 @@ fn run_macos_listen(output: super::OutputSender) -> Result<()> {
             }
             EventType::ButtonRelease(button) => {
                 if let Some(label) = mac_mouse_label(button) {
-                    let release = hold_tracker.release(
-                        mac_mouse_physical_id(button),
-                        captured.instant,
-                        vec![label],
-                    );
+                    let physical_id = mac_mouse_physical_id(button);
+                    let release = hold_tracker.release(physical_id, captured.instant, vec![label]);
                     output.send(super::DaemonOutput::Hook(HookMessage {
                         device: InputDeviceKind::Mouse,
                         labels: release.labels,
                         state: HookKeyState::Up,
+                        physical_id: Some(physical_id.opaque()),
                         vk_code: None,
                         scan_code: None,
                         flags: None,
@@ -503,6 +511,18 @@ mod tests {
         assert_ne!(
             mac_mouse_physical_id(rdev::Button::Left),
             mac_mouse_physical_id(rdev::Button::Right)
+        );
+        assert_eq!(
+            mac_mouse_physical_id(rdev::Button::Left).opaque(),
+            "macos:mouse:Left"
+        );
+    }
+
+    #[test]
+    fn mac_keyboard_opaque_id_preserves_rdev_variant() {
+        assert_eq!(
+            mac_keyboard_physical_id(rdev::Key::Unknown(42)).opaque(),
+            "macos:keyboard:Unknown(42)"
         );
     }
 }

--- a/src-tauri/src/keyboard/daemon/mod.rs
+++ b/src-tauri/src/keyboard/daemon/mod.rs
@@ -197,6 +197,22 @@ pub(super) enum WindowsKeyboardPhysicalId {
 }
 
 #[cfg(any(target_os = "windows", test))]
+impl WindowsKeyboardPhysicalId {
+    pub(super) fn opaque(self) -> String {
+        match self {
+            Self::ScanCode {
+                device,
+                scan_code,
+                extension_flags,
+            } => format!("windows:keyboard:scan:{device}:{scan_code}:{extension_flags}"),
+            Self::VirtualKey { device, vk_code } => {
+                format!("windows:keyboard:vk:{device}:{vk_code}")
+            }
+        }
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
 pub(super) fn windows_keyboard_physical_id(
     device: usize,
     scan_code: u32,
@@ -216,10 +232,37 @@ pub(super) fn windows_keyboard_physical_id(
 
 #[cfg(any(target_os = "windows", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum WindowsPhysicalInputId {
+    Keyboard(WindowsKeyboardPhysicalId),
+    MouseButton(u8),
+}
+
+#[cfg(any(target_os = "windows", test))]
+impl WindowsPhysicalInputId {
+    pub(super) fn opaque(self) -> String {
+        match self {
+            Self::Keyboard(id) => id.opaque(),
+            Self::MouseButton(button) => format!("windows:mouse:button:{button}"),
+        }
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(super) struct WindowsHidPhysicalId {
     device: usize,
     usage_page: u16,
     usage: u16,
+}
+
+#[cfg(any(target_os = "windows", test))]
+impl WindowsHidPhysicalId {
+    pub(super) fn opaque(self) -> String {
+        format!(
+            "windows:hid:{}:{}:{}",
+            self.device, self.usage_page, self.usage
+        )
+    }
 }
 
 #[cfg(any(target_os = "windows", test))]
@@ -265,6 +308,7 @@ mod tests {
     use super::{
         start_output_writer, wait_for_parent_disconnect, windows_hid_physical_id,
         windows_keyboard_physical_id, DaemonOutput, HoldTracker, WindowsKeyboardPhysicalId,
+        WindowsPhysicalInputId,
     };
     use crate::ipc::{DaemonCommand, HidAxisMessage, HookKeyState, HookMessage, InputDeviceKind};
 
@@ -317,6 +361,7 @@ mod tests {
             device: InputDeviceKind::Keyboard,
             labels: vec!["A".to_string()],
             state: HookKeyState::Down,
+            physical_id: Some("windows:keyboard:scan:1:30:0".to_string()),
             vk_code: None,
             scan_code: None,
             flags: None,
@@ -340,6 +385,7 @@ mod tests {
 
         assert_eq!(lines.len(), 3);
         assert_eq!(lines[0]["labels"], serde_json::json!(["A"]));
+        assert_eq!(lines[0]["physical_id"], "windows:keyboard:scan:1:30:0");
         assert_eq!(lines[1]["type"], "toggle_overlay");
         assert_eq!(lines[2]["axis_id"], "axis");
     }
@@ -418,13 +464,41 @@ mod tests {
                 vk_code: 0xA2,
             }
         );
+        assert_eq!(base.opaque(), "windows:keyboard:scan:7:29:0".to_string());
+        assert_eq!(
+            extended.opaque(),
+            "windows:keyboard:scan:7:29:1".to_string()
+        );
+        assert_eq!(fallback.opaque(), "windows:keyboard:vk:7:162".to_string());
+    }
+
+    #[test]
+    fn windows_main_and_numpad_enter_and_mouse_have_distinct_opaque_ids() {
+        let main_enter = WindowsPhysicalInputId::Keyboard(windows_keyboard_physical_id(
+            1, 28, false, false, 0x0d,
+        ));
+        let numpad_enter = WindowsPhysicalInputId::Keyboard(windows_keyboard_physical_id(
+            1, 28, true, false, 0x0d,
+        ));
+        let mouse = WindowsPhysicalInputId::MouseButton(1);
+
+        assert_ne!(main_enter.opaque(), numpad_enter.opaque());
+        assert_eq!(mouse.opaque(), "windows:mouse:button:1");
     }
 
     #[test]
     fn windows_physical_ids_include_device_handle() {
         assert_ne!(
+            windows_keyboard_physical_id(1, 30, false, false, 0x41).opaque(),
+            windows_keyboard_physical_id(2, 30, false, false, 0x41).opaque()
+        );
+        assert_ne!(
             windows_keyboard_physical_id(1, 30, false, false, 0x41),
             windows_keyboard_physical_id(2, 30, false, false, 0x41)
+        );
+        assert_ne!(
+            windows_hid_physical_id(1, 9, 1).opaque(),
+            windows_hid_physical_id(2, 9, 1).opaque()
         );
         assert_ne!(
             windows_hid_physical_id(1, 9, 1),
@@ -437,6 +511,10 @@ mod tests {
         assert_ne!(
             windows_hid_physical_id(1, 9, 1),
             windows_hid_physical_id(1, 9, 2)
+        );
+        assert_eq!(
+            windows_hid_physical_id(1, 9, 1).opaque(),
+            "windows:hid:1:9:1"
         );
     }
 }

--- a/src-tauri/src/keyboard/daemon/windows.rs
+++ b/src-tauri/src/keyboard/daemon/windows.rs
@@ -7,11 +7,7 @@ use super::super::labels::{
 use crate::ipc::{pipe_client_connect, DaemonCommand, HookKeyState, HookMessage, InputDeviceKind};
 use crate::models::ShortcutBinding;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum WindowsPhysicalInputId {
-    Keyboard(super::WindowsKeyboardPhysicalId),
-    MouseButton(u8),
-}
+use super::WindowsPhysicalInputId;
 
 /// 글로벌 단축키 상태 추적기
 struct HotkeyState {
@@ -496,6 +492,7 @@ pub(super) fn run_raw_input() -> Result<()> {
                                 is_e1,
                                 vk_norm,
                             ));
+                        let opaque_physical_id = physical_id.opaque();
                         let current_labels = build_key_labels(&event);
                         let (labels, hold_duration_ms) = match state {
                             HookKeyState::Down => {
@@ -532,6 +529,7 @@ pub(super) fn run_raw_input() -> Result<()> {
                             device: InputDeviceKind::Keyboard,
                             labels,
                             state,
+                            physical_id: Some(opaque_physical_id),
                             vk_code: event.vk_code,
                             scan_code: event.scan_code,
                             flags: event.flags,
@@ -583,6 +581,7 @@ pub(super) fn run_raw_input() -> Result<()> {
 
                         for (button, label, state) in events {
                             let physical_id = WindowsPhysicalInputId::MouseButton(button);
+                            let opaque_physical_id = physical_id.opaque();
                             let current_labels = vec![label];
                             let (labels, hold_duration_ms) = match state {
                                 HookKeyState::Down => (
@@ -606,6 +605,7 @@ pub(super) fn run_raw_input() -> Result<()> {
                                 device: InputDeviceKind::Mouse,
                                 labels,
                                 state,
+                                physical_id: Some(opaque_physical_id),
                                 vk_code: None,
                                 scan_code: None,
                                 flags: None,

--- a/src-tauri/src/keyboard/daemon/windows_hid.rs
+++ b/src-tauri/src/keyboard/daemon/windows_hid.rs
@@ -215,28 +215,28 @@ impl HidProcessor {
 
         for (page, usage) in down {
             let label = button_label(vid, pid, page, usage);
-            let labels = self.hold_tracker.press(
-                super::windows_hid_physical_id(key, page, usage),
-                captured.instant,
-                vec![label],
-            );
+            let physical_id = super::windows_hid_physical_id(key, page, usage);
+            let labels = self
+                .hold_tracker
+                .press(physical_id, captured.instant, vec![label]);
             output.send(super::DaemonOutput::Hook(button_msg(
                 labels,
                 HookKeyState::Down,
+                physical_id.opaque(),
                 None,
                 captured.input_ts_ms,
             )));
         }
         for (page, usage) in up {
             let label = button_label(vid, pid, page, usage);
-            let release = self.hold_tracker.release(
-                super::windows_hid_physical_id(key, page, usage),
-                captured.instant,
-                vec![label],
-            );
+            let physical_id = super::windows_hid_physical_id(key, page, usage);
+            let release = self
+                .hold_tracker
+                .release(physical_id, captured.instant, vec![label]);
             output.send(super::DaemonOutput::Hook(button_msg(
                 release.labels,
                 HookKeyState::Up,
+                physical_id.opaque(),
                 release.hold_duration_ms,
                 captured.input_ts_ms,
             )));
@@ -272,6 +272,7 @@ fn axis_label(vid: u16, pid: u16, page: u16, usage: u16) -> String {
 fn button_msg(
     labels: Vec<String>,
     state: HookKeyState,
+    physical_id: String,
     hold_duration_ms: Option<f64>,
     input_ts_ms: Option<f64>,
 ) -> HookMessage {
@@ -279,6 +280,7 @@ fn button_msg(
         device: InputDeviceKind::Gamepad,
         labels,
         state,
+        physical_id: Some(physical_id),
         vk_code: None,
         scan_code: None,
         flags: None,

--- a/src-tauri/src/keyboard/manager.rs
+++ b/src-tauri/src/keyboard/manager.rs
@@ -23,6 +23,7 @@ pub struct SlotEvent {
     pub slot_indices: Vec<usize>,
     pub transition: Option<bool>,
     pub press: bool,
+    pub can_use_physical_hold_duration: bool,
 }
 
 // 키음 디스패치용: press 이벤트들의 기여 슬롯 인덱스를 병합
@@ -148,6 +149,7 @@ struct KeyboardState {
     held: HashMap<String, HeldEntry>,
     held_labels: HashMap<String, u32>,
     active: HashSet<String>,
+    activation_sources: HashMap<String, String>,
 }
 
 impl KeyboardState {
@@ -161,6 +163,8 @@ impl KeyboardState {
             }
         }
         self.active.clear();
+        // 재구성 시 canonical DOWN을 만든 물리 입력을 확정할 수 없으므로 source 폐기
+        self.activation_sources.clear();
         for slot in &self.compiled.slots {
             if slot.is_active(&self.held_labels) {
                 self.active
@@ -169,7 +173,12 @@ impl KeyboardState {
         }
     }
 
-    fn reevaluate_slots(&mut self, resolved: &str, is_down: bool) -> Vec<SlotEvent> {
+    fn reevaluate_slots(
+        &mut self,
+        resolved: &str,
+        physical_key: &str,
+        is_down: bool,
+    ) -> Vec<SlotEvent> {
         let Some(affected_indices) = self.compiled.member_to_slots.get(resolved).cloned() else {
             return Vec::new();
         };
@@ -211,6 +220,18 @@ impl KeyboardState {
                     .compiled
                     .canonical_is_active(&pending.canonical, &self.held_labels);
                 let transition = (was_active != is_active).then_some(is_active);
+                let can_use_physical_hold_duration = match transition {
+                    Some(true) => {
+                        self.activation_sources
+                            .insert(active_key.clone(), physical_key.to_string());
+                        false
+                    }
+                    Some(false) => self
+                        .activation_sources
+                        .remove(&active_key)
+                        .is_some_and(|source| source == physical_key),
+                    None => false,
+                };
                 if is_active {
                     self.active.insert(active_key);
                 } else {
@@ -221,6 +242,7 @@ impl KeyboardState {
                     slot_indices: pending.slot_indices,
                     transition,
                     press: is_down && (pending.press_on_fresh_down || transition == Some(true)),
+                    can_use_physical_hold_duration,
                 }
             })
             .collect()
@@ -245,6 +267,7 @@ impl KeyboardManager {
                 held: HashMap::new(),
                 held_labels: HashMap::new(),
                 active: HashSet::new(),
+                activation_sources: HashMap::new(),
             })),
         }
     }
@@ -310,7 +333,7 @@ impl KeyboardManager {
             }
             let resolved = state.compiled.resolve(&candidates);
             state.held.insert(
-                physical_key,
+                physical_key.clone(),
                 HeldEntry {
                     candidates,
                     resolved: resolved.clone(),
@@ -321,7 +344,7 @@ impl KeyboardManager {
             }
             let events = resolved
                 .as_deref()
-                .map(|label| state.reevaluate_slots(label, true))
+                .map(|label| state.reevaluate_slots(label, &physical_key, true))
                 .unwrap_or_default();
             return Some(MatchOutcome {
                 mode,
@@ -345,7 +368,7 @@ impl KeyboardManager {
         let events = held
             .resolved
             .as_deref()
-            .map(|label| state.reevaluate_slots(label, false))
+            .map(|label| state.reevaluate_slots(label, &physical_key, false))
             .unwrap_or_default();
         Some(MatchOutcome {
             mode,
@@ -390,6 +413,7 @@ impl KeyboardManager {
         state.held.clear();
         state.held_labels.clear();
         state.active.clear();
+        state.activation_sources.clear();
     }
 
     #[cfg(test)]
@@ -475,6 +499,19 @@ mod tests {
             slot_indices,
             transition,
             press,
+            can_use_physical_hold_duration: false,
+        }
+    }
+
+    fn event_with_physical_hold(
+        canonical: &str,
+        slot_indices: Vec<usize>,
+        transition: Option<bool>,
+        press: bool,
+    ) -> SlotEvent {
+        SlotEvent {
+            can_use_physical_hold_duration: true,
+            ..event(canonical, slot_indices, transition, press)
         }
     }
 
@@ -648,6 +685,124 @@ mod tests {
     }
 
     #[test]
+    fn overlapping_same_label_uses_physical_hold_only_when_transition_sources_match() {
+        let mappings = HashMap::from([("mode".to_string(), vec![single("A")])]);
+
+        let different_source = KeyboardManager::new(mappings.clone(), "mode");
+        let first_down = input(
+            &different_source,
+            Some("keyboard-1:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            first_down.events,
+            vec![event("A", vec![0], Some(true), true)]
+        );
+        assert_eq!(
+            input(
+                &different_source,
+                Some("keyboard-2:a"),
+                InputDeviceKind::Keyboard,
+                &["A"],
+                true,
+            )
+            .unwrap()
+            .events,
+            vec![event("A", vec![0], None, true)]
+        );
+        assert_eq!(
+            input(
+                &different_source,
+                Some("keyboard-1:a"),
+                InputDeviceKind::Keyboard,
+                &["A"],
+                false,
+            )
+            .unwrap()
+            .events,
+            vec![event("A", vec![0], None, false)]
+        );
+        assert_eq!(
+            input(
+                &different_source,
+                Some("keyboard-2:a"),
+                InputDeviceKind::Keyboard,
+                &["A"],
+                false,
+            )
+            .unwrap()
+            .events,
+            vec![event("A", vec![0], Some(false), false)]
+        );
+
+        let same_source = KeyboardManager::new(mappings, "mode");
+        input(
+            &same_source,
+            Some("keyboard-1:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        );
+        input(
+            &same_source,
+            Some("keyboard-2:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        );
+        input(
+            &same_source,
+            Some("keyboard-2:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            false,
+        );
+        assert_eq!(
+            input(
+                &same_source,
+                Some("keyboard-1:a"),
+                InputDeviceKind::Keyboard,
+                &["A"],
+                false,
+            )
+            .unwrap()
+            .events,
+            vec![event_with_physical_hold("A", vec![0], Some(false), false,)]
+        );
+    }
+
+    #[test]
+    fn mapping_rebuild_discards_unknown_activation_source() {
+        let mappings = HashMap::from([("mode".to_string(), vec![single("A")])]);
+        let manager = KeyboardManager::new(mappings.clone(), "mode");
+        input(
+            &manager,
+            Some("keyboard:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        );
+
+        manager.update_mappings(mappings);
+
+        assert_eq!(
+            input(
+                &manager,
+                Some("keyboard:a"),
+                InputDeviceKind::Keyboard,
+                &["A"],
+                false,
+            )
+            .unwrap()
+            .events,
+            vec![event("A", vec![0], Some(false), false)]
+        );
+    }
+
+    #[test]
     fn mode_switch_and_mapping_removal_do_not_lose_later_key_up() {
         let manager = KeyboardManager::new(
             HashMap::from([
@@ -726,18 +881,21 @@ mod tests {
                 slot_indices: vec![1],
                 transition: Some(true),
                 press: true,
+                can_use_physical_hold_duration: false,
             },
             SlotEvent {
                 canonical: "A|B".to_string(),
                 slot_indices: vec![0, 1],
                 transition: None,
                 press: true,
+                can_use_physical_hold_duration: false,
             },
             SlotEvent {
                 canonical: "C".to_string(),
                 slot_indices: vec![2],
                 transition: Some(false),
                 press: false,
+                can_use_physical_hold_duration: true,
             },
         ];
 
@@ -856,7 +1014,12 @@ mod tests {
         .unwrap();
         assert_eq!(
             up.events,
-            vec![event("RIGHT ALT", vec![0], Some(false), false)]
+            vec![event_with_physical_hold(
+                "RIGHT ALT",
+                vec![0],
+                Some(false),
+                false,
+            )]
         );
     }
 

--- a/src-tauri/src/keyboard/manager.rs
+++ b/src-tauri/src/keyboard/manager.rs
@@ -1,149 +1,380 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use parking_lot::RwLock;
 
-use crate::models::KeyMappings;
+use crate::{
+    ipc::InputDeviceKind,
+    models::{normalize_key_mappings, KeyMappings, KeySlot, SlotMatch},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MatchOutcome {
+    pub mode: String,
+    pub pressed_label: Option<String>,
+    pub events: Vec<SlotEvent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlotEvent {
+    pub canonical: String,
+    pub slot_indices: Vec<usize>,
+    pub transition: Option<bool>,
+    pub press: bool,
+}
+
+#[derive(Debug, Clone)]
+struct SlotSpec {
+    members: Vec<String>,
+    match_mode: SlotMatch,
+    canonical: String,
+}
+
+impl SlotSpec {
+    fn from_slot(slot: &KeySlot) -> Self {
+        match slot {
+            KeySlot::Single(key) => Self {
+                members: (!slot.is_unassigned())
+                    .then(|| key.clone())
+                    .into_iter()
+                    .collect(),
+                match_mode: SlotMatch::All,
+                canonical: slot.canonical(),
+            },
+            KeySlot::Multi { keys, match_mode } => Self {
+                members: keys.clone(),
+                match_mode: *match_mode,
+                canonical: slot.canonical(),
+            },
+        }
+    }
+
+    fn is_active(&self, held_labels: &HashMap<String, u32>) -> bool {
+        if self.members.is_empty() {
+            return false;
+        }
+        match self.match_mode {
+            SlotMatch::All => self
+                .members
+                .iter()
+                .all(|member| held_labels.get(member).is_some_and(|count| *count > 0)),
+            SlotMatch::Any => self
+                .members
+                .iter()
+                .any(|member| held_labels.get(member).is_some_and(|count| *count > 0)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct CompiledMode {
+    slots: Vec<SlotSpec>,
+    member_to_slots: HashMap<String, Vec<usize>>,
+    canonical_to_slots: HashMap<String, Vec<usize>>,
+}
+
+impl CompiledMode {
+    fn from_slots(slots: Option<&Vec<KeySlot>>) -> Self {
+        let slots = slots
+            .into_iter()
+            .flatten()
+            .map(SlotSpec::from_slot)
+            .collect::<Vec<_>>();
+        let mut member_to_slots: HashMap<String, Vec<usize>> = HashMap::new();
+        let mut canonical_to_slots: HashMap<String, Vec<usize>> = HashMap::new();
+        for (index, slot) in slots.iter().enumerate() {
+            for member in &slot.members {
+                member_to_slots
+                    .entry(member.clone())
+                    .or_default()
+                    .push(index);
+            }
+            canonical_to_slots
+                .entry(slot.canonical.clone())
+                .or_default()
+                .push(index);
+        }
+        Self {
+            slots,
+            member_to_slots,
+            canonical_to_slots,
+        }
+    }
+
+    fn resolve(&self, candidates: &[String]) -> Option<String> {
+        candidates
+            .iter()
+            .find(|candidate| self.member_to_slots.contains_key(*candidate))
+            .cloned()
+    }
+
+    fn canonical_is_active(&self, canonical: &str, held_labels: &HashMap<String, u32>) -> bool {
+        self.canonical_to_slots
+            .get(canonical)
+            .into_iter()
+            .flatten()
+            .any(|index| self.slots[*index].is_active(held_labels))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HeldEntry {
+    candidates: Vec<String>,
+    resolved: Option<String>,
+}
+
+#[derive(Debug)]
+struct KeyboardState {
+    mappings: KeyMappings,
+    current_mode: String,
+    compiled: CompiledMode,
+    held: HashMap<String, HeldEntry>,
+    held_labels: HashMap<String, u32>,
+    active: HashSet<String>,
+}
+
+impl KeyboardState {
+    fn rebuild_compiled_state(&mut self) {
+        self.compiled = CompiledMode::from_slots(self.mappings.get(&self.current_mode));
+        self.held_labels.clear();
+        for entry in self.held.values_mut() {
+            entry.resolved = self.compiled.resolve(&entry.candidates);
+            if let Some(label) = entry.resolved.as_ref() {
+                *self.held_labels.entry(label.clone()).or_default() += 1;
+            }
+        }
+        self.active.clear();
+        for slot in &self.compiled.slots {
+            if slot.is_active(&self.held_labels) {
+                self.active
+                    .insert(compose_active_key(&self.current_mode, &slot.canonical));
+            }
+        }
+    }
+
+    fn reevaluate_slots(&mut self, resolved: &str, is_down: bool) -> Vec<SlotEvent> {
+        let Some(affected_indices) = self.compiled.member_to_slots.get(resolved).cloned() else {
+            return Vec::new();
+        };
+
+        struct PendingEvent {
+            canonical: String,
+            slot_indices: Vec<usize>,
+            press_on_fresh_down: bool,
+        }
+
+        let mut pending = Vec::<PendingEvent>::new();
+        let mut event_by_canonical = HashMap::<String, usize>::new();
+        for index in affected_indices {
+            let slot = &self.compiled.slots[index];
+            let event_index = if let Some(index) = event_by_canonical.get(&slot.canonical) {
+                *index
+            } else {
+                let index = pending.len();
+                event_by_canonical.insert(slot.canonical.clone(), index);
+                pending.push(PendingEvent {
+                    canonical: slot.canonical.clone(),
+                    slot_indices: Vec::new(),
+                    press_on_fresh_down: false,
+                });
+                index
+            };
+            let event = &mut pending[event_index];
+            event.slot_indices.push(index);
+            event.press_on_fresh_down |=
+                slot.match_mode == SlotMatch::Any || slot.members.len() == 1;
+        }
+
+        pending
+            .into_iter()
+            .map(|pending| {
+                let active_key = compose_active_key(&self.current_mode, &pending.canonical);
+                let was_active = self.active.contains(&active_key);
+                let is_active = self
+                    .compiled
+                    .canonical_is_active(&pending.canonical, &self.held_labels);
+                let transition = (was_active != is_active).then_some(is_active);
+                if is_active {
+                    self.active.insert(active_key);
+                } else {
+                    self.active.remove(&active_key);
+                }
+                SlotEvent {
+                    canonical: pending.canonical,
+                    slot_indices: pending.slot_indices,
+                    transition,
+                    press: is_down && (pending.press_on_fresh_down || transition == Some(true)),
+                }
+            })
+            .collect()
+    }
+}
 
 #[derive(Clone)]
 pub struct KeyboardManager {
-    mappings: Arc<RwLock<KeyMappings>>,
-    current_mode: Arc<RwLock<String>>,
-    valid_keys: Arc<RwLock<HashSet<String>>>,
-    active_keys: Arc<RwLock<HashSet<String>>>,
+    state: Arc<RwLock<KeyboardState>>,
 }
 
 impl KeyboardManager {
-    pub fn new(initial: KeyMappings, default_mode: impl Into<String>) -> Self {
-        let mappings = Arc::new(RwLock::new(initial));
-        let current_mode = Arc::new(RwLock::new(default_mode.into()));
-        let manager = Self {
-            mappings,
-            current_mode,
-            valid_keys: Arc::new(RwLock::new(HashSet::new())),
-            active_keys: Arc::new(RwLock::new(HashSet::new())),
-        };
-        manager.rebuild_valid_keys();
-        manager
+    pub fn new(mut initial: KeyMappings, default_mode: impl Into<String>) -> Self {
+        normalize_key_mappings(&mut initial);
+        let current_mode = default_mode.into();
+        let compiled = CompiledMode::from_slots(initial.get(&current_mode));
+        Self {
+            state: Arc::new(RwLock::new(KeyboardState {
+                mappings: initial,
+                current_mode,
+                compiled,
+                held: HashMap::new(),
+                held_labels: HashMap::new(),
+                active: HashSet::new(),
+            })),
+        }
     }
 
     pub fn set_mode(&self, mode: impl Into<String>) -> bool {
         let mode = mode.into();
-        let mappings = self.mappings.read();
-        if !mappings.contains_key(&mode) {
+        let mut state = self.state.write();
+        if !state.mappings.contains_key(&mode) {
             return false;
         }
-
-        let next_valid_keys = Self::valid_keys_for_mode(&mappings, &mode);
-        let mut current_mode = self.current_mode.write();
-        let mut valid_keys = self.valid_keys.write();
-        let mut active_keys = self.active_keys.write();
-
-        Self::rekey_active_keys(&mut active_keys, &current_mode, &mode, &next_valid_keys);
-        *current_mode = mode;
-        *valid_keys = next_valid_keys;
+        state.current_mode = mode;
+        state.rebuild_compiled_state();
         true
     }
 
     pub fn update_mappings_and_set_mode(
         &self,
-        mappings: KeyMappings,
+        mut mappings: KeyMappings,
         mode: impl Into<String>,
     ) -> bool {
+        normalize_key_mappings(&mut mappings);
         let mode = mode.into();
         let mode_exists = mappings.contains_key(&mode);
-        let mut mappings_guard = self.mappings.write();
-        let mut current_mode = self.current_mode.write();
-        let next_mode = if mode_exists {
-            mode.as_str()
-        } else {
-            current_mode.as_str()
-        };
-        let next_valid_keys = Self::valid_keys_for_mode(&mappings, next_mode);
-        let mut valid_keys = self.valid_keys.write();
-        let mut active_keys = self.active_keys.write();
-
+        let mut state = self.state.write();
+        state.mappings = mappings;
         if mode_exists {
-            Self::rekey_active_keys(&mut active_keys, &current_mode, &mode, &next_valid_keys);
-            *current_mode = mode;
-        } else {
-            Self::retain_active_keys(&mut active_keys, &current_mode, &next_valid_keys);
+            state.current_mode = mode;
         }
-
-        *mappings_guard = mappings;
-        *valid_keys = next_valid_keys;
+        state.rebuild_compiled_state();
         mode_exists
     }
 
-    pub fn update_mappings(&self, mappings: KeyMappings) {
-        let mut mappings_guard = self.mappings.write();
-        let current_mode = self.current_mode.read();
-        let next_valid_keys = Self::valid_keys_for_mode(&mappings, &current_mode);
-        let mut valid_keys = self.valid_keys.write();
-        let mut active_keys = self.active_keys.write();
-
-        Self::retain_active_keys(&mut active_keys, &current_mode, &next_valid_keys);
-        *mappings_guard = mappings;
-        *valid_keys = next_valid_keys;
+    pub fn update_mappings(&self, mut mappings: KeyMappings) {
+        normalize_key_mappings(&mut mappings);
+        let mut state = self.state.write();
+        state.mappings = mappings;
+        state.rebuild_compiled_state();
     }
 
     pub fn current_mode(&self) -> String {
-        self.current_mode.read().clone()
+        self.state.read().current_mode.clone()
     }
 
     pub fn match_and_register<'a>(
         &self,
+        physical_id: Option<&str>,
+        device: InputDeviceKind,
         candidates: impl IntoIterator<Item = &'a str>,
         is_down: bool,
-    ) -> Option<(String, String, bool)> {
-        let current_mode = self.current_mode.read();
-        let valid_keys = self.valid_keys.read();
-        let key = candidates
+    ) -> Option<MatchOutcome> {
+        let candidates = candidates
             .into_iter()
-            .find(|candidate| valid_keys.contains(*candidate))?
-            .to_string();
-        let mut active_keys = self.active_keys.write();
-        let active_key = Self::compose_active_key(&current_mode, &key);
-        let changed = if is_down {
-            active_keys.insert(active_key)
-        } else {
-            active_keys.remove(&active_key)
-        };
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let physical_key =
+            physical_key(physical_id, device, candidates.first().map(String::as_str))?;
+        let mut state = self.state.write();
+        let mode = state.current_mode.clone();
 
-        Some((current_mode.clone(), key, changed))
+        if is_down {
+            if state.held.contains_key(&physical_key) {
+                return None;
+            }
+            let resolved = state.compiled.resolve(&candidates);
+            state.held.insert(
+                physical_key,
+                HeldEntry {
+                    candidates,
+                    resolved: resolved.clone(),
+                },
+            );
+            if let Some(label) = resolved.as_ref() {
+                *state.held_labels.entry(label.clone()).or_default() += 1;
+            }
+            let events = resolved
+                .as_deref()
+                .map(|label| state.reevaluate_slots(label, true))
+                .unwrap_or_default();
+            return Some(MatchOutcome {
+                mode,
+                pressed_label: resolved,
+                events,
+            });
+        }
+
+        let held = state.held.remove(&physical_key)?;
+        if let Some(label) = held.resolved.as_ref() {
+            let remove_label = if let Some(count) = state.held_labels.get_mut(label) {
+                *count = count.saturating_sub(1);
+                *count == 0
+            } else {
+                false
+            };
+            if remove_label {
+                state.held_labels.remove(label);
+            }
+        }
+        let events = held
+            .resolved
+            .as_deref()
+            .map(|label| state.reevaluate_slots(label, false))
+            .unwrap_or_default();
+        Some(MatchOutcome {
+            mode,
+            pressed_label: None,
+            events,
+        })
     }
 
     #[cfg(test)]
     pub fn register_key_down(&self, mode: &str, key: &str) -> bool {
-        let current_mode = self.current_mode.read();
-        if current_mode.as_str() != mode {
+        if self.current_mode() != mode {
             return false;
         }
-        let valid_keys = self.valid_keys.read();
-        if !valid_keys.contains(key) {
-            return false;
-        }
-        self.active_keys
-            .write()
-            .insert(Self::compose_active_key(&current_mode, key))
+        let physical_id = format!("test:key:{key}");
+        self.match_and_register(Some(&physical_id), InputDeviceKind::Keyboard, [key], true)
+            .is_some_and(|outcome| {
+                outcome.pressed_label.is_some()
+                    && outcome
+                        .events
+                        .iter()
+                        .any(|event| event.transition == Some(true))
+            })
     }
 
     #[cfg(test)]
     pub fn register_key_up(&self, mode: &str, key: &str) -> bool {
-        let current_mode = self.current_mode.read();
-        if current_mode.as_str() != mode {
+        if self.current_mode() != mode {
             return false;
         }
-        let valid_keys = self.valid_keys.read();
-        if !valid_keys.contains(key) {
-            return false;
-        }
-        self.active_keys
-            .write()
-            .remove(&Self::compose_active_key(&current_mode, key))
+        let physical_id = format!("test:key:{key}");
+        self.match_and_register(Some(&physical_id), InputDeviceKind::Keyboard, [key], false)
+            .is_some_and(|outcome| {
+                outcome
+                    .events
+                    .iter()
+                    .any(|event| event.transition == Some(false))
+            })
     }
 
     pub fn clear_active_keys(&self) {
-        self.active_keys.write().clear();
+        let mut state = self.state.write();
+        state.held.clear();
+        state.held_labels.clear();
+        state.active.clear();
     }
 
     #[cfg(test)]
@@ -152,207 +383,506 @@ impl KeyboardManager {
     }
 
     pub fn current_mode_and_pressed_keys(&self) -> (String, Vec<String>) {
-        let current_mode = self.current_mode.read();
-        let prefix = format!("{current_mode}::");
-        let active_keys = self.active_keys.read();
-        let mut keys: Vec<String> = active_keys
+        let state = self.state.read();
+        let prefix = format!("{}::", state.current_mode);
+        let mut keys = state
+            .active
             .iter()
             .filter_map(|entry| entry.strip_prefix(&prefix).map(str::to_string))
-            .collect();
+            .collect::<Vec<_>>();
         keys.sort();
-        (current_mode.clone(), keys)
+        (state.current_mode.clone(), keys)
     }
+}
 
-    fn rebuild_valid_keys(&self) {
-        let mappings = self.mappings.read();
-        let mode = self.current_mode.read();
-        *self.valid_keys.write() = Self::valid_keys_for_mode(&mappings, &mode);
+fn physical_key(
+    physical_id: Option<&str>,
+    device: InputDeviceKind,
+    primary_label: Option<&str>,
+) -> Option<String> {
+    if let Some(physical_id) = physical_id {
+        return Some(physical_id.to_string());
     }
+    let primary_label = primary_label?;
+    let device = match device {
+        InputDeviceKind::Keyboard => "keyboard",
+        InputDeviceKind::Mouse => "mouse",
+        InputDeviceKind::Gamepad => "gamepad",
+        InputDeviceKind::Unknown => "unknown",
+    };
+    Some(format!("fallback:{device}:{primary_label}"))
+}
 
-    fn valid_keys_for_mode(mappings: &KeyMappings, mode: &str) -> HashSet<String> {
-        mappings.get(mode).into_iter().flatten().cloned().collect()
-    }
-
-    fn retain_active_keys(
-        active_keys: &mut HashSet<String>,
-        mode: &str,
-        valid_keys: &HashSet<String>,
-    ) {
-        let prefix = format!("{mode}::");
-        active_keys.retain(|entry| {
-            entry
-                .strip_prefix(&prefix)
-                .is_some_and(|key| valid_keys.contains(key))
-        });
-    }
-
-    fn rekey_active_keys(
-        active_keys: &mut HashSet<String>,
-        current_mode: &str,
-        next_mode: &str,
-        next_valid_keys: &HashSet<String>,
-    ) {
-        let prefix = format!("{current_mode}::");
-        *active_keys = active_keys
-            .drain()
-            .filter_map(|entry| {
-                let key = entry.strip_prefix(&prefix)?;
-                next_valid_keys
-                    .contains(key)
-                    .then(|| Self::compose_active_key(next_mode, key))
-            })
-            .collect();
-    }
-
-    fn compose_active_key(mode: &str, key: &str) -> String {
-        format!("{mode}::{key}")
-    }
+fn compose_active_key(mode: &str, canonical: &str) -> String {
+    format!("{mode}::{canonical}")
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
-    use super::KeyboardManager;
+    use crate::{
+        ipc::InputDeviceKind,
+        models::{KeySlot, SlotMatch},
+    };
 
-    #[test]
-    fn pressed_keys_use_event_key_names_for_current_mode() {
-        let mappings = HashMap::from([
-            (
-                "4key".to_string(),
-                vec!["KeyD".to_string(), "KeyF".to_string()],
-            ),
-            (
-                "8key".to_string(),
-                vec!["KeyD".to_string(), "KeyF".to_string()],
-            ),
-        ]);
-        let manager = KeyboardManager::new(mappings, "4key");
+    use super::{KeyboardManager, MatchOutcome, SlotEvent};
 
-        assert!(manager.register_key_down("4key", "KeyF"));
-        assert!(manager.register_key_down("4key", "KeyD"));
-        assert_eq!(manager.pressed_keys(), vec!["KeyD", "KeyF"]);
+    fn single(key: &str) -> KeySlot {
+        KeySlot::Single(key.to_string())
+    }
 
-        assert!(manager.set_mode("8key"));
-        assert_eq!(manager.pressed_keys(), vec!["KeyD", "KeyF"]);
-        assert!(manager.register_key_up("8key", "KeyD"));
-        assert_eq!(manager.pressed_keys(), vec!["KeyF"]);
+    fn multi(keys: &[&str], match_mode: SlotMatch) -> KeySlot {
+        KeySlot::Multi {
+            keys: keys.iter().map(|key| (*key).to_string()).collect(),
+            match_mode,
+        }
+    }
+
+    fn input(
+        manager: &KeyboardManager,
+        physical_id: Option<&str>,
+        device: InputDeviceKind,
+        labels: &[&str],
+        is_down: bool,
+    ) -> Option<MatchOutcome> {
+        manager.match_and_register(physical_id, device, labels.iter().copied(), is_down)
+    }
+
+    fn event(
+        canonical: &str,
+        slot_indices: Vec<usize>,
+        transition: Option<bool>,
+        press: bool,
+    ) -> SlotEvent {
+        SlotEvent {
+            canonical: canonical.to_string(),
+            slot_indices,
+            transition,
+            press,
+        }
     }
 
     #[test]
-    fn mode_switch_retains_only_shared_active_keys() {
-        let mappings = HashMap::from([
-            (
-                "source".to_string(),
-                vec!["KeyD".to_string(), "KeyF".to_string()],
-            ),
-            (
-                "target".to_string(),
-                vec!["KeyF".to_string(), "KeyJ".to_string()],
-            ),
-        ]);
-        let manager = KeyboardManager::new(mappings, "source");
-
-        assert!(manager.register_key_down("source", "KeyD"));
-        assert!(manager.register_key_down("source", "KeyF"));
-        assert!(manager.set_mode("target"));
-
-        assert_eq!(manager.pressed_keys(), vec!["KeyF"]);
-        assert!(!manager.register_key_up("target", "KeyD"));
-        assert!(manager.register_key_up("target", "KeyF"));
-    }
-
-    #[test]
-    fn reset_to_empty_mapping_clears_active_keys() {
+    fn any_slot_counts_each_alternating_fresh_press_and_transitions_at_edges() {
         let manager = KeyboardManager::new(
-            HashMap::from([("custom".to_string(), vec!["KeyD".to_string()])]),
-            "custom",
-        );
-        assert!(manager.register_key_down("custom", "KeyD"));
-
-        manager.update_mappings_and_set_mode(
-            HashMap::from([("custom".to_string(), Vec::new())]),
-            "custom".to_string(),
+            HashMap::from([("mode".to_string(), vec![multi(&["Z", "B"], SlotMatch::Any)])]),
+            "mode",
         );
 
-        assert!(manager.pressed_keys().is_empty());
-        assert!(!manager.register_key_up("custom", "KeyD"));
+        let z_down = input(
+            &manager,
+            Some("keyboard:z"),
+            InputDeviceKind::Keyboard,
+            &["Z"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(z_down.pressed_label.as_deref(), Some("Z"));
+        assert_eq!(z_down.events, vec![event("Z|B", vec![0], Some(true), true)]);
+
+        let b_down = input(
+            &manager,
+            Some("keyboard:b"),
+            InputDeviceKind::Keyboard,
+            &["B"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(b_down.events, vec![event("Z|B", vec![0], None, true)]);
+        assert_eq!(
+            input(
+                &manager,
+                Some("keyboard:b"),
+                InputDeviceKind::Keyboard,
+                &["B"],
+                false,
+            )
+            .unwrap()
+            .events,
+            vec![event("Z|B", vec![0], None, false)]
+        );
+        assert_eq!(
+            input(
+                &manager,
+                Some("keyboard:b"),
+                InputDeviceKind::Keyboard,
+                &["B"],
+                true,
+            )
+            .unwrap()
+            .events,
+            vec![event("Z|B", vec![0], None, true)]
+        );
+        input(
+            &manager,
+            Some("keyboard:z"),
+            InputDeviceKind::Keyboard,
+            &["Z"],
+            false,
+        );
+        assert_eq!(
+            input(
+                &manager,
+                Some("keyboard:b"),
+                InputDeviceKind::Keyboard,
+                &["B"],
+                false,
+            )
+            .unwrap()
+            .events,
+            vec![event("Z|B", vec![0], Some(false), false)]
+        );
     }
 
     #[test]
-    fn update_mappings_and_mode_prunes_removed_active_keys() {
+    fn all_slot_completes_and_recompletes_in_either_order() {
         let manager = KeyboardManager::new(
             HashMap::from([(
-                "4key".to_string(),
-                vec!["KeyD".to_string(), "KeyF".to_string()],
+                "mode".to_string(),
+                vec![multi(&["LEFT CTRL", "Z"], SlotMatch::All)],
             )]),
-            "4key",
-        );
-        assert!(manager.register_key_down("4key", "KeyD"));
-        assert!(manager.register_key_down("4key", "KeyF"));
-
-        manager.update_mappings_and_set_mode(
-            HashMap::from([(
-                "4key".to_string(),
-                vec!["KeyF".to_string(), "KeyJ".to_string()],
-            )]),
-            "4key".to_string(),
-        );
-
-        assert_eq!(manager.pressed_keys(), vec!["KeyF"]);
-        assert!(!manager.register_key_up("4key", "KeyD"));
-        assert!(manager.register_key_up("4key", "KeyF"));
-    }
-
-    #[test]
-    fn stale_mode_or_invalid_key_registration_is_rejected() {
-        let manager = KeyboardManager::new(
-            HashMap::from([
-                ("source".to_string(), vec!["KeyD".to_string()]),
-                ("target".to_string(), vec!["KeyF".to_string()]),
-            ]),
-            "source",
-        );
-
-        assert!(manager.set_mode("target"));
-        assert!(!manager.register_key_down("target", "KeyD"));
-        assert!(!manager.register_key_down("source", "KeyD"));
-        assert!(manager.pressed_keys().is_empty());
-    }
-
-    #[test]
-    fn matching_and_registration_share_one_mode_snapshot() {
-        let manager = KeyboardManager::new(
-            HashMap::from([
-                ("source".to_string(), vec!["KeyD".to_string()]),
-                ("target".to_string(), vec!["KeyF".to_string()]),
-            ]),
-            "source",
+            "mode",
         );
 
         assert_eq!(
-            manager.match_and_register(["KeyD"], true),
-            Some(("source".to_string(), "KeyD".to_string(), true))
+            input(&manager, Some("z"), InputDeviceKind::Keyboard, &["Z"], true,)
+                .unwrap()
+                .events,
+            vec![event("LEFT CTRL+Z", vec![0], None, false)]
         );
-        assert!(manager.set_mode("target"));
-        assert!(manager.pressed_keys().is_empty());
-        assert_eq!(manager.match_and_register(["KeyD"], true), None);
+        assert_eq!(
+            input(
+                &manager,
+                Some("ctrl"),
+                InputDeviceKind::Keyboard,
+                &["LEFT CTRL"],
+                true,
+            )
+            .unwrap()
+            .events,
+            vec![event("LEFT CTRL+Z", vec![0], Some(true), true)]
+        );
+        assert_eq!(
+            input(
+                &manager,
+                Some("z"),
+                InputDeviceKind::Keyboard,
+                &["Z"],
+                false,
+            )
+            .unwrap()
+            .events,
+            vec![event("LEFT CTRL+Z", vec![0], Some(false), false)]
+        );
+        assert_eq!(
+            input(&manager, Some("z"), InputDeviceKind::Keyboard, &["Z"], true,)
+                .unwrap()
+                .events,
+            vec![event("LEFT CTRL+Z", vec![0], Some(true), true)]
+        );
     }
 
     #[test]
-    fn current_mode_and_pressed_keys_share_one_snapshot() {
+    fn repeat_down_and_ghost_up_are_suppressed_by_physical_identity() {
+        let manager = KeyboardManager::new(
+            HashMap::from([("mode".to_string(), vec![single("A")])]),
+            "mode",
+        );
+
+        assert!(input(
+            &manager,
+            Some("physical:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        )
+        .is_some());
+        assert!(input(
+            &manager,
+            Some("physical:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        )
+        .is_none());
+        assert!(input(
+            &manager,
+            Some("physical:ghost"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            false,
+        )
+        .is_none());
+        assert!(input(
+            &manager,
+            Some("physical:empty"),
+            InputDeviceKind::Keyboard,
+            &[],
+            true,
+        )
+        .is_some());
+        assert!(input(
+            &manager,
+            Some("physical:empty"),
+            InputDeviceKind::Keyboard,
+            &[],
+            false,
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn mode_switch_and_mapping_removal_do_not_lose_later_key_up() {
         let manager = KeyboardManager::new(
             HashMap::from([
-                ("source".to_string(), vec!["KeyD".to_string()]),
-                ("target".to_string(), vec!["KeyF".to_string()]),
+                ("source".to_string(), vec![single("A")]),
+                ("target".to_string(), vec![single("B")]),
             ]),
             "source",
         );
-        assert!(manager.register_key_down("source", "KeyD"));
-
-        assert_eq!(
-            manager.current_mode_and_pressed_keys(),
-            ("source".to_string(), vec!["KeyD".to_string()])
+        input(
+            &manager,
+            Some("physical:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
         );
+        assert!(manager.set_mode("target"));
+        assert!(input(
+            &manager,
+            Some("physical:a"),
+            InputDeviceKind::Keyboard,
+            &["changed-up-label"],
+            false,
+        )
+        .is_some());
+        assert!(manager.set_mode("source"));
+        assert!(manager.pressed_keys().is_empty());
+
+        input(
+            &manager,
+            Some("physical:a2"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        );
+        manager.update_mappings(HashMap::from([("source".to_string(), Vec::new())]));
+        assert!(input(
+            &manager,
+            Some("physical:a2"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            false,
+        )
+        .is_some());
+        manager.update_mappings(HashMap::from([("source".to_string(), vec![single("A")])]));
+        assert!(manager.pressed_keys().is_empty());
+    }
+
+    #[test]
+    fn held_unmapped_key_activates_when_switching_to_a_matching_mode() {
+        let manager = KeyboardManager::new(
+            HashMap::from([
+                ("source".to_string(), vec![single("B")]),
+                ("target".to_string(), vec![single("A")]),
+            ]),
+            "source",
+        );
+        let down = input(
+            &manager,
+            Some("physical:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        )
+        .unwrap();
+        assert!(down.pressed_label.is_none());
+
+        assert!(manager.set_mode("target"));
+        assert_eq!(manager.pressed_keys(), vec!["A"]);
+    }
+
+    #[test]
+    fn shared_member_fans_out_slots_but_resolves_one_physical_press() {
+        let manager = KeyboardManager::new(
+            HashMap::from([(
+                "mode".to_string(),
+                vec![single("A"), multi(&["A", "B"], SlotMatch::Any)],
+            )]),
+            "mode",
+        );
+
+        let outcome = input(
+            &manager,
+            Some("physical:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(outcome.pressed_label.as_deref(), Some("A"));
+        assert_eq!(
+            outcome.events,
+            vec![
+                event("A", vec![0], Some(true), true),
+                event("A|B", vec![1], Some(true), true),
+            ]
+        );
+    }
+
+    #[test]
+    fn duplicate_canonical_slots_deduplicate_event_and_collect_indices() {
+        let slot = multi(&["A", "B"], SlotMatch::Any);
+        let manager = KeyboardManager::new(
+            HashMap::from([("mode".to_string(), vec![slot.clone(), slot])]),
+            "mode",
+        );
+
+        let outcome = input(
+            &manager,
+            Some("physical:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            outcome.events,
+            vec![event("A|B", vec![0, 1], Some(true), true)]
+        );
+    }
+
+    #[test]
+    fn alias_candidates_resolve_only_the_first_matching_label() {
+        let manager = KeyboardManager::new(
+            HashMap::from([(
+                "mode".to_string(),
+                vec![multi(&["21", "RIGHT ALT"], SlotMatch::All)],
+            )]),
+            "mode",
+        );
+
+        let alias = input(
+            &manager,
+            Some("physical:altgr"),
+            InputDeviceKind::Keyboard,
+            &["21", "RIGHT ALT"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(alias.pressed_label.as_deref(), Some("21"));
+        assert_eq!(alias.events[0].transition, None);
+
+        let second = input(
+            &manager,
+            Some("physical:right-alt-2"),
+            InputDeviceKind::Keyboard,
+            &["RIGHT ALT"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(second.events[0].transition, Some(true));
+    }
+
+    #[test]
+    fn key_up_uses_resolved_label_saved_on_key_down() {
+        let manager = KeyboardManager::new(
+            HashMap::from([("mode".to_string(), vec![single("RIGHT ALT")])]),
+            "mode",
+        );
+        input(
+            &manager,
+            Some("physical:altgr"),
+            InputDeviceKind::Keyboard,
+            &["21", "RIGHT ALT"],
+            true,
+        );
+
+        let up = input(
+            &manager,
+            Some("physical:altgr"),
+            InputDeviceKind::Keyboard,
+            &["21"],
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            up.events,
+            vec![event("RIGHT ALT", vec![0], Some(false), false)]
+        );
+    }
+
+    #[test]
+    fn missing_physical_id_falls_back_to_device_kind_and_primary_label() {
+        let manager = KeyboardManager::new(
+            HashMap::from([("mode".to_string(), vec![single("A")])]),
+            "mode",
+        );
+
+        assert!(input(&manager, None, InputDeviceKind::Keyboard, &["A"], true,).is_some());
+        assert!(input(&manager, None, InputDeviceKind::Keyboard, &["A"], true,).is_none());
+        assert!(input(&manager, None, InputDeviceKind::Mouse, &["A"], true,).is_some());
+    }
+
+    #[test]
+    fn inert_single_canonical_collision_is_not_a_contributing_slot() {
+        let manager = KeyboardManager::new(
+            HashMap::from([(
+                "mode".to_string(),
+                vec![single("A+B"), multi(&["A", "B"], SlotMatch::All)],
+            )]),
+            "mode",
+        );
+
+        let first = input(
+            &manager,
+            Some("physical:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(first.events, vec![event("A+B", vec![1], None, false)]);
+        let completed = input(
+            &manager,
+            Some("physical:b"),
+            InputDeviceKind::Keyboard,
+            &["B"],
+            true,
+        )
+        .unwrap();
+        assert_eq!(
+            completed.events,
+            vec![event("A+B", vec![1], Some(true), true)]
+        );
+    }
+
+    #[test]
+    fn clear_active_keys_clears_physical_and_canonical_state() {
+        let manager = KeyboardManager::new(
+            HashMap::from([("mode".to_string(), vec![single("A")])]),
+            "mode",
+        );
+        input(
+            &manager,
+            Some("physical:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        );
+        manager.clear_active_keys();
+
+        assert!(manager.pressed_keys().is_empty());
+        assert!(manager.register_key_down("mode", "A"));
+        assert!(manager.register_key_up("mode", "A"));
+        assert!(input(
+            &manager,
+            Some("physical:a"),
+            InputDeviceKind::Keyboard,
+            &["A"],
+            true,
+        )
+        .is_some());
     }
 }

--- a/src-tauri/src/keyboard/manager.rs
+++ b/src-tauri/src/keyboard/manager.rs
@@ -585,6 +585,40 @@ mod tests {
             .events,
             vec![event("Z|B", vec![0], Some(false), false)]
         );
+
+        input(
+            &manager,
+            Some("keyboard:z"),
+            InputDeviceKind::Keyboard,
+            &["Z"],
+            true,
+        );
+        input(
+            &manager,
+            Some("keyboard:b"),
+            InputDeviceKind::Keyboard,
+            &["B"],
+            true,
+        );
+        input(
+            &manager,
+            Some("keyboard:b"),
+            InputDeviceKind::Keyboard,
+            &["B"],
+            false,
+        );
+        assert_eq!(
+            input(
+                &manager,
+                Some("keyboard:z"),
+                InputDeviceKind::Keyboard,
+                &["Z"],
+                false,
+            )
+            .unwrap()
+            .events,
+            vec![event_with_physical_hold("Z|B", vec![0], Some(false), false,)]
+        );
     }
 
     #[test]
@@ -632,6 +666,23 @@ mod tests {
                 .unwrap()
                 .events,
             vec![event("LEFT CTRL+Z", vec![0], Some(true), true)]
+        );
+        assert_eq!(
+            input(
+                &manager,
+                Some("z"),
+                InputDeviceKind::Keyboard,
+                &["Z"],
+                false,
+            )
+            .unwrap()
+            .events,
+            vec![event_with_physical_hold(
+                "LEFT CTRL+Z",
+                vec![0],
+                Some(false),
+                false,
+            )]
         );
     }
 

--- a/src-tauri/src/keyboard/manager.rs
+++ b/src-tauri/src/keyboard/manager.rs
@@ -25,6 +25,21 @@ pub struct SlotEvent {
     pub press: bool,
 }
 
+// 키음 디스패치용: press 이벤트들의 기여 슬롯 인덱스를 병합
+// 한 물리 다운이 여러 슬롯을 트리거해도 사운드는 1회만 재생 (오디오 중첩 방지)
+pub fn collect_sound_dispatch(events: &[SlotEvent]) -> Option<(&str, Vec<usize>)> {
+    let mut canonical: Option<&str> = None;
+    let mut indices: Vec<usize> = Vec::new();
+    for event in events.iter().filter(|event| event.press) {
+        canonical.get_or_insert(event.canonical.as_str());
+        indices.extend_from_slice(&event.slot_indices);
+    }
+    let canonical = canonical?;
+    indices.sort_unstable();
+    indices.dedup();
+    Some((canonical, indices))
+}
+
 #[derive(Debug, Clone)]
 struct SlotSpec {
     members: Vec<String>,
@@ -701,6 +716,38 @@ mod tests {
 
         assert!(manager.set_mode("target"));
         assert_eq!(manager.pressed_keys(), vec!["A"]);
+    }
+
+    #[test]
+    fn collect_sound_dispatch_merges_press_slots_into_single_dispatch() {
+        let events = vec![
+            SlotEvent {
+                canonical: "A".to_string(),
+                slot_indices: vec![1],
+                transition: Some(true),
+                press: true,
+            },
+            SlotEvent {
+                canonical: "A|B".to_string(),
+                slot_indices: vec![0, 1],
+                transition: None,
+                press: true,
+            },
+            SlotEvent {
+                canonical: "C".to_string(),
+                slot_indices: vec![2],
+                transition: Some(false),
+                press: false,
+            },
+        ];
+
+        let (canonical, indices) = super::collect_sound_dispatch(&events).unwrap();
+
+        assert_eq!(canonical, "A");
+        assert_eq!(indices, vec![0, 1]);
+
+        // press 이벤트가 없으면 디스패치 자체가 없음
+        assert!(super::collect_sound_dispatch(&events[2..]).is_none());
     }
 
     #[test]

--- a/src-tauri/src/models/editor.rs
+++ b/src-tauri/src/models/editor.rs
@@ -186,6 +186,8 @@ impl EditorPatchV1 {
 pub struct EditorCommitRequest {
     pub base_revision: u64,
     pub mutation_id: String,
+    #[serde(default)]
+    pub multi_key: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gesture_id: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -62,24 +62,6 @@ impl Default for KeySlot {
     }
 }
 
-impl PartialEq<str> for KeySlot {
-    fn eq(&self, other: &str) -> bool {
-        matches!(self, Self::Single(key) if key == other)
-    }
-}
-
-impl PartialEq<&str> for KeySlot {
-    fn eq(&self, other: &&str) -> bool {
-        self == *other
-    }
-}
-
-impl PartialEq<String> for KeySlot {
-    fn eq(&self, other: &String) -> bool {
-        self == other.as_str()
-    }
-}
-
 impl KeySlot {
     pub fn canonical(&self) -> String {
         match self {

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -10,11 +10,188 @@ pub use plugin::*;
 use serde::de::Error as DeError;
 use serde::ser::{Error as SerError, SerializeMap};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use uuid::Uuid;
 
-pub type KeyMappings = HashMap<String, Vec<String>>;
+pub const MAX_SLOT_KEYS: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SlotMatch {
+    All,
+    Any,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged, from = "RawKeySlot")]
+pub enum KeySlot {
+    Single(String),
+    Multi {
+        keys: Vec<String>,
+        #[serde(rename = "match")]
+        match_mode: SlotMatch,
+    },
+}
+
+#[derive(Deserialize)]
+#[serde(transparent)]
+struct RawKeySlot(serde_json::Value);
+
+impl From<RawKeySlot> for KeySlot {
+    fn from(raw: RawKeySlot) -> Self {
+        normalize_key_slot(raw.0)
+    }
+}
+
+impl From<String> for KeySlot {
+    fn from(value: String) -> Self {
+        Self::Single(value)
+    }
+}
+
+impl From<&str> for KeySlot {
+    fn from(value: &str) -> Self {
+        Self::Single(value.to_string())
+    }
+}
+
+impl Default for KeySlot {
+    fn default() -> Self {
+        Self::Single(String::new())
+    }
+}
+
+impl PartialEq<str> for KeySlot {
+    fn eq(&self, other: &str) -> bool {
+        matches!(self, Self::Single(key) if key == other)
+    }
+}
+
+impl PartialEq<&str> for KeySlot {
+    fn eq(&self, other: &&str) -> bool {
+        self == *other
+    }
+}
+
+impl PartialEq<String> for KeySlot {
+    fn eq(&self, other: &String) -> bool {
+        self == other.as_str()
+    }
+}
+
+impl KeySlot {
+    pub fn canonical(&self) -> String {
+        match self {
+            Self::Single(key) => key.clone(),
+            Self::Multi {
+                keys,
+                match_mode: SlotMatch::All,
+            } => keys.join("+"),
+            Self::Multi {
+                keys,
+                match_mode: SlotMatch::Any,
+            } => keys.join("|"),
+        }
+    }
+
+    pub fn members(&self) -> std::slice::Iter<'_, String> {
+        match self {
+            Self::Single(key) => std::slice::from_ref(key).iter(),
+            Self::Multi { keys, .. } => keys.iter(),
+        }
+    }
+
+    pub fn is_unassigned(&self) -> bool {
+        matches!(self, Self::Single(key) if key.is_empty())
+    }
+
+    pub fn is_multi(&self) -> bool {
+        matches!(self, Self::Multi { .. })
+    }
+}
+
+pub fn normalize_key_slot(raw: serde_json::Value) -> KeySlot {
+    match raw {
+        serde_json::Value::String(key) => {
+            if (key.contains('+') && key != "+") || key.contains('|') {
+                log::warn!(
+                    "[Store] Key slot string contains a reserved canonical separator and may collide visually"
+                );
+            }
+            KeySlot::Single(key)
+        }
+        serde_json::Value::Object(object) => {
+            let has_unknown_fields = object.keys().any(|key| key != "keys" && key != "match");
+            let match_mode = match object.get("match").and_then(serde_json::Value::as_str) {
+                Some("all") => SlotMatch::All,
+                Some("any") => SlotMatch::Any,
+                _ => {
+                    log::warn!("[Store] Normalized an invalid multi-key slot to an unassigned key");
+                    return KeySlot::default();
+                }
+            };
+
+            let mut changed = has_unknown_fields;
+            let mut seen = HashSet::new();
+            let mut keys = Vec::new();
+            let entries = match object.get("keys") {
+                Some(serde_json::Value::Array(entries)) => entries.as_slice(),
+                _ => {
+                    changed = true;
+                    &[]
+                }
+            };
+            for entry in entries {
+                let Some(key) = entry.as_str() else {
+                    changed = true;
+                    continue;
+                };
+                if key.is_empty() || key.contains('+') || key.contains('|') {
+                    changed = true;
+                    continue;
+                }
+                if !seen.insert(key.to_string()) {
+                    changed = true;
+                    continue;
+                }
+                if keys.len() == MAX_SLOT_KEYS {
+                    changed = true;
+                    continue;
+                }
+                keys.push(key.to_string());
+            }
+
+            let normalized = match keys.len() {
+                0 => KeySlot::default(),
+                1 => KeySlot::Single(keys.pop().unwrap_or_default()),
+                _ => KeySlot::Multi { keys, match_mode },
+            };
+            changed |= !normalized.is_multi();
+            if changed {
+                log::warn!("[Store] Normalized a malformed multi-key slot");
+            }
+            normalized
+        }
+        _ => {
+            log::warn!("[Store] Normalized an invalid key slot to an unassigned key");
+            KeySlot::default()
+        }
+    }
+}
+
+pub fn normalize_key_mappings(mappings: &mut HashMap<String, Vec<KeySlot>>) {
+    for slot in mappings.values_mut().flatten() {
+        let raw = serde_json::to_value(&*slot).unwrap_or(serde_json::Value::Null);
+        *slot = normalize_key_slot(raw);
+    }
+}
+
+pub fn key_mappings_contain_multi(mappings: &HashMap<String, Vec<KeySlot>>) -> bool {
+    mappings.values().flatten().any(KeySlot::is_multi)
+}
+
+pub type KeyMappings = HashMap<String, Vec<KeySlot>>;
 pub type KeyPositions = HashMap<String, Vec<KeyPosition>>;
 pub type KeyCounters = HashMap<String, HashMap<String, u32>>;
 pub type StatPositions = HashMap<String, Vec<StatPosition>>;
@@ -2344,10 +2521,84 @@ pub struct SettingsPatch {
 mod tests {
     use super::{
         compact_canonical_rgba, FadePosition, GradientSpec, KeyCounterAlign, KeyCounterAlignMode,
-        KeyCounterColor, KeyCounterPlacement, KeyCounterSettings, KeyPosition, NoteColor,
-        NoteSettings, StatType,
+        KeyCounterColor, KeyCounterPlacement, KeyCounterSettings, KeyMappings, KeyPosition,
+        KeySlot, NoteColor, NoteSettings, SlotMatch, StatType, MAX_SLOT_KEYS,
     };
     use serde::Deserialize;
+
+    #[test]
+    fn legacy_string_key_mappings_round_trip_without_loss() {
+        let raw = serde_json::json!({
+            "4key": ["A", "A+B", "+", ""]
+        });
+
+        let mappings: KeyMappings = serde_json::from_value(raw.clone()).unwrap();
+
+        assert_eq!(serde_json::to_value(mappings).unwrap(), raw);
+    }
+
+    #[test]
+    fn multi_key_slot_wire_shape_and_canonical_are_stable() {
+        let raw = serde_json::json!({ "keys": ["LEFT CTRL", "Z"], "match": "all" });
+
+        let slot: KeySlot = serde_json::from_value(raw.clone()).unwrap();
+
+        assert_eq!(
+            slot,
+            KeySlot::Multi {
+                keys: vec!["LEFT CTRL".to_string(), "Z".to_string()],
+                match_mode: SlotMatch::All,
+            }
+        );
+        assert_eq!(slot.canonical(), "LEFT CTRL+Z");
+        assert_eq!(serde_json::to_value(slot).unwrap(), raw);
+    }
+
+    #[test]
+    fn malformed_key_slots_normalize_without_deserialization_failure() {
+        let too_many = (0..=MAX_SLOT_KEYS)
+            .map(|index| serde_json::Value::String(format!("K{index}")))
+            .collect::<Vec<_>>();
+        let cases = [
+            (serde_json::json!({ "keys": ["Z"] }), KeySlot::default()),
+            (
+                serde_json::json!({
+                    "keys": ["A", 7, "", "A", "B+C", "D|E", "B"],
+                    "match": "any",
+                    "ignored": true
+                }),
+                KeySlot::Multi {
+                    keys: vec!["A".to_string(), "B".to_string()],
+                    match_mode: SlotMatch::Any,
+                },
+            ),
+            (
+                serde_json::json!({ "keys": ["Z"], "match": "all" }),
+                KeySlot::Single("Z".to_string()),
+            ),
+            (
+                serde_json::json!({ "keys": [], "match": "any" }),
+                KeySlot::default(),
+            ),
+            (
+                serde_json::json!({ "keys": too_many, "match": "any" }),
+                KeySlot::Multi {
+                    keys: (0..MAX_SLOT_KEYS)
+                        .map(|index| format!("K{index}"))
+                        .collect(),
+                    match_mode: SlotMatch::Any,
+                },
+            ),
+            (serde_json::json!(42), KeySlot::default()),
+            (serde_json::json!(["A", "B"]), KeySlot::default()),
+            (serde_json::Value::Null, KeySlot::default()),
+        ];
+
+        for (raw, expected) in cases {
+            let slot: KeySlot = serde_json::from_value(raw).unwrap();
+            assert_eq!(slot, expected);
+        }
+    }
 
     #[test]
     fn stat_type_wire_values_round_trip() {

--- a/src-tauri/src/models/obs.rs
+++ b/src-tauri/src/models/obs.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-/// WS 프로토콜 버전
-pub const OBS_PROTOCOL_VERSION: u32 = 1;
+/// WS 프로토콜 버전 (v2: 키 슬롯 와이어 형식이 KeySlot union으로 확장됨)
+pub const OBS_PROTOCOL_VERSION: u32 = 2;
 
 /// 기본 OBS 포트
 pub const DEFAULT_OBS_PORT: u16 = 34891;

--- a/src-tauri/src/services/obs_bridge.rs
+++ b/src-tauri/src/services/obs_bridge.rs
@@ -1641,6 +1641,37 @@ mod tests {
         bridge.stop();
     }
 
+    // v1 번들은 KeySlot union 와이어 형식을 소비할 수 없으므로 handshake에서 결정적으로 거부
+    #[tokio::test]
+    async fn legacy_protocol_v1_hello_is_rejected() {
+        let bridge = Arc::new(ObsBridgeService::new("test"));
+        let port = bridge
+            .start(0, "token".to_string())
+            .await
+            .expect("OBS bridge 시작 실패");
+
+        let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{port}"))
+            .await
+            .expect("WS 연결 실패");
+        let hello = serde_json::json!({
+            "v": 1,
+            "type": "hello",
+            "seq": 0,
+            "payload": { "token": "token", "protocol": 1 },
+        });
+        ws.send(Message::Text(hello.to_string()))
+            .await
+            .expect("hello 전송 실패");
+
+        let error = receive_envelope(&mut ws, "error").await;
+        assert_eq!(
+            error.payload.get("code").and_then(Value::as_str),
+            Some("PROTOCOL_MISMATCH")
+        );
+
+        bridge.stop();
+    }
+
     #[test]
     fn binding_listens_on_all_interfaces_for_lan_access() {
         assert!(bind_address(34891).ip().is_unspecified());

--- a/src-tauri/src/services/obs_bridge.rs
+++ b/src-tauri/src/services/obs_bridge.rs
@@ -385,6 +385,7 @@ impl ObsBridgeService {
             "overlay:lock",
             "overlay:anchor",
             "input:raw",
+            "input:press",
             "input:axis",
             "css:use",
             "css:content",

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -726,6 +726,17 @@ fn key_state_payload(
     payload
 }
 
+fn canonical_hold_duration_ms(
+    can_use_physical_hold_duration: bool,
+    physical_hold_duration_ms: Option<f64>,
+) -> Option<f64> {
+    if can_use_physical_hold_duration {
+        physical_hold_duration_ms
+    } else {
+        None
+    }
+}
+
 fn collect_frontend_lifecycle_targets<T>(
     mut resolve: impl FnMut(&str) -> Option<T>,
 ) -> Vec<(String, T)> {
@@ -2595,7 +2606,10 @@ impl AppState {
                                     &outcome.mode,
                                     event_age_ms,
                                     is_active,
-                                    message.hold_duration_ms,
+                                    canonical_hold_duration_ms(
+                                        slot_event.can_use_physical_hold_duration,
+                                        message.hold_duration_ms,
+                                    ),
                                 );
 
                                 let mut emitted = false;
@@ -5077,24 +5091,24 @@ mod tests {
     use super::{
         acknowledge_editor_flush_handshake, acknowledge_panel_close_request,
         apply_panel_bounds_change, begin_panel_close_request, bootstrap_keyboard_state,
-        changed_panel_max_height, collect_authorized_css_paths, collect_frontend_lifecycle_targets,
-        frontend_history_mutation_blocked, frontend_lifecycle_restore_labels,
-        global_css_watch_path, install_history_handshake, install_lifecycle_handshake,
-        key_state_payload, next_keyboard_recovery_plan, panel_bounds_from_sample,
-        panel_height_bounds, publish_panel_hidden_transition, publish_panel_visibility_transition,
-        publish_selection_snapshot, resolve_event_age_ms, resolve_panel_window_layout,
-        run_panel_close_timeout, should_create_overlay_on_startup, should_recover_keyboard_daemon,
-        take_cancelable_editor_flush_handshake, take_editor_flush_handshake,
-        take_targeted_panel_view_state, validate_selection_session, EditorFlushAcknowledge,
-        EditorFlushCompletion, EditorFlushHandshake, EditorFlushRequest, FrontendFlushAction,
-        FrontendHistoryFlushPhase, FrontendHistoryFlushReady, FrontendLifecycleAction,
-        LifecycleHandshakeInstall, MonitorData, MonitorSpec, Mutex, PanelBoundsChange,
-        PanelBoundsPersistenceController, PanelBoundsPersistenceState, PanelBoundsSample,
-        PanelCloseRequestState, PanelCloseRequestedPayload, PanelLayerTab, PanelPropertyTab,
-        PanelViewMode, PanelViewState, PanelViewTarget, PanelVisibilityEventEmitter,
-        PanelVisibilityPayload, PanelVisibilityReason, PhysicalPosition, PhysicalSize,
-        SelectionSessionElement, SelectionSessionSnapshot, TargetedPanelViewState,
-        HISTORY_FRONTEND_FLUSH_INTERRUPTED, KEYBOARD_DAEMON_STABLE_RUNTIME,
+        canonical_hold_duration_ms, changed_panel_max_height, collect_authorized_css_paths,
+        collect_frontend_lifecycle_targets, frontend_history_mutation_blocked,
+        frontend_lifecycle_restore_labels, global_css_watch_path, install_history_handshake,
+        install_lifecycle_handshake, key_state_payload, next_keyboard_recovery_plan,
+        panel_bounds_from_sample, panel_height_bounds, publish_panel_hidden_transition,
+        publish_panel_visibility_transition, publish_selection_snapshot, resolve_event_age_ms,
+        resolve_panel_window_layout, run_panel_close_timeout, should_create_overlay_on_startup,
+        should_recover_keyboard_daemon, take_cancelable_editor_flush_handshake,
+        take_editor_flush_handshake, take_targeted_panel_view_state, validate_selection_session,
+        EditorFlushAcknowledge, EditorFlushCompletion, EditorFlushHandshake, EditorFlushRequest,
+        FrontendFlushAction, FrontendHistoryFlushPhase, FrontendHistoryFlushReady,
+        FrontendLifecycleAction, LifecycleHandshakeInstall, MonitorData, MonitorSpec, Mutex,
+        PanelBoundsChange, PanelBoundsPersistenceController, PanelBoundsPersistenceState,
+        PanelBoundsSample, PanelCloseRequestState, PanelCloseRequestedPayload, PanelLayerTab,
+        PanelPropertyTab, PanelViewMode, PanelViewState, PanelViewTarget,
+        PanelVisibilityEventEmitter, PanelVisibilityPayload, PanelVisibilityReason,
+        PhysicalPosition, PhysicalSize, SelectionSessionElement, SelectionSessionSnapshot,
+        TargetedPanelViewState, HISTORY_FRONTEND_FLUSH_INTERRUPTED, KEYBOARD_DAEMON_STABLE_RUNTIME,
         KEYBOARD_RECOVERY_DELAYS_MS, MAX_SELECTION_ELEMENTS, MAX_SELECTION_ELEMENT_TYPE_BYTES,
         MAX_SELECTION_FULL_ID_BYTES, MAX_SELECTION_GROUP_ID_BYTES, MAX_SELECTION_MODE_BYTES,
         OVERLAY_LABEL, PANEL_ENTRYPOINT, PANEL_INITIAL_HEIGHT, PANEL_LABEL, PANEL_MIN_HEIGHT,
@@ -6065,6 +6079,13 @@ mod tests {
         assert!(down.get("holdDurationMs").is_none());
         assert_eq!(up["holdDurationMs"], serde_json::json!(15.0));
         assert!(unmatched_up.get("holdDurationMs").is_none());
+    }
+
+    #[test]
+    fn canonical_hold_duration_requires_matching_transition_source() {
+        assert_eq!(canonical_hold_duration_ms(true, Some(15.0)), Some(15.0));
+        assert_eq!(canonical_hold_duration_ms(false, Some(15.0)), None);
+        assert_eq!(canonical_hold_duration_ms(true, None), None);
     }
 
     #[test]

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -43,7 +43,7 @@ use crate::{
     keyboard::KeyboardManager,
     models::{
         overlay_resize_anchor_from_str, AppStoreData, BootstrapOverlayState, BootstrapPayload,
-        DefaultsPayload, HistoryStatus, KeyCounterSettings, KeyCounters, KeyMappings,
+        DefaultsPayload, HistoryStatus, KeyCounterSettings, KeyCounters, KeyMappings, KeySlot,
         KeySoundOutputBackendPersist, OverlayBounds, OverlayResizeAnchor, PanelBounds,
         SettingsDiff, SettingsState, TabCssOverrides,
     },
@@ -2431,6 +2431,7 @@ impl AppState {
                                     } else {
                                         crate::ipc::HookKeyState::Up
                                     },
+                                    physical_id: None,
                                     vk_code: None,
                                     scan_code: None,
                                     flags: None,
@@ -2472,156 +2473,174 @@ impl AppState {
                             }
 
                             let is_down = state == "DOWN";
-                            let Some((mode, key_label, state_changed)) = keyboard.match_and_register(
-                                message.labels.iter().map(|s| s.as_str()),
+                            let Some(outcome) = keyboard.match_and_register(
+                                message.physical_id.as_deref(),
+                                message.device,
+                                message.labels.iter().map(String::as_str),
                                 is_down,
-                            )
-                            else {
+                            ) else {
                                 continue;
                             };
-                            if is_down && state_changed {
-                                app_state.increment_key_counter_and_emit(
-                                    &app_handle,
-                                    &mode,
-                                    &key_label,
-                                );
-                            }
-                            if !state_changed {
-                                continue;
-                            }
-                            if message.device == crate::ipc::InputDeviceKind::Keyboard
-                                && state == "DOWN"
-                            {
-                                if let Some((sound_path, per_key_volume)) =
-                                    app_state.resolve_key_sound_binding(&mode, &key_label)
-                                {
-                                    #[cfg(debug_assertions)]
-                                    let key_sound_input_started_at = Instant::now();
-                                    #[cfg(debug_assertions)]
-                                    let key_sound_dispatch_started_at = Instant::now();
-                                    #[cfg(debug_assertions)]
-                                    let dispatch_ms =
-                                        key_sound_dispatch_started_at.elapsed().as_secs_f64()
-                                            * 1000.0;
-                                    #[cfg(debug_assertions)]
-                                    let trace = KeySoundDispatchTrace::new(
-                                        key_sound_input_started_at,
-                                        dispatch_ms,
-                                    );
-                                    app_state.key_sound.play_file(
-                                        &sound_path,
-                                        per_key_volume,
-                                        #[cfg(debug_assertions)]
-                                        Some(trace),
-                                        #[cfg(not(debug_assertions))]
-                                        None,
-                                    );
-                                    #[cfg(debug_assertions)]
-                                    if app_state.key_sound.latency_logging_enabled() {
-                                        log::debug!(
-                                            "[KeySound][Latency] route=dispatch dispatchMs={dispatch_ms:.3} mode={} key={} volume={:.3} path={}",
-                                            mode,
-                                            key_label,
-                                            per_key_volume,
-                                            sound_path
-                                        );
-                                    }
-                                } else {
-                                    #[cfg(debug_assertions)]
-                                    let key_sound_input_started_at = Instant::now();
-                                    #[cfg(debug_assertions)]
-                                    let key_sound_dispatch_started_at = Instant::now();
-                                    #[cfg(debug_assertions)]
-                                    let dispatch_ms =
-                                        key_sound_dispatch_started_at.elapsed().as_secs_f64()
-                                            * 1000.0;
-                                    #[cfg(debug_assertions)]
-                                    let trace = KeySoundDispatchTrace::new(
-                                        key_sound_input_started_at,
-                                        dispatch_ms,
-                                    );
-                                    app_state
-                                        .key_sound
-                                        .play_labels(
-                                            &message.labels,
-                                            #[cfg(debug_assertions)]
-                                            Some(trace),
-                                            #[cfg(not(debug_assertions))]
-                                            None,
-                                        );
-                                    #[cfg(debug_assertions)]
-                                    if app_state.key_sound.latency_logging_enabled() {
-                                        log::debug!(
-                                            "[KeySound][Latency] route=dispatch dispatchMs={dispatch_ms:.3} mode={} key={} source=soundpack",
-                                            mode,
-                                            key_label
-                                        );
-                                    }
+
+                            if let Some(pressed_label) = outcome.pressed_label.as_ref() {
+                                if let Err(err) = app_handle.emit(
+                                    "input:press",
+                                    &json!({ "label": pressed_label, "mode": &outcome.mode }),
+                                ) {
+                                    error!("failed to emit input:press: {err}");
                                 }
                             }
-                            // 데몬 캡처 시각부터 emit까지 경과 시간
+
                             let fallback_age_ms = recv_at.elapsed().as_secs_f64() * 1000.0;
                             let event_age_ms = resolve_event_age_ms(
                                 message.input_ts_ms,
                                 unix_epoch_ms(),
                                 fallback_age_ms,
                             );
-                            let payload = key_state_payload(
-                                &key_label,
-                                state,
-                                &mode,
-                                event_age_ms,
-                                is_down,
-                                message.hold_duration_ms,
-                            );
 
-                            let mut emitted = false;
-                            if let Some(overlay) = overlay_window.as_ref() {
-                                match overlay.emit("keys:state", &payload) {
-                                    Ok(_) => emitted = true,
-                                    Err(err) => {
-                                        error!("failed to emit keys:state to overlay: {err}");
-                                        overlay_window = None;
+                            for slot_event in outcome.events {
+                                if slot_event.press && is_down {
+                                    app_state.increment_key_counter_and_emit(
+                                        &app_handle,
+                                        &outcome.mode,
+                                        &slot_event.canonical,
+                                    );
+
+                                    if message.device == crate::ipc::InputDeviceKind::Keyboard {
+                                        if let Some((sound_path, per_key_volume)) = app_state
+                                            .resolve_key_sound_binding(
+                                                &outcome.mode,
+                                                &slot_event.slot_indices,
+                                            )
+                                        {
+                                            #[cfg(debug_assertions)]
+                                            let key_sound_input_started_at = Instant::now();
+                                            #[cfg(debug_assertions)]
+                                            let key_sound_dispatch_started_at = Instant::now();
+                                            #[cfg(debug_assertions)]
+                                            let dispatch_ms = key_sound_dispatch_started_at
+                                                .elapsed()
+                                                .as_secs_f64()
+                                                * 1000.0;
+                                            #[cfg(debug_assertions)]
+                                            let trace = KeySoundDispatchTrace::new(
+                                                key_sound_input_started_at,
+                                                dispatch_ms,
+                                            );
+                                            app_state.key_sound.play_file(
+                                                &sound_path,
+                                                per_key_volume,
+                                                #[cfg(debug_assertions)]
+                                                Some(trace),
+                                                #[cfg(not(debug_assertions))]
+                                                None,
+                                            );
+                                            #[cfg(debug_assertions)]
+                                            if app_state.key_sound.latency_logging_enabled() {
+                                                log::debug!(
+                                                    "[KeySound][Latency] route=dispatch dispatchMs={dispatch_ms:.3} mode={} key={} volume={:.3} path={}",
+                                                    outcome.mode,
+                                                    slot_event.canonical,
+                                                    per_key_volume,
+                                                    sound_path
+                                                );
+                                            }
+                                        } else {
+                                            #[cfg(debug_assertions)]
+                                            let key_sound_input_started_at = Instant::now();
+                                            #[cfg(debug_assertions)]
+                                            let key_sound_dispatch_started_at = Instant::now();
+                                            #[cfg(debug_assertions)]
+                                            let dispatch_ms = key_sound_dispatch_started_at
+                                                .elapsed()
+                                                .as_secs_f64()
+                                                * 1000.0;
+                                            #[cfg(debug_assertions)]
+                                            let trace = KeySoundDispatchTrace::new(
+                                                key_sound_input_started_at,
+                                                dispatch_ms,
+                                            );
+                                            app_state.key_sound.play_labels(
+                                                &message.labels,
+                                                #[cfg(debug_assertions)]
+                                                Some(trace),
+                                                #[cfg(not(debug_assertions))]
+                                                None,
+                                            );
+                                            #[cfg(debug_assertions)]
+                                            if app_state.key_sound.latency_logging_enabled() {
+                                                log::debug!(
+                                                    "[KeySound][Latency] route=dispatch dispatchMs={dispatch_ms:.3} mode={} key={} source=soundpack",
+                                                    outcome.mode,
+                                                    slot_event.canonical
+                                                );
+                                            }
+                                        }
                                     }
                                 }
-                            }
-                            if !emitted {
-                                if overlay_window.is_none() {
-                                    overlay_window = app_handle.get_webview_window(OVERLAY_LABEL);
-                                    if let Some(overlay) = overlay_window.as_ref() {
-                                        if overlay.emit("keys:state", &payload).is_ok() {
-                                            emitted = true;
-                                        } else {
+
+                                let Some(is_active) = slot_event.transition else {
+                                    continue;
+                                };
+                                let transition_state = if is_active { "DOWN" } else { "UP" };
+                                let payload = key_state_payload(
+                                    &slot_event.canonical,
+                                    transition_state,
+                                    &outcome.mode,
+                                    event_age_ms,
+                                    is_active,
+                                    message.hold_duration_ms,
+                                );
+
+                                let mut emitted = false;
+                                if let Some(overlay) = overlay_window.as_ref() {
+                                    match overlay.emit("keys:state", &payload) {
+                                        Ok(_) => emitted = true,
+                                        Err(err) => {
+                                            error!("failed to emit keys:state to overlay: {err}");
                                             overlay_window = None;
                                         }
                                     }
                                 }
                                 if !emitted {
-                                    if app_state.is_obs_mode_active() {
-                                        app_state.obs_bridge.broadcast_tauri_event(
-                                            "keys:state".to_string(),
-                                            payload.clone(),
-                                        );
-                                        emitted = true;
-                                    } else if let Err(err) =
-                                        app_handle.emit("keys:state", &payload)
-                                    {
-                                        error!("failed to emit keys:state (fallback): {err}");
-                                    } else {
-                                        emitted = true;
+                                    if overlay_window.is_none() {
+                                        overlay_window =
+                                            app_handle.get_webview_window(OVERLAY_LABEL);
+                                        if let Some(overlay) = overlay_window.as_ref() {
+                                            if overlay.emit("keys:state", &payload).is_ok() {
+                                                emitted = true;
+                                            } else {
+                                                overlay_window = None;
+                                            }
+                                        }
+                                    }
+                                    if !emitted {
+                                        if app_state.is_obs_mode_active() {
+                                            app_state.obs_bridge.broadcast_tauri_event(
+                                                "keys:state".to_string(),
+                                                payload.clone(),
+                                            );
+                                            emitted = true;
+                                        } else if let Err(err) =
+                                            app_handle.emit("keys:state", &payload)
+                                        {
+                                            error!("failed to emit keys:state (fallback): {err}");
+                                        } else {
+                                            emitted = true;
+                                        }
                                     }
                                 }
-                            }
 
-                            if emitted {
-                                keys_state_emit_count += 1;
-                                if keys_state_emit_count.is_multiple_of(500) {
-                                    log::debug!(
-                                        "[AppState] emitted keys:state {} times (last key={}, state={})",
-                                        keys_state_emit_count,
-                                        key_label,
-                                        state
-                                    );
+                                if emitted {
+                                    keys_state_emit_count += 1;
+                                    if keys_state_emit_count.is_multiple_of(500) {
+                                        log::debug!(
+                                            "[AppState] emitted keys:state {} times (last key={}, state={})",
+                                            keys_state_emit_count,
+                                            slot_event.canonical,
+                                            transition_state
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -3804,9 +3823,13 @@ impl AppState {
         target.retain(|mode, _| keys.contains_key(mode));
         for (mode, key_list) in keys.iter() {
             let entry = target.entry(mode.clone()).or_default();
-            entry.retain(|key, _| key_list.contains(key));
-            for key in key_list.iter() {
-                entry.entry(key.clone()).or_insert(0);
+            let canonical_keys = key_list
+                .iter()
+                .map(KeySlot::canonical)
+                .collect::<HashSet<_>>();
+            entry.retain(|key, _| canonical_keys.contains(key));
+            for key in canonical_keys {
+                entry.entry(key).or_insert(0);
             }
         }
     }
@@ -3895,17 +3918,16 @@ impl AppState {
         self.key_sound.invalidate_file_cache(path);
     }
 
-    fn resolve_key_sound_binding(&self, mode: &str, key_label: &str) -> Option<(String, f32)> {
+    fn resolve_key_sound_binding(
+        &self,
+        mode: &str,
+        slot_indices: &[usize],
+    ) -> Option<(String, f32)> {
         self.store.with_state(|state| {
-            let mappings = state.keys.get(mode)?;
             let positions = state.key_positions.get(mode)?;
 
-            for (index, mapped_key) in mappings.iter().enumerate() {
-                if mapped_key != key_label {
-                    continue;
-                }
-
-                let Some(position) = positions.get(index) else {
+            for index in slot_indices {
+                let Some(position) = positions.get(*index) else {
                     continue;
                 };
 
@@ -5997,7 +6019,7 @@ mod tests {
     #[test]
     fn bootstrap_keyboard_state_includes_mode_and_registered_event_key_names() {
         let manager = KeyboardManager::new(
-            HashMap::from([("4key".to_string(), vec!["KeyD".to_string()])]),
+            HashMap::from([("4key".to_string(), vec!["KeyD".into()])]),
             "4key",
         );
 

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -2498,6 +2498,84 @@ impl AppState {
                                 fallback_age_ms,
                             );
 
+                            // 키음은 물리 다운당 1회: press 기여 슬롯을 병합해
+                            // 사운드 활성 첫 슬롯 설정 사용 (오디오 중첩 방지)
+                            if is_down && message.device == crate::ipc::InputDeviceKind::Keyboard {
+                                if let Some((sound_canonical, sound_slot_indices)) =
+                                    crate::keyboard::manager::collect_sound_dispatch(&outcome.events)
+                                {
+                                    if let Some((sound_path, per_key_volume)) = app_state
+                                        .resolve_key_sound_binding(
+                                            &outcome.mode,
+                                            &sound_slot_indices,
+                                        )
+                                    {
+                                        #[cfg(debug_assertions)]
+                                        let key_sound_input_started_at = Instant::now();
+                                        #[cfg(debug_assertions)]
+                                        let key_sound_dispatch_started_at = Instant::now();
+                                        #[cfg(debug_assertions)]
+                                        let dispatch_ms = key_sound_dispatch_started_at
+                                            .elapsed()
+                                            .as_secs_f64()
+                                            * 1000.0;
+                                        #[cfg(debug_assertions)]
+                                        let trace = KeySoundDispatchTrace::new(
+                                            key_sound_input_started_at,
+                                            dispatch_ms,
+                                        );
+                                        app_state.key_sound.play_file(
+                                            &sound_path,
+                                            per_key_volume,
+                                            #[cfg(debug_assertions)]
+                                            Some(trace),
+                                            #[cfg(not(debug_assertions))]
+                                            None,
+                                        );
+                                        #[cfg(debug_assertions)]
+                                        if app_state.key_sound.latency_logging_enabled() {
+                                            log::debug!(
+                                                "[KeySound][Latency] route=dispatch dispatchMs={dispatch_ms:.3} mode={} key={} volume={:.3} path={}",
+                                                outcome.mode,
+                                                sound_canonical,
+                                                per_key_volume,
+                                                sound_path
+                                            );
+                                        }
+                                    } else {
+                                        #[cfg(debug_assertions)]
+                                        let key_sound_input_started_at = Instant::now();
+                                        #[cfg(debug_assertions)]
+                                        let key_sound_dispatch_started_at = Instant::now();
+                                        #[cfg(debug_assertions)]
+                                        let dispatch_ms = key_sound_dispatch_started_at
+                                            .elapsed()
+                                            .as_secs_f64()
+                                            * 1000.0;
+                                        #[cfg(debug_assertions)]
+                                        let trace = KeySoundDispatchTrace::new(
+                                            key_sound_input_started_at,
+                                            dispatch_ms,
+                                        );
+                                        app_state.key_sound.play_labels(
+                                            &message.labels,
+                                            #[cfg(debug_assertions)]
+                                            Some(trace),
+                                            #[cfg(not(debug_assertions))]
+                                            None,
+                                        );
+                                        #[cfg(debug_assertions)]
+                                        if app_state.key_sound.latency_logging_enabled() {
+                                            log::debug!(
+                                                "[KeySound][Latency] route=dispatch dispatchMs={dispatch_ms:.3} mode={} key={} source=soundpack",
+                                                outcome.mode,
+                                                sound_canonical
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+
                             for slot_event in outcome.events {
                                 if slot_event.press && is_down {
                                     app_state.increment_key_counter_and_emit(
@@ -2505,78 +2583,6 @@ impl AppState {
                                         &outcome.mode,
                                         &slot_event.canonical,
                                     );
-
-                                    if message.device == crate::ipc::InputDeviceKind::Keyboard {
-                                        if let Some((sound_path, per_key_volume)) = app_state
-                                            .resolve_key_sound_binding(
-                                                &outcome.mode,
-                                                &slot_event.slot_indices,
-                                            )
-                                        {
-                                            #[cfg(debug_assertions)]
-                                            let key_sound_input_started_at = Instant::now();
-                                            #[cfg(debug_assertions)]
-                                            let key_sound_dispatch_started_at = Instant::now();
-                                            #[cfg(debug_assertions)]
-                                            let dispatch_ms = key_sound_dispatch_started_at
-                                                .elapsed()
-                                                .as_secs_f64()
-                                                * 1000.0;
-                                            #[cfg(debug_assertions)]
-                                            let trace = KeySoundDispatchTrace::new(
-                                                key_sound_input_started_at,
-                                                dispatch_ms,
-                                            );
-                                            app_state.key_sound.play_file(
-                                                &sound_path,
-                                                per_key_volume,
-                                                #[cfg(debug_assertions)]
-                                                Some(trace),
-                                                #[cfg(not(debug_assertions))]
-                                                None,
-                                            );
-                                            #[cfg(debug_assertions)]
-                                            if app_state.key_sound.latency_logging_enabled() {
-                                                log::debug!(
-                                                    "[KeySound][Latency] route=dispatch dispatchMs={dispatch_ms:.3} mode={} key={} volume={:.3} path={}",
-                                                    outcome.mode,
-                                                    slot_event.canonical,
-                                                    per_key_volume,
-                                                    sound_path
-                                                );
-                                            }
-                                        } else {
-                                            #[cfg(debug_assertions)]
-                                            let key_sound_input_started_at = Instant::now();
-                                            #[cfg(debug_assertions)]
-                                            let key_sound_dispatch_started_at = Instant::now();
-                                            #[cfg(debug_assertions)]
-                                            let dispatch_ms = key_sound_dispatch_started_at
-                                                .elapsed()
-                                                .as_secs_f64()
-                                                * 1000.0;
-                                            #[cfg(debug_assertions)]
-                                            let trace = KeySoundDispatchTrace::new(
-                                                key_sound_input_started_at,
-                                                dispatch_ms,
-                                            );
-                                            app_state.key_sound.play_labels(
-                                                &message.labels,
-                                                #[cfg(debug_assertions)]
-                                                Some(trace),
-                                                #[cfg(not(debug_assertions))]
-                                                None,
-                                            );
-                                            #[cfg(debug_assertions)]
-                                            if app_state.key_sound.latency_logging_enabled() {
-                                                log::debug!(
-                                                    "[KeySound][Latency] route=dispatch dispatchMs={dispatch_ms:.3} mode={} key={} source=soundpack",
-                                                    outcome.mode,
-                                                    slot_event.canonical
-                                                );
-                                            }
-                                        }
-                                    }
                                 }
 
                                 let Some(is_active) = slot_event.transition else {

--- a/src-tauri/src/state/editor.rs
+++ b/src-tauri/src/state/editor.rs
@@ -10,13 +10,14 @@ use crate::{
     errors::EditorCommitError,
     models::{
         AppStoreData, CustomTab, EditorCommitRequest, EditorDocumentV1, EditorField,
-        ElementShadowSpec, KeyCounters, KeyMappings, KeyPosition, EDITOR_SCHEMA_VERSION,
+        ElementShadowSpec, KeyCounters, KeyMappings, KeyPosition, KeySlot, EDITOR_SCHEMA_VERSION,
     },
 };
 
 pub(crate) const MAX_SAFE_EDITOR_REVISION: u64 = 9_007_199_254_740_991;
 pub(crate) const MUTATION_ACK_CAPACITY: usize = 32;
 pub(crate) const MAX_CUSTOM_TABS: usize = 30;
+pub(crate) const MAX_SLOTS_PER_MEMBER: usize = 16;
 
 const MAX_MUTATION_ID_BYTES: usize = 64;
 const MAX_GESTURE_ID_BYTES: usize = 64;
@@ -45,6 +46,7 @@ pub(crate) type RequestFingerprint = [u8; 32];
 #[serde(rename_all = "camelCase")]
 struct FingerprintPayload<'a> {
     base_revision: u64,
+    multi_key: bool,
     gesture_id: Option<&'a str>,
     gesture_ids: &'a [String],
     changes: &'a crate::models::EditorPatchV1,
@@ -216,6 +218,7 @@ pub(crate) fn request_fingerprint(
 ) -> Result<RequestFingerprint, EditorCommitError> {
     canonical_request_fingerprint(&FingerprintPayload {
         base_revision: request.base_revision,
+        multi_key: request.multi_key,
         gesture_id: request.gesture_id.as_deref(),
         gesture_ids: &request.gesture_ids,
         changes: &request.changes,
@@ -618,6 +621,7 @@ fn validate_metric_limits(
     )?;
 
     validate_collection_limits("keys", &current.keys, &candidate.keys)?;
+    validate_key_member_fanout(&current.keys, &candidate.keys)?;
     validate_collection_limits(
         "keyPositions",
         &current.key_positions,
@@ -673,19 +677,22 @@ fn validate_metric_limits(
     }
 
     for (mode, keys) in &candidate.keys {
-        for (index, key) in keys.iter().enumerate() {
-            let current_len = current
-                .keys
-                .get(mode)
-                .and_then(|values| values.get(index))
-                .map_or(0, String::len);
-            validate_count_limit(
-                "KEY_LABEL_TOO_LONG",
-                &format!("key label {mode}[{index}] byte length"),
-                current_len,
-                key.len(),
-                MAX_KEY_LABEL_BYTES,
-            )?;
+        for (slot_index, slot) in keys.iter().enumerate() {
+            for (member_index, member) in slot.members().enumerate() {
+                let current_len = current
+                    .keys
+                    .get(mode)
+                    .and_then(|values| values.get(slot_index))
+                    .and_then(|slot| slot.members().nth(member_index))
+                    .map_or(0, String::len);
+                validate_count_limit(
+                    "KEY_LABEL_TOO_LONG",
+                    &format!("key label {mode}[{slot_index}].members[{member_index}] byte length"),
+                    current_len,
+                    member.len(),
+                    MAX_KEY_LABEL_BYTES,
+                )?;
+            }
         }
     }
 
@@ -822,6 +829,40 @@ fn validate_collection_limits<T>(
         )?;
     }
     Ok(())
+}
+
+fn validate_key_member_fanout(
+    current: &KeyMappings,
+    candidate: &KeyMappings,
+) -> Result<(), EditorCommitError> {
+    for (mode, slots) in candidate {
+        let current_counts = current
+            .get(mode)
+            .map(|slots| member_slot_counts(slots))
+            .unwrap_or_default();
+        for (member, count) in member_slot_counts(slots) {
+            validate_count_limit(
+                "TOO_MANY_SLOTS_PER_MEMBER",
+                &format!("key member '{member}' slot count in mode '{mode}'"),
+                current_counts.get(&member).copied().unwrap_or_default(),
+                count,
+                MAX_SLOTS_PER_MEMBER,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn member_slot_counts(slots: &[KeySlot]) -> HashMap<String, usize> {
+    let mut counts = HashMap::new();
+    for member in slots
+        .iter()
+        .flat_map(KeySlot::members)
+        .filter(|member| !member.is_empty())
+    {
+        *counts.entry(member.clone()).or_default() += 1;
+    }
+    counts
 }
 
 fn validate_count_limit(
@@ -1010,9 +1051,13 @@ fn collect_group_reference_violations(
 pub(crate) fn sync_key_counters(counters: &mut KeyCounters, keys: &KeyMappings) {
     for (mode, key_list) in keys {
         let entry = counters.entry(mode.clone()).or_default();
-        entry.retain(|key, _| key_list.contains(key));
-        for key in key_list {
-            entry.entry(key.clone()).or_insert(0);
+        let canonical_keys = key_list
+            .iter()
+            .map(KeySlot::canonical)
+            .collect::<HashSet<_>>();
+        entry.retain(|key, _| canonical_keys.contains(key));
+        for key in canonical_keys {
+            entry.entry(key).or_insert(0);
         }
     }
 
@@ -1054,6 +1099,7 @@ mod tests {
         EditorCommitRequest {
             base_revision: 0,
             mutation_id: Uuid::new_v4().to_string(),
+            multi_key: false,
             gesture_id: None,
             gesture_ids: Vec::new(),
             changes: EditorPatchV1 {
@@ -1140,17 +1186,139 @@ mod tests {
     #[test]
     fn canonical_fingerprint_ignores_hash_map_insertion_order() {
         let mut left = HashMap::new();
-        left.insert("4key".to_string(), vec!["A".to_string()]);
-        left.insert("5key".to_string(), vec!["B".to_string()]);
+        left.insert("4key".to_string(), vec![KeySlot::from("A")]);
+        left.insert("5key".to_string(), vec![KeySlot::from("B")]);
 
         let mut right = HashMap::new();
-        right.insert("5key".to_string(), vec!["B".to_string()]);
-        right.insert("4key".to_string(), vec!["A".to_string()]);
+        right.insert("5key".to_string(), vec![KeySlot::from("B")]);
+        right.insert("4key".to_string(), vec![KeySlot::from("A")]);
 
         assert_eq!(
             request_fingerprint(&request(left)).unwrap(),
             request_fingerprint(&request(right)).unwrap()
         );
+    }
+
+    #[test]
+    fn canonical_fingerprint_includes_multi_key_capability() {
+        let mut legacy = request(KeyMappings::new());
+        let mut capable = legacy.clone();
+        capable.multi_key = true;
+
+        assert_ne!(
+            request_fingerprint(&legacy).unwrap(),
+            request_fingerprint(&capable).unwrap()
+        );
+
+        legacy.multi_key = true;
+        assert_eq!(
+            request_fingerprint(&legacy).unwrap(),
+            request_fingerprint(&capable).unwrap()
+        );
+    }
+
+    #[test]
+    fn commit_envelope_defaults_multi_key_to_false() {
+        let request = request(KeyMappings::new());
+        let mut wire = serde_json::to_value(request).unwrap();
+        wire.as_object_mut().unwrap().remove("multiKey");
+
+        let decoded: EditorCommitRequest = serde_json::from_value(wire).unwrap();
+
+        assert!(!decoded.multi_key);
+        let mut capable = decoded;
+        capable.multi_key = true;
+        assert_eq!(serde_json::to_value(capable).unwrap()["multiKey"], true);
+    }
+
+    #[test]
+    fn member_fanout_limit_accepts_sixteen_and_rejects_new_excess() {
+        let store = default_editor_store();
+        let current = EditorDocumentV1::from_store(&store);
+        let mut at_limit = current.clone();
+        at_limit
+            .keys
+            .get_mut("4key")
+            .unwrap()
+            .extend((0..MAX_SLOTS_PER_MEMBER).map(|index| KeySlot::Multi {
+                keys: vec!["SHARED".to_string(), format!("K{index}")],
+                match_mode: crate::models::SlotMatch::Any,
+            }));
+        at_limit
+            .key_positions
+            .get_mut("4key")
+            .unwrap()
+            .extend(vec![KeyPosition::default(); MAX_SLOTS_PER_MEMBER]);
+        let mut at_limit_store = store.clone();
+        at_limit.apply_to_store(&mut at_limit_store);
+
+        validate_document_transition(&current, &at_limit, &store, &at_limit_store).unwrap();
+
+        let mut over_limit = at_limit.clone();
+        over_limit
+            .keys
+            .get_mut("4key")
+            .unwrap()
+            .push(KeySlot::Multi {
+                keys: vec!["SHARED".to_string(), "EXTRA".to_string()],
+                match_mode: crate::models::SlotMatch::Any,
+            });
+        over_limit
+            .key_positions
+            .get_mut("4key")
+            .unwrap()
+            .push(KeyPosition::default());
+        let mut over_limit_store = at_limit_store.clone();
+        over_limit.apply_to_store(&mut over_limit_store);
+
+        let error = validate_document_transition(
+            &at_limit,
+            &over_limit,
+            &at_limit_store,
+            &over_limit_store,
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.details.unwrap().validation_code.as_deref(),
+            Some("TOO_MANY_SLOTS_PER_MEMBER")
+        );
+
+        validate_document_transition(
+            &over_limit,
+            &over_limit,
+            &over_limit_store,
+            &over_limit_store,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn counter_sync_uses_canonical_and_separates_any_from_all() {
+        let keys = HashMap::from([(
+            "mode".to_string(),
+            vec![
+                KeySlot::Single("A".to_string()),
+                KeySlot::Multi {
+                    keys: vec!["A".to_string(), "B".to_string()],
+                    match_mode: crate::models::SlotMatch::Any,
+                },
+                KeySlot::Multi {
+                    keys: vec!["A".to_string(), "B".to_string()],
+                    match_mode: crate::models::SlotMatch::All,
+                },
+            ],
+        )]);
+        let mut counters = HashMap::from([(
+            "mode".to_string(),
+            HashMap::from([("A".to_string(), 7), ("stale".to_string(), 3)]),
+        )]);
+
+        sync_key_counters(&mut counters, &keys);
+
+        assert_eq!(counters["mode"]["A"], 7);
+        assert_eq!(counters["mode"]["A|B"], 0);
+        assert_eq!(counters["mode"]["A+B"], 0);
+        assert!(!counters["mode"].contains_key("stale"));
     }
 
     #[test]
@@ -1162,7 +1330,7 @@ mod tests {
             .keys
             .entry("4key".to_string())
             .or_default()
-            .push("A".to_string());
+            .push(KeySlot::from("A"));
 
         let error = validate_paired_update(&current, &candidate, true, false).unwrap_err();
         assert_eq!(
@@ -1176,13 +1344,13 @@ mod tests {
         let mut store = AppStoreData::default();
         store
             .keys
-            .insert("ghost".to_string(), vec!["A".to_string()]);
+            .insert("ghost".to_string(), vec![KeySlot::from("A")]);
         store
             .key_positions
             .insert("ghost".to_string(), vec![KeyPosition::default()]);
         let current = EditorDocumentV1::from_store(&store);
         let mut candidate = current.clone();
-        candidate.keys.get_mut("ghost").unwrap()[0] = "B".to_string();
+        candidate.keys.get_mut("ghost").unwrap()[0] = KeySlot::from("B");
 
         validate_document_transition(&current, &candidate, &store, &store).unwrap();
     }
@@ -1194,7 +1362,7 @@ mod tests {
         let mut candidate = current.clone();
         candidate
             .keys
-            .insert("ghost".to_string(), vec!["A".to_string()]);
+            .insert("ghost".to_string(), vec![KeySlot::from("A")]);
         candidate
             .key_positions
             .insert("ghost".to_string(), vec![KeyPosition::default()]);
@@ -1217,7 +1385,7 @@ mod tests {
         });
         candidate_store
             .keys
-            .insert("custom".to_string(), vec!["A".to_string()]);
+            .insert("custom".to_string(), vec![KeySlot::from("A")]);
         candidate_store
             .key_positions
             .insert("custom".to_string(), vec![KeyPosition::default()]);
@@ -1231,7 +1399,7 @@ mod tests {
         let mut store = AppStoreData::default();
         store
             .keys
-            .insert("custom".to_string(), vec!["A".to_string()]);
+            .insert("custom".to_string(), vec![KeySlot::from("A")]);
         store
             .key_positions
             .insert("custom".to_string(), vec![KeyPosition::default()]);
@@ -1425,7 +1593,9 @@ mod tests {
         let mut store = store_with_custom_modes(1);
         store.keys.insert(
             "custom-0".to_string(),
-            (0..514).map(|index| format!("Key{index}")).collect(),
+            (0..514)
+                .map(|index| KeySlot::from(format!("Key{index}")))
+                .collect(),
         );
         store
             .key_positions
@@ -1445,7 +1615,7 @@ mod tests {
             .keys
             .get_mut("custom-0")
             .unwrap()
-            .push("Extra".to_string());
+            .push(KeySlot::from("Extra"));
         increased
             .key_positions
             .get_mut("custom-0")
@@ -1532,7 +1702,9 @@ mod tests {
         let mut collection_at_limit = collection_empty.clone();
         collection_at_limit.keys.insert(
             "custom-0".to_string(),
-            (0..512).map(|index| format!("Key{index}")).collect(),
+            (0..512)
+                .map(|index| KeySlot::from(format!("Key{index}")))
+                .collect(),
         );
         collection_at_limit
             .key_positions
@@ -1551,7 +1723,7 @@ mod tests {
             .keys
             .get_mut("custom-0")
             .unwrap()
-            .push("Extra".to_string());
+            .push(KeySlot::from("Extra"));
         collection_too_large
             .key_positions
             .get_mut("custom-0")
@@ -1574,7 +1746,7 @@ mod tests {
             let mode = format!("custom-{index}");
             render_at_limit
                 .keys
-                .insert(mode.clone(), vec![String::new(); 512]);
+                .insert(mode.clone(), vec![KeySlot::default(); 512]);
             render_at_limit
                 .key_positions
                 .insert(mode, vec![KeyPosition::default(); 512]);
@@ -1657,6 +1829,7 @@ mod tests {
         let invalid = EditorCommitRequest {
             base_revision: 0,
             mutation_id: "not-a-uuid".to_string(),
+            multi_key: false,
             gesture_id: None,
             gesture_ids: Vec::new(),
             changes: EditorPatchV1::default(),
@@ -1707,7 +1880,7 @@ mod tests {
             let mode = format!("custom-{index}");
             render_store
                 .keys
-                .insert(mode.clone(), vec![String::new(); 512]);
+                .insert(mode.clone(), vec![KeySlot::default(); 512]);
             render_store
                 .key_positions
                 .insert(mode, vec![KeyPosition::default(); 512]);
@@ -1853,7 +2026,7 @@ mod tests {
     fn compact_request_size_boundaries_are_exact() {
         fn sized_request(target_bytes: usize) -> EditorCommitRequest {
             let mut empty_keys = KeyMappings::new();
-            empty_keys.insert("4key".to_string(), vec![String::new()]);
+            empty_keys.insert("4key".to_string(), vec![KeySlot::default()]);
             let empty = request(empty_keys);
             let overhead = serde_json::to_vec(&empty).unwrap().len();
             assert!(target_bytes >= overhead);
@@ -1861,7 +2034,7 @@ mod tests {
             let mut keys = KeyMappings::new();
             keys.insert(
                 "4key".to_string(),
-                vec!["x".repeat(target_bytes - overhead)],
+                vec![KeySlot::from("x".repeat(target_bytes - overhead))],
             );
             let request = EditorCommitRequest {
                 mutation_id: empty.mutation_id,

--- a/src-tauri/src/state/gesture.rs
+++ b/src-tauri/src/state/gesture.rs
@@ -26,6 +26,7 @@ pub(crate) fn validate_gesture_commit_request(
     let editor_envelope = EditorCommitRequest {
         base_revision: request.editor_base_revision,
         mutation_id: request.mutation_id.clone(),
+        multi_key: false,
         gesture_id: Some(request.gesture_id.clone()),
         gesture_ids: Vec::new(),
         changes: request.editor_changes.clone().unwrap_or_default(),

--- a/src-tauri/src/state/history.rs
+++ b/src-tauri/src/state/history.rs
@@ -1308,7 +1308,7 @@ mod tests {
             schema_version: EDITOR_SCHEMA_VERSION,
             keys: Some(std::collections::HashMap::from([(
                 "mode".to_string(),
-                vec![text.to_string()],
+                vec![text.into()],
             )])),
             ..EditorPatchV1::default()
         }
@@ -1726,7 +1726,7 @@ mod tests {
     fn barrier_drains_admitted_runtime_publication_before_restore_mapping() {
         let gate = Arc::new(HistoryAdmissionGate::default());
         let keyboard = KeyboardManager::new(
-            HashMap::from([("mode".to_string(), vec!["initial".to_string()])]),
+            HashMap::from([("mode".to_string(), vec!["initial".into()])]),
             "mode",
         );
         let admission = gate.admit_mutation().unwrap();
@@ -1738,7 +1738,7 @@ mod tests {
             store_committed_tx.send(()).unwrap();
             publish_rx.recv().unwrap();
             stale_keyboard.update_mappings_and_set_mode(
-                HashMap::from([("mode".to_string(), vec!["stale".to_string()])]),
+                HashMap::from([("mode".to_string(), vec!["stale".into()])]),
                 "mode",
             );
             drop(admission);
@@ -1753,7 +1753,7 @@ mod tests {
         let barrier = thread::spawn(move || {
             let lease = barrier_gate.close("history-operation").unwrap();
             restored_keyboard.update_mappings_and_set_mode(
-                HashMap::from([("mode".to_string(), vec!["restored".to_string()])]),
+                HashMap::from([("mode".to_string(), vec!["restored".into()])]),
                 "mode",
             );
             restored_tx.send(()).unwrap();

--- a/src-tauri/src/state/history.rs
+++ b/src-tauri/src/state/history.rs
@@ -1295,7 +1295,10 @@ impl Drop for HistoryBarrierLease {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{keyboard::KeyboardManager, models::EDITOR_SCHEMA_VERSION};
+    use crate::{
+        keyboard::KeyboardManager,
+        models::{KeySlot, EDITOR_SCHEMA_VERSION},
+    };
     use std::{
         collections::HashMap,
         sync::mpsc,
@@ -1422,7 +1425,7 @@ mod tests {
         assert!(matches!(
             history.past.back().map(|entry| &entry.before),
             Some(HistorySnapshot::Editor { before, .. })
-                if before.keys.as_ref().unwrap()["mode"] == ["repeated"]
+                if before.keys.as_ref().unwrap()["mode"] == [KeySlot::from("repeated")]
         ));
     }
 
@@ -1469,7 +1472,7 @@ mod tests {
                 HistorySnapshot::PluginElements(plugin),
                 HistorySnapshot::Editor { before, .. }
             ] if plugin.plugin_id == "plugin-b"
-                && before.keys.as_ref().unwrap()["mode"] == ["before"]
+                && before.keys.as_ref().unwrap()["mode"] == [KeySlot::from("before")]
         ));
     }
 
@@ -1515,7 +1518,7 @@ mod tests {
         assert!(matches!(
             &latest.before,
             HistorySnapshot::Editor { before, .. }
-                if before.keys.as_ref().unwrap()["mode"] == ["after-intervening-editor"]
+                if before.keys.as_ref().unwrap()["mode"] == [KeySlot::from("after-intervening-editor")]
         ));
 
         let intervening = undo_order.next().unwrap();
@@ -1523,7 +1526,7 @@ mod tests {
         assert!(matches!(
             &intervening.before,
             HistorySnapshot::Editor { before, .. }
-                if before.keys.as_ref().unwrap()["mode"] == ["before-intervening-editor"]
+                if before.keys.as_ref().unwrap()["mode"] == [KeySlot::from("before-intervening-editor")]
         ));
     }
 

--- a/src-tauri/src/state/migration.rs
+++ b/src-tauri/src/state/migration.rs
@@ -2301,7 +2301,11 @@ mod tests {
         ] {
             let loaded = load_literal_fixture(version, &fixture);
             assert_eq!(loaded.editor_revision, 0, "{version}");
-            assert_eq!(loaded.keys["fixture-tab"], vec!["F13"], "{version}");
+            assert_eq!(
+                loaded.keys["fixture-tab"],
+                vec![KeySlot::from("F13")],
+                "{version}"
+            );
             assert_eq!(loaded.key_positions["fixture-tab"][0].dx, 13.0, "{version}");
             assert_eq!(loaded.key_counters["fixture-tab"]["F13"], 17, "{version}");
 
@@ -2340,6 +2344,50 @@ mod tests {
         v1_4_plus.plugin_data.clear();
         let cleared = serde_json::to_value(v1_4_plus).unwrap();
         assert!(cleared.get("editorRevision").is_none());
+    }
+
+    // master(구버전) recover_key_mapping_entries의 동결 사본: 문자열이 아닌
+    // 항목을 제자리 빈 문자열로 대체 (구버전 복구 동작, 2026-08 기준)
+    fn frozen_legacy_recover_keys(entries: &serde_json::Value) -> Vec<String> {
+        entries
+            .as_array()
+            .expect("keys mode must be an array")
+            .iter()
+            .map(|entry| entry.as_str().unwrap_or("").to_string())
+            .collect()
+    }
+
+    #[test]
+    fn downgrade_recovery_replaces_multi_slots_in_place_without_compaction() {
+        // 신버전이 직렬화한 keys 와이어 형식이 구버전 복구에서 어떻게 열화되는지 고정
+        let slots = vec![
+            KeySlot::from("Q"),
+            KeySlot::Multi {
+                keys: vec!["A".to_string(), "B".to_string()],
+                match_mode: SlotMatch::Any,
+            },
+            KeySlot::from("C"),
+            KeySlot::Multi {
+                keys: vec!["LEFT CTRL".to_string(), "Z".to_string()],
+                match_mode: SlotMatch::All,
+            },
+            KeySlot::default(),
+        ];
+        let wire = serde_json::to_value(&slots).unwrap();
+
+        let recovered = frozen_legacy_recover_keys(&wire);
+
+        // 배열 길이 보존(keyPositions 인덱스 결합 불변식), Multi만 제자리 "" 대체
+        assert_eq!(
+            recovered,
+            vec![
+                "Q".to_string(),
+                String::new(),
+                "C".to_string(),
+                String::new(),
+                String::new(),
+            ]
+        );
     }
 
     #[test]
@@ -2577,7 +2625,10 @@ mod tests {
         let loaded = load_store_from_path(&path).unwrap();
         assert!(!loaded.repaired);
         assert!(loaded.needs_persist);
-        assert_eq!(loaded.data.keys["4key"].last().unwrap(), "F5");
+        assert_eq!(
+            loaded.data.keys["4key"].last().unwrap(),
+            &KeySlot::from("F5")
+        );
         assert_eq!(
             loaded.data.key_positions["4key"].last().unwrap(),
             &KeyPosition::default()
@@ -2588,7 +2639,7 @@ mod tests {
         );
         assert!(loaded.data.keys["5key"].last().unwrap().is_unassigned());
         assert_eq!(loaded.data.key_positions["keys-only"].len(), 2);
-        assert_eq!(loaded.data.keys["positions-only"], vec![String::new()]);
+        assert_eq!(loaded.data.keys["positions-only"], vec![KeySlot::default()]);
 
         let modes = loaded
             .data
@@ -2970,7 +3021,10 @@ mod tests {
                 name: "Legacy tab".to_string(),
             }]
         );
-        assert_eq!(loaded.data.keys["legacy-tab"], vec!["A", "B"]);
+        assert_eq!(
+            loaded.data.keys["legacy-tab"],
+            vec![KeySlot::from("A"), KeySlot::from("B")]
+        );
         assert_eq!(loaded.data.key_positions["legacy-tab"].len(), 2);
         assert_eq!(loaded.data.key_positions["legacy-tab"][0].dx, 777.0);
         assert_eq!(loaded.data.key_positions["legacy-tab"][1].dx, 888.0);
@@ -3051,7 +3105,10 @@ mod tests {
 
         assert!(!loaded.repaired);
         assert_eq!(loaded.data.selected_key_type, "tauri-legacy-tab");
-        assert_eq!(loaded.data.keys["tauri-legacy-tab"], vec!["Q"]);
+        assert_eq!(
+            loaded.data.keys["tauri-legacy-tab"],
+            vec![KeySlot::from("Q")]
+        );
         assert_eq!(loaded.data.key_positions["tauri-legacy-tab"].len(), 1);
         let position = &loaded.data.key_positions["tauri-legacy-tab"][0];
         assert_eq!(position.dx, 654.0);
@@ -3134,14 +3191,14 @@ mod tests {
         assert_eq!(
             loaded.data.keys["alpha-tab"],
             vec![
-                String::new(),
-                "A".to_string(),
-                String::new(),
-                "C".to_string(),
-                String::new(),
+                KeySlot::default(),
+                KeySlot::from("A"),
+                KeySlot::default(),
+                KeySlot::from("C"),
+                KeySlot::default(),
             ]
         );
-        assert_eq!(loaded.data.keys["beta-tab"], vec!["D".to_string()]);
+        assert_eq!(loaded.data.keys["beta-tab"], vec![KeySlot::from("D")]);
         assert!(loaded.data.keys["empty-mode"].is_empty());
         assert_eq!(loaded.data.keys["4key"], default_keys()["4key"]);
         assert_eq!(
@@ -3452,7 +3509,7 @@ mod tests {
         assert_eq!(loaded.data.selected_key_type, "positions-damaged");
         assert_eq!(
             loaded.data.keys["keys-damaged"],
-            vec![String::new(), String::new()]
+            vec![KeySlot::default(), KeySlot::default()]
         );
         assert_eq!(
             loaded.data.key_positions["keys-damaged"]
@@ -3461,14 +3518,17 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![111.0, 222.0]
         );
-        assert_eq!(loaded.data.keys["positions-damaged"], vec!["A", "B", "C"]);
+        assert_eq!(
+            loaded.data.keys["positions-damaged"],
+            vec![KeySlot::from("A"), KeySlot::from("B"), KeySlot::from("C")]
+        );
         assert_eq!(
             loaded.data.key_positions["positions-damaged"],
             vec![KeyPosition::default(); 3]
         );
         assert_eq!(
             loaded.data.keys["valid-mismatch"],
-            vec!["Q".to_string(), String::new()]
+            vec![KeySlot::from("Q"), KeySlot::default()]
         );
         assert_eq!(loaded.data.key_positions["valid-mismatch"].len(), 2);
         assert!(loaded.data.keys["missing-both"].is_empty());
@@ -3520,7 +3580,7 @@ mod tests {
         assert!(!loaded.repaired);
         assert!(loaded.needs_persist);
         assert_eq!(loaded.data.selected_key_type, "4key");
-        assert_eq!(loaded.data.keys["ghost-tab"], vec!["G"]);
+        assert_eq!(loaded.data.keys["ghost-tab"], vec![KeySlot::from("G")]);
     }
 
     #[test]
@@ -3730,7 +3790,7 @@ mod tests {
         assert!(loaded.repaired);
         assert!(loaded.data.custom_tabs.is_empty());
         assert_eq!(loaded.data.selected_key_type, "4key");
-        assert_eq!(loaded.data.keys["ghost-tab"], vec!["G".to_string()]);
+        assert_eq!(loaded.data.keys["ghost-tab"], vec![KeySlot::from("G")]);
     }
 
     #[test]

--- a/src-tauri/src/state/migration.rs
+++ b/src-tauri/src/state/migration.rs
@@ -22,12 +22,12 @@ use crate::{
     },
     defaults::{default_keys, default_positions},
     models::{
-        AppStoreData, CounterAnimationPreset, CustomCss, CustomCssHistoryEntry, CustomFont,
-        CustomJs, CustomTab, FontType, GradientSpec, GraphPosition, GraphPositions, GraphStatType,
-        GraphType, GridSettings, JsPlugin, KeyCounters, KeyMappings, KeyPosition, KeyPositions,
-        KnobPosition, KnobPositions, LayerGroupDef, LayerGroups, NoteSettings, OverlayBounds,
-        ShortcutsState, SoundLibraryEntry, StatPosition, StatPositions, StatType, TabCss,
-        TabNoteSettings,
+        normalize_key_slot, AppStoreData, CounterAnimationPreset, CustomCss, CustomCssHistoryEntry,
+        CustomFont, CustomJs, CustomTab, FontType, GradientSpec, GraphPosition, GraphPositions,
+        GraphStatType, GraphType, GridSettings, JsPlugin, KeyCounters, KeyMappings, KeyPosition,
+        KeyPositions, KeySlot, KnobPosition, KnobPositions, LayerGroupDef, LayerGroups,
+        NoteSettings, OverlayBounds, ShortcutsState, SoundLibraryEntry, StatPosition,
+        StatPositions, StatType, TabCss, TabNoteSettings,
     },
 };
 
@@ -1075,7 +1075,7 @@ pub(crate) fn pad_key_position_lengths(
             );
             keys.entry(mode)
                 .or_default()
-                .resize(position_count, String::new());
+                .resize(position_count, KeySlot::default());
             changed = true;
         }
     }
@@ -1093,9 +1093,13 @@ fn key_position_lengths_mismatch(keys: &KeyMappings, positions: &KeyPositions) -
 fn merge_default_counters(target: &mut KeyCounters, keys: &KeyMappings) {
     for (mode, key_list) in keys.iter() {
         let entry = target.entry(mode.clone()).or_default();
-        entry.retain(|key, _| key_list.contains(key));
-        for key in key_list.iter() {
-            entry.entry(key.clone()).or_insert(0);
+        let canonical_keys = key_list
+            .iter()
+            .map(KeySlot::canonical)
+            .collect::<HashSet<_>>();
+        entry.retain(|key, _| canonical_keys.contains(key));
+        for key in canonical_keys {
+            entry.entry(key).or_insert(0);
         }
     }
 
@@ -1178,7 +1182,8 @@ fn repair_custom_tab_key_layout_pairs(
                     "[Store] Rebuilding invalid keys mode '{mode}' with {} unassigned entries during recovery",
                     positions.len()
                 );
-                data.keys.insert(mode, vec![String::new(); positions.len()]);
+                data.keys
+                    .insert(mode, vec![KeySlot::default(); positions.len()]);
                 repaired = true;
             }
             (Some(keys), None) => {
@@ -1312,15 +1317,9 @@ fn recover_key_mapping_entries(value: &Value) -> Option<Value> {
         let recovered_entries = match entries {
             Value::Array(entries) => entries
                 .iter()
-                .enumerate()
-                .map(|(index, entry)| match entry.as_str() {
-                    Some(key) => Value::String(key.to_string()),
-                    None => {
-                        log::warn!(
-                            "[Store] Replacing invalid keys entry '{mode}[{index}]' with an unassigned key during recovery"
-                        );
-                        Value::String(String::new())
-                    }
+                .map(|entry| {
+                    serde_json::to_value(normalize_key_slot(entry.clone()))
+                        .unwrap_or(Value::String(String::new()))
                 })
                 .collect(),
             _ => {
@@ -1329,7 +1328,11 @@ fn recover_key_mapping_entries(value: &Value) -> Option<Value> {
                 );
                 defaults
                     .get(mode)
-                    .map(|keys| keys.iter().cloned().map(Value::String).collect())
+                    .map(|keys| {
+                        keys.iter()
+                            .filter_map(|slot| serde_json::to_value(slot).ok())
+                            .collect()
+                    })
                     .unwrap_or_default()
             }
         };
@@ -1876,17 +1879,18 @@ struct LegacyOverlayPosition {
 mod tests {
     use super::{
         load_store_from_path, migrate_local_fonts_to_app_data, migrate_sound_library_enabled,
-        normalize_state, parse_portable_asset_reference, rehome_foreign_asset_references,
-        rgba_to_hex, AssetCategory, LEGACY_OVERLAY_HEIGHT, LEGACY_OVERLAY_WIDTH,
-        LEGACY_PANEL_DETACH_ENABLED_KEY,
+        normalize_state, parse_portable_asset_reference, recover_key_mapping_entries,
+        rehome_foreign_asset_references, rgba_to_hex, AssetCategory, LEGACY_OVERLAY_HEIGHT,
+        LEGACY_OVERLAY_WIDTH, LEGACY_PANEL_DETACH_ENABLED_KEY,
     };
     use crate::{
         defaults::{default_keys, default_positions},
         models::{
             AppStoreData, CustomCssHistoryEntry, CustomFont, CustomTab, FontType, GraphPosition,
             GraphStatType, GraphType, KeyCounterAlign, KeyCounterAlignMode, KeyCounterColor,
-            KeyCounterPlacement, KeyPosition, KnobPosition, LayerGroupDef, OverlayBounds,
-            SoundLibraryEntry, StatPosition, StatType, TabCss, TabNoteSettings,
+            KeyCounterPlacement, KeyMappings, KeyPosition, KeySlot, KnobPosition, LayerGroupDef,
+            OverlayBounds, SlotMatch, SoundLibraryEntry, StatPosition, StatType, TabCss,
+            TabNoteSettings,
         },
     };
     use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
@@ -2168,14 +2172,14 @@ mod tests {
     #[serde(rename_all = "camelCase")]
     struct HistoricalTauri13Store {
         #[serde(default)]
-        keys: crate::models::KeyMappings,
+        keys: std::collections::HashMap<String, Vec<String>>,
     }
 
     #[derive(Debug, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct HistoricalTauri14PlusStore {
         #[serde(default)]
-        keys: crate::models::KeyMappings,
+        keys: std::collections::HashMap<String, Vec<String>>,
         #[serde(default, flatten)]
         plugin_data: std::collections::HashMap<String, serde_json::Value>,
     }
@@ -2339,6 +2343,91 @@ mod tests {
     }
 
     #[test]
+    fn reverse_downgrade_multi_key_fixture_enters_legacy_recovery_path() {
+        let fixture = serde_json::json!({
+            "keys": {
+                "4key": [
+                    { "keys": ["A", "B"], "match": "any" },
+                    "C"
+                ]
+            }
+        });
+
+        assert!(serde_json::from_value::<HistoricalTauri13Store>(fixture.clone()).is_err());
+        assert!(serde_json::from_value::<HistoricalTauri14PlusStore>(fixture).is_err());
+    }
+
+    #[test]
+    fn key_mapping_recovery_normalizes_in_place_without_compacting_slots() {
+        let raw = serde_json::json!({
+            "mode": [
+                { "keys": ["A", "B"], "match": "any" },
+                { "keys": ["Z"], "match": "all" },
+                { "keys": ["A", 7, "A", "B+C", "C"], "match": "all" },
+                { "keys": ["A", "B"] },
+                null
+            ]
+        });
+
+        let recovered = recover_key_mapping_entries(&raw).unwrap();
+        let mappings: KeyMappings = serde_json::from_value(recovered).unwrap();
+
+        assert_eq!(mappings["mode"].len(), 5);
+        assert_eq!(
+            mappings["mode"],
+            vec![
+                KeySlot::Multi {
+                    keys: vec!["A".to_string(), "B".to_string()],
+                    match_mode: SlotMatch::Any,
+                },
+                KeySlot::Single("Z".to_string()),
+                KeySlot::Multi {
+                    keys: vec!["A".to_string(), "C".to_string()],
+                    match_mode: SlotMatch::All,
+                },
+                KeySlot::default(),
+                KeySlot::default(),
+            ]
+        );
+    }
+
+    #[test]
+    fn normalize_state_keeps_single_count_and_separates_any_all_counters() {
+        let keys = vec![
+            KeySlot::Single("A".to_string()),
+            KeySlot::Multi {
+                keys: vec!["A".to_string(), "B".to_string()],
+                match_mode: SlotMatch::Any,
+            },
+            KeySlot::Multi {
+                keys: vec!["A".to_string(), "B".to_string()],
+                match_mode: SlotMatch::All,
+            },
+        ];
+        let data = normalize_state(AppStoreData {
+            keys: KeyMappings::from([("4key".to_string(), keys)]),
+            key_positions: crate::models::KeyPositions::from([(
+                "4key".to_string(),
+                vec![KeyPosition::default(); 3],
+            )]),
+            key_counters: crate::models::KeyCounters::from([(
+                "4key".to_string(),
+                std::collections::HashMap::from([
+                    ("A".to_string(), 9),
+                    ("A|B".to_string(), 4),
+                    ("stale".to_string(), 7),
+                ]),
+            )]),
+            ..AppStoreData::default()
+        });
+
+        assert_eq!(data.key_counters["4key"]["A"], 9);
+        assert_eq!(data.key_counters["4key"]["A|B"], 4);
+        assert_eq!(data.key_counters["4key"]["A+B"], 0);
+        assert!(!data.key_counters["4key"].contains_key("stale"));
+    }
+
+    #[test]
     fn load_repairs_unsafe_editor_revision_without_touching_editor_data() {
         let path = std::env::temp_dir().join(format!(
             "dmnote-unsafe-editor-revision-{}.json",
@@ -2468,7 +2557,7 @@ mod tests {
             key_positions: default_positions().clone(),
             ..AppStoreData::default()
         };
-        data.keys.get_mut("4key").unwrap().push("F5".to_string());
+        data.keys.get_mut("4key").unwrap().push("F5".into());
         let preserved_position = KeyPosition {
             dx: 987.0,
             ..KeyPosition::default()
@@ -2477,10 +2566,8 @@ mod tests {
             .get_mut("5key")
             .unwrap()
             .push(preserved_position.clone());
-        data.keys.insert(
-            "keys-only".to_string(),
-            vec!["A".to_string(), "B".to_string()],
-        );
+        data.keys
+            .insert("keys-only".to_string(), vec!["A".into(), "B".into()]);
         data.key_positions.insert(
             "positions-only".to_string(),
             vec![preserved_position.clone()],
@@ -2499,7 +2586,7 @@ mod tests {
             loaded.data.key_positions["5key"].last().unwrap(),
             &preserved_position
         );
-        assert!(loaded.data.keys["5key"].last().unwrap().is_empty());
+        assert!(loaded.data.keys["5key"].last().unwrap().is_unassigned());
         assert_eq!(loaded.data.key_positions["keys-only"].len(), 2);
         assert_eq!(loaded.data.keys["positions-only"], vec![String::new()]);
 
@@ -3424,7 +3511,7 @@ mod tests {
         };
         fixture
             .keys
-            .insert("ghost-tab".to_string(), vec!["G".to_string()]);
+            .insert("ghost-tab".to_string(), vec!["G".into()]);
         std::fs::write(&path, serde_json::to_vec_pretty(&fixture).unwrap()).unwrap();
 
         let loaded = load_store_from_path(&path).unwrap();

--- a/src-tauri/src/state/store.rs
+++ b/src-tauri/src/state/store.rs
@@ -5870,7 +5870,7 @@ mod tests {
         assert_eq!(store.writer.persist_count(), persist_count + 1);
         let snapshot = store.snapshot();
         assert_eq!(snapshot.editor_revision, 1);
-        assert_eq!(snapshot.keys["4key"][0], "StrictKey");
+        assert_eq!(snapshot.keys["4key"][0], KeySlot::from("StrictKey"));
         assert_eq!(snapshot.key_counters["4key"]["StrictKey"], 0);
         assert!(!snapshot.key_counters["4key"].contains_key(&old_key));
         assert_eq!(change.history_status.unwrap().history_revision, 1);
@@ -5882,7 +5882,7 @@ mod tests {
             .unwrap()
             .data;
         assert_eq!(reloaded.editor_revision, 1);
-        assert_eq!(reloaded.keys["4key"][0], "StrictKey");
+        assert_eq!(reloaded.keys["4key"][0], KeySlot::from("StrictKey"));
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -7031,7 +7031,7 @@ mod tests {
         drop(barrier);
 
         let restored = store.snapshot();
-        assert_eq!(restored.keys["4key"][0], old_key);
+        assert_eq!(restored.keys["4key"][0].canonical(), old_key);
         assert_eq!(restored.key_counters, counters_after_commit);
 
         store.flush_and_shutdown().unwrap();
@@ -7451,7 +7451,10 @@ mod tests {
         let outcome = undo.join().unwrap();
 
         assert_eq!(outcome.change.unwrap().result.revision, 3);
-        assert_eq!(state.store.snapshot().keys[&mode][0], original_key);
+        assert_eq!(
+            state.store.snapshot().keys[&mode][0].canonical(),
+            original_key
+        );
         assert_eq!(state.snapshot_key_counters(), expected_counters);
         assert!(state.keyboard.register_key_down(&mode, &original_key));
         assert!(!state.keyboard.register_key_down(&mode, &legacy_key));
@@ -8052,7 +8055,7 @@ mod tests {
             .unwrap();
 
         let snapshot = store.snapshot();
-        assert_eq!(snapshot.keys["ghost"], vec!["GhostKey".to_string()]);
+        assert_eq!(snapshot.keys["ghost"], vec![KeySlot::from("GhostKey")]);
         assert_eq!(
             snapshot.key_positions["ghost"],
             vec![KeyPosition::default()]
@@ -8208,7 +8211,7 @@ mod tests {
         let keys = change.document.keys;
         let positions = change.document.key_positions;
         assert_eq!(store.writer.persist_count(), persist_count + 1);
-        assert_eq!(keys["4key"].last().unwrap(), "F5");
+        assert_eq!(keys["4key"].last().unwrap(), &KeySlot::from("F5"));
         assert_eq!(positions["4key"].last().unwrap(), &KeyPosition::default());
         assert!(keys["5key"].last().unwrap().is_unassigned());
         assert_eq!(keys["4key"].len(), positions["4key"].len());
@@ -9702,7 +9705,7 @@ mod tests {
         assert!(!store.skip_asset_sweep);
         let snapshot = store.snapshot();
         assert_eq!(snapshot.custom_tabs.len(), 1);
-        assert_eq!(snapshot.keys[tab_id], vec!["F5"]);
+        assert_eq!(snapshot.keys[tab_id], vec![KeySlot::from("F5")]);
         assert_eq!(snapshot.key_positions[tab_id].len(), 1);
         assert_eq!(snapshot.stat_positions[tab_id].len(), 1);
         assert_eq!(snapshot.graph_positions[tab_id].len(), 1);
@@ -9730,7 +9733,7 @@ mod tests {
         let reloaded = crate::state::migration::load_store_from_path(&store_path).unwrap();
         assert!(!reloaded.repaired);
         assert_eq!(reloaded.data.custom_tabs.len(), 1);
-        assert_eq!(reloaded.data.keys[tab_id], vec!["F5"]);
+        assert_eq!(reloaded.data.keys[tab_id], vec![KeySlot::from("F5")]);
         assert_eq!(reloaded.data.key_positions[tab_id].len(), 1);
         assert_eq!(reloaded.data.stat_positions[tab_id].len(), 1);
         assert_eq!(reloaded.data.graph_positions[tab_id].len(), 1);

--- a/src-tauri/src/state/store.rs
+++ b/src-tauri/src/state/store.rs
@@ -9,12 +9,12 @@ use std::{
 
 use crate::errors::{EditorCommitError, EditorCommitErrorCode};
 use crate::models::{
-    AppStoreData, CommittedEditorChange, CustomCssPatch, CustomJsPatch, EditorCommitOrigin,
-    EditorCommitRequest, EditorCommitResult, EditorCommittedV1, EditorDocumentV1, EditorField,
-    EditorGetResult, EditorTransactionResult, FontType, GestureCommitRequest, GestureCommitResult,
-    HistoryStatus, KeyCounters, KeyPosition, NoteSettingsPatch, PluginInstancesCommitRequest,
-    PluginInstancesReconcileRequest, SavedPluginInstance, SettingsDiff, SettingsPatchInput,
-    SettingsState, EDITOR_SCHEMA_VERSION,
+    key_mappings_contain_multi, normalize_key_mappings, AppStoreData, CommittedEditorChange,
+    CustomCssPatch, CustomJsPatch, EditorCommitOrigin, EditorCommitRequest, EditorCommitResult,
+    EditorCommittedV1, EditorDocumentV1, EditorField, EditorGetResult, EditorTransactionResult,
+    FontType, GestureCommitRequest, GestureCommitResult, HistoryStatus, KeyCounters, KeyPosition,
+    NoteSettingsPatch, PluginInstancesCommitRequest, PluginInstancesReconcileRequest,
+    SavedPluginInstance, SettingsDiff, SettingsPatchInput, SettingsState, EDITOR_SCHEMA_VERSION,
 };
 use anyhow::{anyhow, Context, Result};
 use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
@@ -804,9 +804,12 @@ impl AppStore {
 
     fn commit_editor_document_inner(
         &self,
-        request: EditorCommitRequest,
+        mut request: EditorCommitRequest,
         admission: &HistoryAdmissionLease,
     ) -> std::result::Result<CommittedEditorChange, EditorCommitError> {
+        if let Some(keys) = request.changes.keys.as_mut() {
+            normalize_key_mappings(keys);
+        }
         validate_request_envelope(&request)?;
         let fingerprint = request_fingerprint(&request)?;
         let mut guard = self
@@ -840,6 +843,13 @@ impl AppStore {
             return Err(EditorCommitError::revision_conflict(
                 guard.data.editor_revision,
             ));
+        }
+
+        if request.changes.keys.is_some()
+            && key_mappings_contain_multi(&guard.data.keys)
+            && !request.multi_key
+        {
+            return Err(EditorCommitError::multi_key_unsupported());
         }
 
         let gesture_id = request.history_gesture_id();
@@ -2761,6 +2771,7 @@ fn editor_error_outcome(code: EditorCommitErrorCode) -> &'static str {
         EditorCommitErrorCode::TooManyGestureIds => "too_many_gesture_ids",
         EditorCommitErrorCode::InvalidGestureId => "invalid_gesture_id",
         EditorCommitErrorCode::PairedUpdateRequired => "paired_update_required",
+        EditorCommitErrorCode::MultiKeyUnsupported => "multi_key_unsupported",
         EditorCommitErrorCode::MutationIdReused => "mutation_id_reused",
         EditorCommitErrorCode::HistoryInProgress => "history_in_progress",
         EditorCommitErrorCode::HistoryEpochConflict => "history_epoch_conflict",
@@ -3991,11 +4002,11 @@ mod tests {
             AppStoreData, CommittedEditorChange, CustomCss, CustomFont, CustomTab,
             EditorCommitOrigin, EditorCommitRequest, EditorDocumentV1, EditorField, EditorPatchV1,
             FontSettings, FontType, GestureCommitRequest, GesturePluginInstancesChange,
-            GraphPosition, GraphStatType, GraphType, JsPlugin, KeyCounters, KeyPosition,
+            GraphPosition, GraphStatType, GraphType, JsPlugin, KeyCounters, KeyPosition, KeySlot,
             KnobPosition, OverlayBounds, PanelBounds, PendingProcessedWavReplacement,
             PluginInstancesCommitRequest, PluginInstancesReconcileRequest, PluginPoint,
-            SavedPluginInstance, SettingsPatchInput, SoundLibraryEntry, SoundSource, StatPosition,
-            StatType, TabCss, TabNoteSettings,
+            SavedPluginInstance, SettingsPatchInput, SlotMatch, SoundLibraryEntry, SoundSource,
+            StatPosition, StatType, TabCss, TabNoteSettings,
         },
         services::{css_watcher::commit_css_reload, settings::apply_patch_to_store},
         state::{
@@ -4102,6 +4113,7 @@ mod tests {
         EditorCommitRequest {
             base_revision,
             mutation_id: mutation_id.into(),
+            multi_key: false,
             gesture_id: None,
             gesture_ids: Vec::new(),
             changes,
@@ -5822,9 +5834,9 @@ mod tests {
         let store = AppStore::initialize_in_dir(&dir).unwrap();
         let persist_count = store.writer.persist_count();
         let before = store.snapshot();
-        let old_key = before.keys["4key"][0].clone();
+        let old_key = before.keys["4key"][0].canonical();
         let mut keys = before.keys.clone();
-        keys.get_mut("4key").unwrap()[0] = "StrictKey".to_string();
+        keys.get_mut("4key").unwrap()[0] = "StrictKey".into();
         let first_gesture_id = uuid::Uuid::new_v4().to_string();
         let gesture_id = uuid::Uuid::new_v4().to_string();
         let mut request = editor_request(
@@ -5871,6 +5883,79 @@ mod tests {
             .data;
         assert_eq!(reloaded.editor_revision, 1);
         assert_eq!(reloaded.keys["4key"][0], "StrictKey");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn strict_editor_commit_rechecks_multi_key_capability_under_store_lock() {
+        let dir = test_directory("multi-key-capability-gate-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = AppStore::initialize_in_dir(&dir).unwrap();
+        let initial = store.editor_get().document;
+
+        let mut legacy_keys = initial.keys.clone();
+        legacy_keys.get_mut("4key").unwrap()[0] = KeySlot::Single("Legacy".to_string());
+        let legacy_request = editor_request(
+            1,
+            uuid::Uuid::new_v4().to_string(),
+            EditorPatchV1 {
+                keys: Some(legacy_keys),
+                ..EditorPatchV1::default()
+            },
+        );
+
+        let mut multi_keys = initial.keys;
+        multi_keys.get_mut("4key").unwrap()[0] = KeySlot::Multi {
+            keys: vec!["A".to_string(), "B".to_string()],
+            match_mode: SlotMatch::Any,
+        };
+        let mut capable_request = editor_request(
+            0,
+            uuid::Uuid::new_v4().to_string(),
+            EditorPatchV1 {
+                keys: Some(multi_keys),
+                ..EditorPatchV1::default()
+            },
+        );
+        capable_request.multi_key = true;
+        store.commit_editor_document(capable_request).unwrap();
+        let committed_keys = serde_json::to_vec(&store.snapshot().keys).unwrap();
+        let committed_disk = std::fs::read(dir.join("store.json")).unwrap();
+        let persist_count = store.writer.persist_count();
+
+        let error = store.commit_editor_document(legacy_request).unwrap_err();
+
+        assert_eq!(error.error_code, EditorCommitErrorCode::MultiKeyUnsupported);
+        assert_eq!(
+            serde_json::to_value(&error).unwrap()["errorCode"],
+            "MULTI_KEY_UNSUPPORTED"
+        );
+        assert!(!error.retryable);
+        assert_eq!(store.snapshot().editor_revision, 1);
+        assert_eq!(
+            serde_json::to_vec(&store.snapshot().keys).unwrap(),
+            committed_keys
+        );
+        assert_eq!(store.writer.persist_count(), persist_count);
+        assert_eq!(
+            std::fs::read(dir.join("store.json")).unwrap(),
+            committed_disk
+        );
+
+        let position_change = store
+            .commit_editor_document(editor_request(
+                1,
+                uuid::Uuid::new_v4().to_string(),
+                position_patch(&store, 321.0),
+            ))
+            .unwrap();
+        assert_eq!(position_change.result.revision, 2);
+        assert_eq!(
+            serde_json::to_vec(&store.snapshot().keys).unwrap(),
+            committed_keys
+        );
+
+        store.flush_and_shutdown().unwrap();
         let _ = std::fs::remove_dir_all(dir);
     }
 
@@ -6541,7 +6626,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let store = AppStore::initialize_in_dir(&dir).unwrap();
         let mode = store.snapshot().selected_key_type;
-        let original_key = store.snapshot().keys[&mode][0].clone();
+        let original_key = store.snapshot().keys[&mode][0].canonical();
         let initial_plugin = JsPlugin {
             id: "initial-plugin".to_string(),
             name: "Initial Plugin".to_string(),
@@ -6628,7 +6713,7 @@ mod tests {
                 &[EditorField::Keys],
                 runtime_counters,
                 |data| {
-                    data.keys.get_mut(&mode).unwrap()[0] = preset_key.clone();
+                    data.keys.get_mut(&mode).unwrap()[0] = preset_key.clone().into();
                     data.use_custom_css = true;
                     data.custom_css = CustomCss {
                         path: Some(dir.join("preset.css").to_string_lossy().to_string()),
@@ -6914,10 +6999,10 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let store = AppStore::initialize_in_dir(&dir).unwrap();
         let before = store.snapshot();
-        let old_key = before.keys["4key"][0].clone();
+        let old_key = before.keys["4key"][0].canonical();
         let new_key = "HistoryCounterScopeKey".to_string();
         let mut keys = before.keys;
-        keys.get_mut("4key").unwrap()[0] = new_key.clone();
+        keys.get_mut("4key").unwrap()[0] = new_key.clone().into();
         let commit = editor_request(
             0,
             uuid::Uuid::new_v4().to_string(),
@@ -7251,10 +7336,10 @@ mod tests {
             Arc::new(AppState::initialize(AppStore::initialize_in_dir(&dir).unwrap()).unwrap());
         let initial = state.store.snapshot();
         let mode = initial.selected_key_type.clone();
-        let original_key = initial.keys[&mode][0].clone();
+        let original_key = initial.keys[&mode][0].canonical();
 
         let mut strict_keys = initial.keys.clone();
-        strict_keys.get_mut(&mode).unwrap()[0] = "StrictHistoryKey".to_string();
+        strict_keys.get_mut(&mode).unwrap()[0] = "StrictHistoryKey".into();
         state
             .store
             .commit_editor_document(editor_request(
@@ -7269,7 +7354,7 @@ mod tests {
 
         let legacy_key = "LegacyPublishedKey".to_string();
         let mut legacy_keys = state.store.snapshot().keys;
-        legacy_keys.get_mut(&mode).unwrap()[0] = legacy_key.clone();
+        legacy_keys.get_mut(&mode).unwrap()[0] = legacy_key.clone().into();
         let transaction = state
             .store
             .commit_legacy_editor_transaction(
@@ -7391,10 +7476,10 @@ mod tests {
         let state = AppState::initialize(AppStore::initialize_in_dir(&dir).unwrap()).unwrap();
         let initial = state.store.snapshot();
         let mode = initial.selected_key_type.clone();
-        let old_key = initial.keys[&mode][0].clone();
+        let old_key = initial.keys[&mode][0].canonical();
         let new_key = "PublicationOrderedKey".to_string();
         let mut changed_keys = initial.keys;
-        changed_keys.get_mut(&mode).unwrap()[0] = new_key.clone();
+        changed_keys.get_mut(&mode).unwrap()[0] = new_key.clone().into();
 
         let stale_transaction = state
             .store
@@ -7438,6 +7523,8 @@ mod tests {
 
         assert_eq!(state.snapshot_key_counters()[&mode][&new_key], 9);
         assert_eq!(state.store.snapshot().key_counters[&mode][&new_key], 9);
+        assert_eq!(state.keyboard.pressed_keys(), vec![new_key.clone()]);
+        assert!(state.keyboard.register_key_up(&mode, &new_key));
         assert!(state.keyboard.register_key_down(&mode, &new_key));
         assert!(!state.keyboard.register_key_down(&mode, &old_key));
         assert!(events.lock().unwrap().is_empty());
@@ -7727,7 +7814,7 @@ mod tests {
         let store = AppStore::initialize_in_dir(&dir).unwrap();
         let before = store.snapshot();
         let mut keys = before.keys.clone();
-        keys.get_mut("4key").unwrap().push("F5".to_string());
+        keys.get_mut("4key").unwrap().push("F5".into());
         let error = store
             .commit_editor_document(editor_request(
                 0,
@@ -7951,7 +8038,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let mut data = super::initialize_default_state();
         data.keys
-            .insert("ghost".to_string(), vec!["GhostKey".to_string()]);
+            .insert("ghost".to_string(), vec!["GhostKey".into()]);
         data.key_positions
             .insert("ghost".to_string(), vec![KeyPosition::default()]);
         let store = AppStore::new(dir.join("store.json"), data, false).unwrap();
@@ -8033,8 +8120,7 @@ mod tests {
                         id: custom_mode.clone(),
                         name: "Custom".to_string(),
                     });
-                    data.keys
-                        .insert(custom_mode.clone(), vec!["KeyA".to_string()]);
+                    data.keys.insert(custom_mode.clone(), vec!["KeyA".into()]);
                     data.key_positions
                         .insert(custom_mode.clone(), vec![KeyPosition::default()]);
                     data.selected_key_type = custom_mode.clone();
@@ -8082,8 +8168,8 @@ mod tests {
         let before = store.snapshot();
         let disk_before = std::fs::read(dir.join("store.json")).unwrap();
         let mut mappings = before.keys.clone();
-        mappings.get_mut("4key").unwrap().push("F5".to_string());
-        mappings.get_mut("5key").unwrap().push(String::new());
+        mappings.get_mut("4key").unwrap().push("F5".into());
+        mappings.get_mut("5key").unwrap().push(KeySlot::default());
         let mut positions = before.key_positions.clone();
         positions
             .get_mut("4key")
@@ -8124,7 +8210,7 @@ mod tests {
         assert_eq!(store.writer.persist_count(), persist_count + 1);
         assert_eq!(keys["4key"].last().unwrap(), "F5");
         assert_eq!(positions["4key"].last().unwrap(), &KeyPosition::default());
-        assert!(keys["5key"].last().unwrap().is_empty());
+        assert!(keys["5key"].last().unwrap().is_unassigned());
         assert_eq!(keys["4key"].len(), positions["4key"].len());
         assert_eq!(keys["5key"].len(), positions["5key"].len());
 
@@ -8141,7 +8227,7 @@ mod tests {
 
         let before = store.snapshot();
         let mut mappings = before.keys.clone();
-        mappings.get_mut("4key").unwrap().push("F5".to_string());
+        mappings.get_mut("4key").unwrap().push("F5".into());
         assert!(
             legacy_editor_commit(&store, &[EditorField::Keys], move |data| {
                 data.keys = mappings;
@@ -8305,7 +8391,7 @@ mod tests {
         let before_mode = state.keyboard.current_mode();
         let before_counters = state.snapshot_key_counters();
         let mut keys = before_store.keys.clone();
-        keys.get_mut("4key").unwrap()[0] = "PresetKey".to_string();
+        keys.get_mut("4key").unwrap()[0] = "PresetKey".into();
 
         state.store.writer.fail_next_persist();
         let result = state.store.commit_legacy_editor_transaction(
@@ -8766,7 +8852,7 @@ mod tests {
         let store = AppStore::initialize_in_dir(&dir).unwrap();
         let snapshot = store.snapshot();
         let mode = snapshot.selected_key_type.clone();
-        let key = snapshot.keys[&mode][0].clone();
+        let key = snapshot.keys[&mode][0].canonical();
         let mut counters = snapshot.key_counters;
         counters
             .entry(mode.clone())
@@ -8797,7 +8883,7 @@ mod tests {
         let store = AppStore::initialize_in_dir(&dir).unwrap();
         let snapshot = store.snapshot();
         let mode = snapshot.selected_key_type.clone();
-        let key = snapshot.keys[&mode][0].clone();
+        let key = snapshot.keys[&mode][0].canonical();
         store
             .update(|data| {
                 data.key_counter_enabled = true;
@@ -8879,7 +8965,7 @@ mod tests {
         let store = AppStore::initialize_in_dir(&dir).unwrap();
         let snapshot = store.snapshot();
         let mode = snapshot.selected_key_type.clone();
-        let key = snapshot.keys[&mode][0].clone();
+        let key = snapshot.keys[&mode][0].canonical();
         store
             .update(|data| {
                 data.key_counter_enabled = true;

--- a/src-tauri/src/state/store/gradient_real_data_simulation.rs
+++ b/src-tauri/src/state/store/gradient_real_data_simulation.rs
@@ -8,6 +8,7 @@ use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 
 use super::AppStore;
+use crate::models::KeySlot;
 use crate::{
     commands::preset::{
         load::read_preset_file_for_simulation, save::write_preset_file_for_simulation, PresetFile,
@@ -733,7 +734,7 @@ fn simulation_5_inline_legacy_preset_imports_without_gradients() {
         .expect("gradient-free legacy preset must pass the import parser");
     let imported = import_editor_preset(&directory.path().join("imported"), preset);
     let position = &imported.key_positions["4key"][0];
-    assert_eq!(imported.keys["4key"], vec!["KeyQ"]);
+    assert_eq!(imported.keys["4key"], vec![KeySlot::from("KeyQ")]);
     assert_eq!(position.background_color.as_deref(), Some("#123456"));
     assert_eq!(position.active_background_color.as_deref(), Some("#234567"));
     assert_eq!(position.border_color.as_deref(), Some("#345678"));

--- a/src/renderer/api/ipcShim.test.ts
+++ b/src/renderer/api/ipcShim.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 프로토콜 버전 스큐 경계: 서버가 PROTOCOL_MISMATCH를 보내면
+// 구 페이지처럼 조용한 재접속 루프에 빠지지 않고 즉시 종단되어야 함
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  sent: string[] = [];
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.onclose?.();
+  }
+}
+
+describe('ipcShim 프로토콜 불일치 처리', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+    FakeWebSocket.instances = [];
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('PROTOCOL_MISMATCH는 재접속 없이 즉시 종단 오류로 거부한다', async () => {
+    const { initIpcShim } = await import('./ipcShim');
+
+    const promise = initIpcShim('ws://127.0.0.1:34891', 'token');
+    const socket = FakeWebSocket.instances[0];
+    expect(socket).toBeDefined();
+
+    socket.onopen?.();
+    socket.onmessage?.({
+      data: JSON.stringify({
+        v: 2,
+        type: 'error',
+        seq: 0,
+        ts: 0,
+        payload: {
+          code: 'PROTOCOL_MISMATCH',
+          message: 'Unsupported protocol version',
+        },
+      }),
+    });
+
+    await expect(promise).rejects.toThrow('protocol mismatch');
+
+    // 서버가 연결을 닫아도 재접속 타이머가 생성되지 않아야 함
+    socket.onclose?.();
+    vi.advanceTimersByTime(10_000);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it('AUTH_FAILED도 동일하게 종단 처리를 유지한다', async () => {
+    const { initIpcShim } = await import('./ipcShim');
+
+    const promise = initIpcShim('ws://127.0.0.1:34891', 'bad-token');
+    const socket = FakeWebSocket.instances[0];
+
+    socket.onopen?.();
+    socket.onmessage?.({
+      data: JSON.stringify({
+        v: 2,
+        type: 'error',
+        seq: 0,
+        ts: 0,
+        payload: { code: 'AUTH_FAILED', message: 'Invalid token' },
+      }),
+    });
+
+    await expect(promise).rejects.toThrow('auth failed');
+
+    socket.onclose?.();
+    vi.advanceTimersByTime(10_000);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/src/renderer/api/ipcShim.ts
+++ b/src/renderer/api/ipcShim.ts
@@ -325,11 +325,21 @@ export function initIpcShim(wsUrl: string, token: string): Promise<void> {
 
         if (envelope.type === 'error') {
           const payload = envelope.payload as Record<string, unknown>;
-          if (payload?.code === 'AUTH_FAILED') {
+          // 종단 오류: 재접속으로 해소되지 않으므로 재시도 없이 즉시 중단
+          if (
+            payload?.code === 'AUTH_FAILED' ||
+            payload?.code === 'PROTOCOL_MISMATCH'
+          ) {
             disposed = true;
             if (!resolved) {
               resolved = true;
-              reject(new Error('OBS auth failed'));
+              reject(
+                new Error(
+                  payload.code === 'AUTH_FAILED'
+                    ? 'OBS auth failed'
+                    : 'OBS protocol mismatch - refresh the browser source',
+                ),
+              );
             }
           }
           return;

--- a/src/renderer/api/modules/editorApi.ts
+++ b/src/renderer/api/modules/editorApi.ts
@@ -16,21 +16,29 @@ import type {
   EditorGetResult,
 } from '@src/types/editor';
 
+// envelope 무가공 전송. 플러그인 게이트웨이 전용 - multiKey 기본값을 주입하지
+// 않아 플러그인이 선언한 값만 백엔드 게이트에 도달한다 (계약 §10)
+export const editorCommitRaw = async (
+  request: EditorCommitRequest,
+): Promise<EditorCommitResult> => {
+  if (window.__dmn_runtime === 'obs') throw new EditorReadOnlyError();
+  assertSafeEditorRevision(request.baseRevision, 'baseRevision');
+  const result = await invoke<EditorCommitResult>('editor_commit', {
+    request,
+  });
+  assertEditorCommitResult(result);
+  return result;
+};
+
 export const editorApi = {
   get: async (): Promise<EditorGetResult> => {
     const result = await invoke<EditorGetResult>('editor_get');
     assertEditorGetResult(result);
     return result;
   },
-  commit: async (request: EditorCommitRequest): Promise<EditorCommitResult> => {
-    if (window.__dmn_runtime === 'obs') throw new EditorReadOnlyError();
-    assertSafeEditorRevision(request.baseRevision, 'baseRevision');
-    const result = await invoke<EditorCommitResult>('editor_commit', {
-      request,
-    });
-    assertEditorCommitResult(result);
-    return result;
-  },
+  // 자사 표면: 멀티 키 지원을 항상 선언 (명시값이 있으면 그 값 우선, 계약 §10)
+  commit: (request: EditorCommitRequest): Promise<EditorCommitResult> =>
+    editorCommitRaw({ multiKey: true, ...request }),
   onCommitted: (listener: (event: EditorCommittedV1) => void) =>
     subscribe<EditorCommittedV1>('editor:committed', (event) => {
       try {

--- a/src/renderer/api/modules/keysApi.ts
+++ b/src/renderer/api/modules/keysApi.ts
@@ -84,6 +84,8 @@ export const updatePositionsWithGesture = (
 export const keysApi = {
   get: () => invoke<KeyMappings>('keys_get'),
   getCounters: () => invoke<KeyCounters>('keys_get_counters'),
+  // 자사 UI 전용 경로. 플러그인 발신 keys 쓰기는 플러그인 프록시가
+  // pluginWriteGateway로 별도 라우팅한다 (계약 §10)
   update: (mappings: KeyMappings) =>
     enqueueEditorCompatibilityWrite(
       () => editorCoordinator.commitPatch({ schemaVersion: 1, keys: mappings }),

--- a/src/renderer/components/main/Grid/PropertiesPanel.detachedContracts.test.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel.detachedContracts.test.tsx
@@ -8,6 +8,7 @@ import { useKnobItemStore } from '@stores/data/useKnobItemStore';
 import { useStatItemStore } from '@stores/data/useStatItemStore';
 import { useGridSelectionStore } from '@stores/grid/useGridSelectionStore';
 import { usePropertiesPanelStore } from '@stores/grid/usePropertiesPanelStore';
+import { useKeySlotCapture } from '@hooks/useKeySlotCapture';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -459,31 +460,38 @@ describe('PropertiesPanel plugin settings Escape contract', () => {
   });
 });
 
-describe('PropertiesPanel key mapping listening contract', () => {
-  let mounted: MountedPanel;
+describe('useKeySlotCapture listening contract', () => {
   let originalApi: typeof window.api;
   let rawListener: ((payload: Record<string, unknown>) => void) | null;
   let rawUnsubscribe: ReturnType<typeof vi.fn>;
-  let onKeyMappingChange: ReturnType<
-    typeof vi.fn<(index: number, newKey: string) => void>
+  let onCapture: ReturnType<
+    typeof vi.fn<(globalKey: string, listenIndex: number | null) => void>
   >;
+  let harness: { root: Root; container: HTMLDivElement };
+  let latest: {
+    isListening: boolean;
+    startListen: (index: number | null) => void;
+  } | null;
+
+  const CaptureHarness = () => {
+    // 캡처 훅 상태를 테스트에서 관찰하기 위한 최소 하네스
+    const capture = useKeySlotCapture({ onCapture, escapeCancels: true });
+    React.useEffect(() => {
+      latest = capture;
+    });
+    return null;
+  };
 
   const startListening = () => {
-    const props = singleKeyStatPropsMock.mock.lastCall?.[0] as {
-      handleKeyListen: () => void;
-    };
-    act(() => props.handleKeyListen());
-    expect(
-      (singleKeyStatPropsMock.mock.lastCall?.[0] as { isListening: boolean })
-        .isListening,
-    ).toBe(true);
+    act(() => latest?.startListen(null));
+    expect(latest?.isListening).toBe(true);
   };
 
   beforeEach(() => {
-    resetStores();
     rawListener = null;
     rawUnsubscribe = vi.fn();
-    onKeyMappingChange = vi.fn<(index: number, newKey: string) => void>();
+    onCapture =
+      vi.fn<(globalKey: string, listenIndex: number | null) => void>();
     originalApi = window.api;
     window.api = {
       ...originalApi,
@@ -496,31 +504,21 @@ describe('PropertiesPanel key mapping listening contract', () => {
       },
     } as typeof window.api;
 
-    const position = {
-      dx: 0,
-      dy: 0,
-      width: 60,
-      height: 60,
-    } as never;
-    useKeyStore.setState({
-      keyMappings: { '4key': ['Z'] },
-      positions: { '4key': [position] },
-      canonicalPositions: { '4key': [position] },
-    });
-    useGridSelectionStore.setState({
-      selectedElements: [{ type: 'key', id: 'key-0', index: 0 }],
-      selectedGroupIds: [],
-    });
-    mounted = mountPanel(true, onKeyMappingChange);
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => root.render(<CaptureHarness />));
+    harness = { root, container };
   });
 
   afterEach(() => {
-    act(() => mounted.root.unmount());
-    mounted.container.remove();
+    act(() => harness.root.unmount());
+    harness.container.remove();
     window.api = originalApi;
+    latest = null;
   });
 
-  it('plain Escape cancels listening without changing the mapping', () => {
+  it('plain Escape cancels listening without capturing', () => {
     startListening();
     const event = new KeyboardEvent('keydown', {
       key: 'Escape',
@@ -531,11 +529,8 @@ describe('PropertiesPanel key mapping listening contract', () => {
     act(() => window.dispatchEvent(event));
 
     expect(event.defaultPrevented).toBe(true);
-    expect(onKeyMappingChange).not.toHaveBeenCalled();
-    expect(
-      (singleKeyStatPropsMock.mock.lastCall?.[0] as { isListening: boolean })
-        .isListening,
-    ).toBe(false);
+    expect(onCapture).not.toHaveBeenCalled();
+    expect(latest?.isListening).toBe(false);
     expect(rawUnsubscribe).toHaveBeenCalledOnce();
   });
 
@@ -551,14 +546,11 @@ describe('PropertiesPanel key mapping listening contract', () => {
       }),
     );
 
-    expect(onKeyMappingChange).not.toHaveBeenCalled();
-    expect(
-      (singleKeyStatPropsMock.mock.lastCall?.[0] as { isListening: boolean })
-        .isListening,
-    ).toBe(false);
+    expect(onCapture).not.toHaveBeenCalled();
+    expect(latest?.isListening).toBe(false);
   });
 
-  it('assigns one normal raw key and stops listening', () => {
+  it('captures one normal raw key and stops listening', () => {
     startListening();
 
     act(() =>
@@ -570,11 +562,25 @@ describe('PropertiesPanel key mapping listening contract', () => {
       }),
     );
 
-    expect(onKeyMappingChange).toHaveBeenCalledOnce();
-    expect(onKeyMappingChange).toHaveBeenCalledWith(0, 'A');
-    expect(
-      (singleKeyStatPropsMock.mock.lastCall?.[0] as { isListening: boolean })
-        .isListening,
-    ).toBe(false);
+    expect(onCapture).toHaveBeenCalledOnce();
+    expect(onCapture).toHaveBeenCalledWith('A', null);
+    expect(latest?.isListening).toBe(false);
+  });
+
+  it('captures into a replace target index', () => {
+    act(() => latest?.startListen(1));
+    expect(latest?.isListening).toBe(true);
+
+    act(() =>
+      rawListener?.({
+        label: 'B',
+        labels: ['B'],
+        state: 'DOWN',
+        device: 'keyboard',
+      }),
+    );
+
+    expect(onCapture).toHaveBeenCalledWith('B', 1);
+    expect(latest?.isListening).toBe(false);
   });
 });

--- a/src/renderer/components/main/Grid/PropertiesPanel.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel.tsx
@@ -40,12 +40,12 @@ import type {
   PluginSettingSchema,
   PluginMessages,
   PluginDefinitionInternal,
-  RawInputPayload,
 } from '@src/types/plugin/api';
 import {
   createDefaultCounterSettings,
   normalizeCounterSettings,
 } from '@src/types/key/keys';
+import { slotCanonical, slotDisplayName } from '@utils/keySlot';
 import { useLenis } from '@hooks/useLenis';
 import { editGestureController } from '@src/renderer/editor/runtime/editGestureController';
 import { isHistoryEditorFlushLocked } from '@src/renderer/editor/runtime/historyEditorFlushLock';
@@ -319,13 +319,22 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
     singleKeyIndex !== null
       ? positions[selectedKeyType]?.[singleKeyIndex]
       : null;
-  const singleKeyCode =
+  const singleKeySlot =
     singleKeyIndex !== null
-      ? keyMappings[selectedKeyType]?.[singleKeyIndex]
+      ? keyMappings[selectedKeyType]?.[singleKeyIndex] ?? null
       : null;
-  const singleKeyInfo = singleKeyCode
-    ? getKeyInfoByGlobalKey(singleKeyCode)
-    : null;
+  const singleKeyCode =
+    singleKeySlot != null ? slotCanonical(singleKeySlot) : null;
+  const singleKeyInfo =
+    singleKeySlot != null && singleKeyCode
+      ? typeof singleKeySlot === 'string'
+        ? getKeyInfoByGlobalKey(singleKeySlot)
+        : {
+            browserKey: singleKeyCode,
+            globalKey: singleKeyCode,
+            displayName: slotDisplayName(singleKeySlot),
+          }
+      : null;
 
   // 단일 통계 요소 선택인 경우의 데이터
   const singleStatIndex =
@@ -419,13 +428,6 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
   const renameCancelledRef = useRef(false);
   const renameRequestSignal = usePropertiesPanelStore(
     (state) => state.renameRequestSignal,
-  );
-
-  // 키 리스닝 상태
-  const [isListening, setIsListening] = useState(false);
-  const justAssignedRef = useRef(false);
-  const listeningFlagTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
   );
 
   // 이미지 픽커 상태
@@ -934,7 +936,6 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
     setShowImagePicker(false);
     setShowGraphImagePicker(false);
     setShowBatchImagePicker(false);
-    setIsListening(false);
     closePage();
   }, [
     singleKeyIndex,
@@ -1052,132 +1053,6 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
     selectedElements.length,
     setIsPanelVisible,
   ]);
-
-  // 키 리스닝 상태를 전역으로 노출
-  useEffect(() => {
-    if (listeningFlagTimerRef.current !== null) {
-      clearTimeout(listeningFlagTimerRef.current);
-      listeningFlagTimerRef.current = null;
-    }
-
-    if (isListening) {
-      window.__dmn_isKeyListening = true;
-    } else {
-      listeningFlagTimerRef.current = setTimeout(() => {
-        window.__dmn_isKeyListening = false;
-        listeningFlagTimerRef.current = null;
-      }, 150);
-    }
-
-    return () => {
-      if (listeningFlagTimerRef.current !== null) {
-        clearTimeout(listeningFlagTimerRef.current);
-        listeningFlagTimerRef.current = null;
-      }
-    };
-  }, [isListening]);
-
-  // 컴포넌트 언마운트 시 반드시 플래그 해제
-  useEffect(() => {
-    return () => {
-      window.__dmn_isKeyListening = false;
-      if (listeningFlagTimerRef.current !== null) {
-        clearTimeout(listeningFlagTimerRef.current);
-        listeningFlagTimerRef.current = null;
-      }
-    };
-  }, []);
-
-  // 키 리스닝 중 브라우저 기본 동작 차단
-  useEffect(() => {
-    if (!isListening) return undefined;
-
-    const blockKeyboardEvents = (e: KeyboardEvent) => {
-      if (
-        e.key === 'Escape' &&
-        !e.metaKey &&
-        !e.ctrlKey &&
-        !e.altKey &&
-        !e.shiftKey
-      ) {
-        e.preventDefault();
-        e.stopPropagation();
-        setIsListening(false);
-        return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-    };
-
-    const blockMouseEvents = (e: MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-    };
-
-    const blockContextMenu = (e: Event) => {
-      e.preventDefault();
-      e.stopPropagation();
-    };
-
-    window.addEventListener('keydown', blockKeyboardEvents, true);
-    window.addEventListener('keyup', blockKeyboardEvents, true);
-    window.addEventListener('keypress', blockKeyboardEvents, true);
-    window.addEventListener('mousedown', blockMouseEvents, true);
-    window.addEventListener('contextmenu', blockContextMenu, true);
-
-    return () => {
-      window.removeEventListener('keydown', blockKeyboardEvents, true);
-      window.removeEventListener('keyup', blockKeyboardEvents, true);
-      window.removeEventListener('keypress', blockKeyboardEvents, true);
-      window.removeEventListener('mousedown', blockMouseEvents, true);
-      window.removeEventListener('contextmenu', blockContextMenu, true);
-    };
-  }, [isListening]);
-
-  // 키 리스닝 effect
-  useEffect(() => {
-    if (!isListening) return undefined;
-    if (typeof window === 'undefined' || !window.api?.keys?.onRawInput) {
-      return undefined;
-    }
-
-    const unsubscribe = window.api.keys.onRawInput(
-      (payload: RawInputPayload) => {
-        if (isHistoryEditorFlushLocked()) return;
-        if (!payload || payload.state !== 'DOWN') return;
-        const targetLabel =
-          payload.label ||
-          (Array.isArray(payload.labels) ? payload.labels[0] : null);
-        if (!targetLabel) return;
-
-        const info = getKeyInfoByGlobalKey(targetLabel);
-
-        if (info.globalKey === 'ESCAPE') {
-          setIsListening(false);
-          return;
-        }
-
-        justAssignedRef.current = true;
-        setTimeout(() => {
-          justAssignedRef.current = false;
-        }, 100);
-
-        setIsListening(false);
-
-        if (singleKeyIndex !== null && onKeyMappingChange) {
-          onKeyMappingChange(singleKeyIndex, info.globalKey);
-        }
-      },
-    );
-
-    return () => {
-      try {
-        unsubscribe?.();
-      } catch (error) {
-        console.error('Failed to unsubscribe raw input listener', error);
-      }
-    };
-  }, [isListening, singleKeyIndex, onKeyMappingChange]);
 
   // ============================================================================
   // 핸들러
@@ -1316,11 +1191,6 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
     }
     handleTogglePanel();
   });
-
-  const handleKeyListen = () => {
-    if (justAssignedRef.current) return;
-    setIsListening(true);
-  };
 
   const handleStatUpdate = (
     data: Partial<StatItemPosition> & { index: number },
@@ -1651,8 +1521,18 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
         const index = el.index!;
         if (el.type === 'key') {
           const position = positions[selectedKeyType]?.[index];
-          const keyCode = keyMappings[selectedKeyType]?.[index] ?? null;
-          const keyInfo = keyCode ? getKeyInfoByGlobalKey(keyCode) : null;
+          const slot = keyMappings[selectedKeyType]?.[index] ?? null;
+          const keyCode = slot != null ? slotCanonical(slot) : null;
+          const keyInfo =
+            slot != null && keyCode
+              ? typeof slot === 'string'
+                ? getKeyInfoByGlobalKey(slot)
+                : {
+                    browserKey: keyCode,
+                    globalKey: keyCode,
+                    displayName: slotDisplayName(slot),
+                  }
+              : null;
           return { index, position, keyCode, keyInfo };
         }
         const position = statItemPositions[selectedKeyType]?.[index];
@@ -1697,8 +1577,18 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
         const index = el.index!;
         if (el.type === 'key') {
           const position = positions[selectedKeyType]?.[index];
-          const keyCode = keyMappings[selectedKeyType]?.[index] ?? null;
-          const keyInfo = keyCode ? getKeyInfoByGlobalKey(keyCode) : null;
+          const slot = keyMappings[selectedKeyType]?.[index] ?? null;
+          const keyCode = slot != null ? slotCanonical(slot) : null;
+          const keyInfo =
+            slot != null && keyCode
+              ? typeof slot === 'string'
+                ? getKeyInfoByGlobalKey(slot)
+                : {
+                    browserKey: keyCode,
+                    globalKey: keyCode,
+                    displayName: slotDisplayName(slot),
+                  }
+              : null;
           return { index, position, keyCode, keyInfo };
         }
         if (el.type === 'stat') {
@@ -2910,6 +2800,7 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
         singleKeyPosition={singleKeyPosition}
         singleStatPosition={singleStatPosition}
         singleKeyCode={singleKeyCode}
+        singleKeySlot={singleKeySlot}
         singleKeyInfo={singleKeyInfo}
         selectedKeyType={selectedKeyType}
         isRenaming={isRenaming}
@@ -2928,8 +2819,6 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
         onKeyMappingChange={onKeyMappingChange}
         handleStatUpdate={handleStatUpdate}
         handleStatPreview={handleStatPreview}
-        isListening={isListening}
-        handleKeyListen={handleKeyListen}
         localState={localState}
         setLocalState={setLocalState}
         handleSizeBlur={handleSizeBlur}

--- a/src/renderer/components/main/Grid/PropertiesPanel/layer/layerPanelModel.ts
+++ b/src/renderer/components/main/Grid/PropertiesPanel/layer/layerPanelModel.ts
@@ -3,7 +3,7 @@
  * LayerTabContent에서 사용하는 layerItems / displayItems 생성
  */
 
-import { getKeyInfoByGlobalKey } from '@utils/core/KeyMaps';
+import { slotDisplayName } from '@utils/keySlot';
 import type { KeyMappings, KeyPositions } from '@src/types/key/keys';
 import type { StatItemPositions } from '@src/types/key/statItems';
 import type { GraphItemPositions } from '@src/types/key/graphItems';
@@ -41,9 +41,8 @@ export function buildLayerItems({
   const currentPositions = positions[selectedKeyType] || [];
   const currentKeyMappings = keyMappings[selectedKeyType] || [];
   currentPositions.forEach((pos, index) => {
-    const keyCode = currentKeyMappings[index] || '';
-    const keyInfo = keyCode ? getKeyInfoByGlobalKey(keyCode) : null;
-    const defaultName = keyInfo?.displayName || keyCode || `Key ${index + 1}`;
+    const slot = currentKeyMappings[index] ?? '';
+    const defaultName = slotDisplayName(slot) || `Key ${index + 1}`;
     items.push({
       type: 'key',
       id: `key-${index}`,

--- a/src/renderer/components/main/Grid/PropertiesPanel/single/SingleSelectionPanel.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/single/SingleSelectionPanel.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/refs */
 import React, { useEffect, useRef, useState } from 'react';
-import type { ImageFit, KeyPosition } from '@src/types/key/keys';
+import type { ImageFit, KeyPosition, KeySlot } from '@src/types/key/keys';
 import {
   STAT_BASE_OPTIONS,
   STAT_KPS_OPTIONS,
@@ -1503,6 +1503,7 @@ interface SingleKeyStatPanelProps {
   singleKeyPosition: KeyPosition | null;
   singleStatPosition: StatItemPosition | null;
   singleKeyCode: string | null;
+  singleKeySlot: KeySlot | null;
   singleKeyInfo: KeyInfo | null;
   selectedKeyType: string;
   isRenaming: boolean;
@@ -1518,7 +1519,7 @@ interface SingleKeyStatPanelProps {
   onPositionChange: (index: number, dx: number, dy: number) => void;
   onKeyUpdate: (data: Partial<KeyPosition> & { index: number }) => void;
   onKeyPreview?: (index: number, updates: Partial<KeyPosition>) => void;
-  onKeyMappingChange?: (index: number, newKey: string) => void;
+  onKeyMappingChange?: (index: number, newSlot: KeySlot) => void;
   handleStatUpdate: (
     data: Partial<StatItemPosition> & { index: number },
   ) => void;
@@ -1526,8 +1527,6 @@ interface SingleKeyStatPanelProps {
     index: number,
     updates: Partial<StatItemPosition>,
   ) => void;
-  isListening: boolean;
-  handleKeyListen: () => void;
   localState: Partial<KeyPosition> & { dx?: number; dy?: number };
   setLocalState: React.Dispatch<
     React.SetStateAction<Partial<KeyPosition> & { dx?: number; dy?: number }>
@@ -1551,6 +1550,7 @@ export const SingleKeyStatPanel: React.FC<SingleKeyStatPanelProps> = ({
   singleKeyPosition,
   singleStatPosition,
   singleKeyCode,
+  singleKeySlot,
   singleKeyInfo,
   selectedKeyType: _selectedKeyType,
   isRenaming,
@@ -1569,8 +1569,6 @@ export const SingleKeyStatPanel: React.FC<SingleKeyStatPanelProps> = ({
   onKeyMappingChange,
   handleStatUpdate,
   handleStatPreview,
-  isListening,
-  handleKeyListen,
   localState,
   setLocalState,
   handleSizeBlur,
@@ -1746,8 +1744,7 @@ export const SingleKeyStatPanel: React.FC<SingleKeyStatPanelProps> = ({
                 index: keyLikeIndex,
               }}
               onKeyMappingChange={isSingleStat ? undefined : onKeyMappingChange}
-              isListening={isListening}
-              onKeyListen={isSingleStat ? undefined : handleKeyListen}
+              keySlot={isSingleStat ? undefined : singleKeySlot}
               mappingControlLayout={mappingControlLayout}
               mappingLabel={
                 isSingleStat

--- a/src/renderer/components/main/Grid/PropertiesPanel/single/StyleTabContent.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/single/StyleTabContent.tsx
@@ -1,8 +1,18 @@
-/* eslint-disable react-hooks/set-state-in-effect */
 import React, { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import type { StyleTabContentProps } from '../types';
 import type { ImageFit, KeyPosition } from '@src/types/key/keys';
+import {
+  slotMembers,
+  slotUiMode,
+  slotCanonical,
+  buildSlot,
+  slotCompactParts,
+  MAX_SLOT_KEYS,
+} from '@utils/keySlot';
+import type { KeySlotUiMode } from '@utils/keySlot';
+import { useKeySlotCapture } from '@hooks/useKeySlotCapture';
+import KeySlotPicker from '@components/main/common/KeySlotPicker';
 import {
   PropertyRow,
   PropertySection,
@@ -89,9 +99,8 @@ const StyleTabContent: React.FC<StyleTabContentInternalProps> = ({
   onPositionChange,
   onKeyUpdate,
   onKeyPreview,
-  onKeyMappingChange: _onKeyMappingChange,
-  isListening = false,
-  onKeyListen,
+  onKeyMappingChange,
+  keySlot,
   mappingControl,
   mappingControlLayout,
   mappingLabel,
@@ -125,6 +134,79 @@ const StyleTabContent: React.FC<StyleTabContentInternalProps> = ({
 
   // 개별 편집 모드인지 확인 (로컬 상태 핸들러가 없으면 개별 편집 모드)
   const isIndividualMode = !onLocalDxChange;
+
+  // 키 슬롯 칩 에디터 (keySlot 제공 시에만 활성)
+  const slotEditable = keySlot != null && Boolean(onKeyMappingChange);
+  const members = keySlot != null ? slotMembers(keySlot) : [];
+  const slotIdentityKey = `${keyIndex}:${
+    keySlot != null ? slotCanonical(keySlot) : ''
+  }`;
+
+  // 입력 방식 - 멤버 1개에서 개별/동시를 고른 상태를 유지해야 하므로 로컬 소유,
+  // 선택 전환·undo 등 외부 변경 시에만 슬롯에서 재동기화
+  const [slotMode, setSlotMode] = useState<KeySlotUiMode>(() =>
+    keySlot != null ? slotUiMode(keySlot) : 'single',
+  );
+  useEffect(() => {
+    setSlotMode(keySlot != null ? slotUiMode(keySlot) : 'single');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slotIdentityKey]);
+
+  const commitMembers = (
+    nextMembers: string[],
+    mode: KeySlotUiMode = slotMode,
+  ) => {
+    const sliced = mode === 'single' ? nextMembers.slice(0, 1) : nextMembers;
+    onKeyMappingChange?.(
+      keyIndex,
+      buildSlot(sliced, mode === 'all' ? 'all' : 'any'),
+    );
+  };
+
+  // 입력 방식 변경 - 단일은 첫 키만 유지, 멤버 1개의 개별/동시는 로컬만
+  const handleSlotModeChange = (mode: KeySlotUiMode) => {
+    setSlotMode(mode);
+    if (mode === 'single') {
+      if (members.length > 1) commitMembers(members, 'single');
+    } else if (members.length >= 2) {
+      commitMembers(members, mode);
+    }
+  };
+
+  // 멀티 키 편집 팝업
+  const [slotPickerOpen, setSlotPickerOpen] = useState(false);
+  const slotEditButtonRef = useRef<HTMLButtonElement>(null);
+  const slotParts = slotCompactParts(
+    buildSlot(members, slotMode === 'all' ? 'all' : 'any'),
+  );
+
+  const {
+    isListening: slotListening,
+    listenIndex: slotListenIndex,
+    startListen: startSlotListen,
+    stopListen: stopSlotListen,
+  } = useKeySlotCapture({
+    escapeCancels: true,
+    onCapture: (captured, target) => {
+      const duplicateAt = members.indexOf(captured);
+      if (target !== null) {
+        // 리스닝 중 제거로 인덱스가 밀린 경우 방어
+        if (target >= members.length) return;
+        // 멤버 교체, 다른 자리에 이미 있는 키는 무시
+        if (duplicateAt !== -1 && duplicateAt !== target) return;
+        const next = [...members];
+        next[target] = captured;
+        commitMembers(next);
+      } else {
+        // 멤버 추가, 중복·상한 초과는 무시
+        if (duplicateAt !== -1 || members.length >= MAX_SLOT_KEYS) return;
+        // 단일 상태에서 키가 늘면 개별 판정으로 승격
+        const nextMode = slotMode === 'single' ? 'any' : slotMode;
+        if (nextMode !== slotMode) setSlotMode(nextMode);
+        commitMembers([...members, captured], nextMode);
+      }
+    },
+  });
   const hasIdleImage = Boolean(keyPosition.inactiveImage?.trim());
   const hasActiveImage = Boolean(
     keyPosition.activeImage?.trim() || keyPosition.inactiveImage?.trim(),
@@ -584,22 +666,79 @@ const StyleTabContent: React.FC<StyleTabContentInternalProps> = ({
             {mappingControl}
           </PropertyRow>
         </PropertySection>
-      ) : onKeyListen ? (
+      ) : slotEditable ? (
         <PropertySection>
           <PropertyRow label={t('propertiesPanel.keyMapping') || '키 매핑'}>
             <button
-              onClick={onKeyListen}
-              className={`flex items-center justify-center h-[23px] min-w-[0px] px-[8px] bg-fill hover:bg-fill-hover active:bg-fill-active transition-colors duration-fast rounded-md ${
-                isListening ? 'shadow-focus-ring' : ''
+              onClick={() =>
+                // 기존처럼 즉시 캡처 (멀티 슬롯이면 첫 키 교체)
+                startSlotListen(members.length === 0 ? null : 0)
+              }
+              className={`flex items-center justify-center h-[23px] min-w-[0px] max-w-[120px] px-[8px] bg-fill hover:bg-fill-hover active:bg-fill-active transition-colors duration-fast rounded-md ${
+                slotListening && !slotPickerOpen ? 'shadow-focus-ring' : ''
               } text-fg text-label`}
             >
-              {isListening
-                ? t('propertiesPanel.pressAnyKey') || 'Press any key'
-                : keyInfo?.displayName ||
-                  t('propertiesPanel.clickToSet') ||
-                  'Click to set'}
+              <span className="truncate">
+                {slotListening && !slotPickerOpen
+                  ? t('propertiesPanel.pressAnyKey') || 'Press any key'
+                  : slotParts.label ||
+                    t('propertiesPanel.clickToSet') ||
+                    'Click to set'}
+              </span>
+              {!(slotListening && !slotPickerOpen) && slotParts.extra && (
+                // case 피처: +를 숫자 중심에 맞춘 글리프로 치환.
+                // tracking은 +와 숫자 사이 0.25px 확보용, 끝 글자 뒤 여분은 -mr로 상쇄 (배지는 한 자리 전제)
+                <span className="pl-[3px] tracking-[0.25px] -mr-[0.25px] text-fg-faint [font-feature-settings:'case']">
+                  {slotParts.extra}
+                </span>
+              )}
             </button>
           </PropertyRow>
+
+          {/* 다중 키·판정 방식 편집 - 그림자 행과 같은 설정하기 패턴 */}
+          <PropertyRow
+            label={t('propertiesPanel.multiKey') || 'Mapping details'}
+          >
+            <button
+              ref={slotEditButtonRef}
+              onClick={() => setSlotPickerOpen((prev) => !prev)}
+              className={`px-[8px] h-[23px] bg-fill hover:bg-fill-hover active:bg-fill-active transition-colors duration-fast rounded-md flex items-center justify-center ${
+                slotPickerOpen ? 'shadow-focus-ring' : ''
+              } text-fg text-body`}
+            >
+              {t('propertiesPanel.configure') || '설정하기'}
+            </button>
+          </PropertyRow>
+
+          <KeySlotPicker
+            open={slotPickerOpen}
+            referenceRef={slotEditButtonRef}
+            panelElement={panelElement}
+            onClose={() => {
+              setSlotPickerOpen(false);
+              stopSlotListen();
+            }}
+            members={members}
+            mode={slotMode}
+            isListening={slotListening}
+            listenIndex={slotListenIndex}
+            onChipClick={(index) => startSlotListen(index)}
+            onAddClick={() => startSlotListen(null)}
+            onRemove={(index) => {
+              // 진행 중 리스닝 취소 후 제거 (인덱스 밀림 방어)
+              stopSlotListen();
+              commitMembers(members.filter((_, i) => i !== index));
+            }}
+            onModeChange={handleSlotModeChange}
+            labels={{
+              title: t('propertiesPanel.multiKeyEdit') || 'Multi-key',
+              modeAny: t('propertiesPanel.matchAny') || 'Individual',
+              modeAll: t('propertiesPanel.matchAll') || 'Combined',
+              pressAnyKey: t('propertiesPanel.pressAnyKey') || 'Press any key',
+              addKey: t('propertiesPanel.addKey') || 'Add key',
+              removeKey: t('propertiesPanel.removeKey') || 'Remove key',
+            }}
+          />
         </PropertySection>
       ) : null}
 

--- a/src/renderer/components/main/Grid/PropertiesPanel/types.ts
+++ b/src/renderer/components/main/Grid/PropertiesPanel/types.ts
@@ -1,4 +1,4 @@
-import type { KeyPosition } from '@src/types/key/keys';
+import type { KeyPosition, KeySlot } from '@src/types/key/keys';
 import type { ColorModeValue, GradientSpec } from '@src/types/color';
 import type {
   GradientCanvasAnchor,
@@ -34,7 +34,7 @@ export interface PropertiesPanelProps {
   onPositionChange: (index: number, dx: number, dy: number) => void;
   onKeyUpdate: (data: Partial<KeyPosition> & { index: number }) => void;
   onKeyPreview?: (index: number, updates: Partial<KeyPosition>) => void;
-  onKeyMappingChange?: (index: number, newKey: string) => void;
+  onKeyMappingChange?: (index: number, newSlot: KeySlot) => void;
 }
 
 export interface PropertyRowProps {
@@ -170,11 +170,10 @@ export interface SingleKeyContentProps {
   onPositionChange: (index: number, dx: number, dy: number) => void;
   onKeyUpdate: (data: Partial<KeyPosition> & { index: number }) => void;
   onKeyPreview?: (index: number, updates: Partial<KeyPosition>) => void;
-  onKeyMappingChange?: (index: number, newKey: string) => void;
+  onKeyMappingChange?: (index: number, newSlot: KeySlot) => void;
 
-  // 키 리스닝 상태 (옵션 - 개별 편집 모드에서는 사용하지 않음)
-  isListening?: boolean;
-  onKeyListen?: () => void;
+  // 편집 대상 슬롯 (칩 에디터용, 개별 편집 모드에서는 미사용)
+  keySlot?: KeySlot | null;
 
   // 이미지 픽커 상태 (옵션 - 개별 편집 모드에서는 사용하지 않음)
   showImagePicker?: boolean;
@@ -202,9 +201,9 @@ export interface StyleTabContentProps {
   onPositionChange: (index: number, dx: number, dy: number) => void;
   onKeyUpdate: (data: Partial<KeyPosition> & { index: number }) => void;
   onKeyPreview?: (index: number, updates: Partial<KeyPosition>) => void;
-  onKeyMappingChange?: (index: number, newKey: string) => void;
-  isListening?: boolean;
-  onKeyListen?: () => void;
+  onKeyMappingChange?: (index: number, newSlot: KeySlot) => void;
+  // 편집 대상 슬롯 (칩 에디터용)
+  keySlot?: KeySlot | null;
   // 키 매핑 UI를 대체하는 커스텀 컨트롤 (통계 요소 등)
   mappingControl?: React.ReactNode;
   // 키 매핑 영역을 통째로 대체하는 커스텀 레이아웃 (다중 라인 라벨 등)

--- a/src/renderer/components/main/Grid/core/Grid.tsx
+++ b/src/renderer/components/main/Grid/core/Grid.tsx
@@ -12,7 +12,6 @@ declare global {
 }
 import { useTranslation } from '@contexts/useTranslation';
 import DraggableKey from '@components/shared/Key';
-import { getKeyInfoByGlobalKey } from '@utils/core/KeyMaps';
 import GridKeySettingModal from './GridKeySettingModal';
 import TabCssModal from '../../Modal/content/editors/TabCssModal';
 import TabNoteSettingModal from '../../Modal/content/editors/TabNoteSettingModal';
@@ -1462,8 +1461,8 @@ const Grid = ({
         suppressDefault: Boolean(previewImage),
       }),
     );
-    const displayName =
-      getKeyInfoByGlobalKey(keyName)?.displayName || keyName || '';
+    // keyName은 호출부에서 slotDisplayName으로 합성된 표시 라벨
+    const displayName = keyName || '';
 
     // 키의 중심이 마우스에 위치하도록 오프셋 계산
     const offsetX = duplicateCursor.x - width / 2;
@@ -2101,7 +2100,7 @@ const Grid = ({
                 { confirmText: t('confirm.remove') },
               );
             } else if (id === 'duplicate') {
-              const keyCode = slotDisplayName(
+              const displayLabel = slotDisplayName(
                 keyMappings[selectedKeyType]?.[contextIndex] ?? '',
               );
               const position =
@@ -2141,7 +2140,7 @@ const Grid = ({
                 setDuplicateState({
                   elementType: 'key',
                   sourceIndex: contextIndex,
-                  keyName: keyCode,
+                  keyName: displayLabel,
                   position: {
                     ...position,
                     noteColor: clonedNoteColor,

--- a/src/renderer/components/main/Grid/core/Grid.tsx
+++ b/src/renderer/components/main/Grid/core/Grid.tsx
@@ -61,11 +61,13 @@ import type {
   KeyMappings,
   KeyPositions,
   KeyPosition,
+  KeySlot,
   NoteColor,
   KeyCounterSettings,
   CounterAnimationBezier,
   ImageFit,
 } from '@src/types/key/keys';
+import { slotCanonical, slotDisplayName } from '@utils/keySlot';
 import type { StatItemPosition } from '@src/types/key/statItems';
 import type { GraphItemPosition } from '@src/types/key/graphItems';
 import type { KnobItemPosition } from '@src/types/key/knobs';
@@ -110,7 +112,7 @@ type ToolbarAddRequest = {
 } | null;
 
 interface SelectedKeyInfo {
-  key: string;
+  key: KeySlot;
   index: number;
 }
 
@@ -945,7 +947,7 @@ const Grid = ({
           key={`${selectedKeyType}-${index}`}
           index={index}
           position={position}
-          keyName={keyMappings[selectedKeyType]?.[index] || ''}
+          keyName={slotDisplayName(keyMappings[selectedKeyType]?.[index] ?? '')}
           onPositionChange={onPositionChange}
           zIndex={position.zIndex ?? index}
           onClick={() => {
@@ -1128,9 +1130,8 @@ const Grid = ({
           onMultiDragEnd={commitSelectedElementsDrag}
           activeTool={activeTool}
           onEraserClick={() => {
-            const globalKey = keyMappings[selectedKeyType]?.[index] || '';
-            const displayName =
-              getKeyInfoByGlobalKey(globalKey)?.displayName || globalKey;
+            const slot = keyMappings[selectedKeyType]?.[index] ?? '';
+            const displayName = slotDisplayName(slot);
             showConfirm(
               t('confirm.removeKey', { name: displayName }),
               () => onKeyDelete(index),
@@ -2059,7 +2060,10 @@ const Grid = ({
                 positions[selectedKeyType]?.[contextIndex];
               if (!positionForContext) return;
               const context = {
-                keyCode: keyMappings[selectedKeyType]?.[contextIndex] || '',
+                // 플러그인 메뉴 표면은 canonical 문자열 유지
+                keyCode: slotCanonical(
+                  keyMappings[selectedKeyType]?.[contextIndex] ?? '',
+                ),
                 index: contextIndex,
                 position: positionForContext,
                 mode: selectedKeyType,
@@ -2089,18 +2093,17 @@ const Grid = ({
 
             // 기본 메뉴 처리
             if (id === 'delete') {
-              const globalKey =
-                keyMappings[selectedKeyType]?.[contextIndex] || '';
-              const displayName =
-                getKeyInfoByGlobalKey(globalKey)?.displayName || globalKey;
+              const slot = keyMappings[selectedKeyType]?.[contextIndex] ?? '';
+              const displayName = slotDisplayName(slot);
               showConfirm(
                 t('confirm.removeKey', { name: displayName }),
                 () => onKeyDelete(contextIndex),
                 { confirmText: t('confirm.remove') },
               );
             } else if (id === 'duplicate') {
-              const keyCode =
-                keyMappings[selectedKeyType]?.[contextIndex] || '';
+              const keyCode = slotDisplayName(
+                keyMappings[selectedKeyType]?.[contextIndex] ?? '',
+              );
               const position =
                 positions[selectedKeyType]?.[contextIndex] || null;
               if (position) {
@@ -2148,10 +2151,10 @@ const Grid = ({
                 setDuplicateCursor(initialCursor);
               }
             } else if (id === 'counterReset') {
-              const globalKey =
-                keyMappings[selectedKeyType]?.[contextIndex] || '';
-              const displayName =
-                getKeyInfoByGlobalKey(globalKey)?.displayName || globalKey;
+              const slot = keyMappings[selectedKeyType]?.[contextIndex] ?? '';
+              // 카운터 리셋 커맨드의 key 인자 = canonical (계약 §7)
+              const globalKey = slotCanonical(slot);
+              const displayName = slotDisplayName(slot);
               showConfirm(
                 t('confirm.resetKeyCounter', { name: displayName }),
                 async () => {

--- a/src/renderer/components/main/Grid/core/GridKeySettingModal.tsx
+++ b/src/renderer/components/main/Grid/core/GridKeySettingModal.tsx
@@ -5,6 +5,7 @@ import { editGestureController } from '@src/renderer/editor/runtime/editGestureC
 import type {
   KeyPosition,
   KeyCounterSettings,
+  KeySlot,
   NoteColor,
 } from '@src/types/key/keys';
 import type {
@@ -17,7 +18,7 @@ import type {
 // ============================================================================
 
 interface SelectedKeyInfo {
-  key: string;
+  key: KeySlot;
   index: number;
 }
 

--- a/src/renderer/components/main/Modal/content/settings/KeyTabContent.tsx
+++ b/src/renderer/components/main/Modal/content/settings/KeyTabContent.tsx
@@ -1,17 +1,20 @@
 import React, {
   useRef,
-  useEffect,
+  useState,
   useImperativeHandle,
   forwardRef,
 } from 'react';
 import { useTranslation } from '@contexts/useTranslation';
 import { useSettingsStore } from '@stores/useSettingsStore';
 import {
+  NumberInput,
   PropertyRow,
   PropertySection,
 } from '@components/main/Grid/PropertiesPanel/PropertyInputs';
-import { getKeyInfoByGlobalKey } from '@utils/core/KeyMaps';
-import { isHistoryEditorFlushLocked } from '@src/renderer/editor/runtime/historyEditorFlushLock';
+import { MAX_SLOT_KEYS, buildSlot, slotCompactParts } from '@utils/keySlot';
+import type { KeySlotUiMode } from '@utils/keySlot';
+import { useKeySlotCapture } from '@hooks/useKeySlotCapture';
+import KeySlotPicker from '@components/main/common/KeySlotPicker';
 import type {
   KeyTabState,
   KeyPreviewData,
@@ -40,10 +43,6 @@ const KeyTabContent = forwardRef<KeyTabContentRef, KeyTabContentProps>(
     const { t } = useTranslation();
     const { useCustomCSS } = useSettingsStore();
     const imageButtonRef = useRef<HTMLButtonElement>(null);
-    const justAssignedRef = useRef<boolean>(false);
-    const listeningFlagTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-      null,
-    );
 
     // ref를 통해 imageButtonRef 노출
     useImperativeHandle(
@@ -54,123 +53,70 @@ const KeyTabContent = forwardRef<KeyTabContentRef, KeyTabContentProps>(
       [],
     );
 
-    // 키 리스닝 플래그를 전역으로 노출 (Grid 단축키 등에서 체크)
-    useEffect(() => {
-      // 이전 타이머 정리
-      if (listeningFlagTimerRef.current !== null) {
-        clearTimeout(listeningFlagTimerRef.current);
-        listeningFlagTimerRef.current = null;
-      }
+    // 캡처 완료 시 멤버 교체 또는 추가 (중복·상한 초과는 무시)
+    const { isListening, listenIndex, startListen, stopListen } =
+      useKeySlotCapture({
+        escapeCancels: true,
+        onCapture: (captured, target) => {
+          setState((prev) => {
+            const members = [...prev.members];
+            const duplicateAt = members.indexOf(captured);
 
-      if (state.isListening) {
-        window.__dmn_isKeyListening = true;
-      } else {
-        // macOS: raw input이 브라우저 keydown보다 먼저 도착할 수 있어 지연 해제
-        listeningFlagTimerRef.current = setTimeout(() => {
-          window.__dmn_isKeyListening = false;
-          listeningFlagTimerRef.current = null;
-        }, 150);
-      }
-
-      return () => {
-        if (listeningFlagTimerRef.current !== null) {
-          clearTimeout(listeningFlagTimerRef.current);
-          listeningFlagTimerRef.current = null;
-        }
-      };
-    }, [state.isListening]);
-
-    // 컴포넌트 언마운트 시 반드시 플래그 해제
-    useEffect(() => {
-      return () => {
-        window.__dmn_isKeyListening = false;
-        if (listeningFlagTimerRef.current !== null) {
-          clearTimeout(listeningFlagTimerRef.current);
-          listeningFlagTimerRef.current = null;
-        }
-      };
-    }, []);
-
-    // 키 리스닝 중 브라우저 기본 동작 차단
-    useEffect(() => {
-      if (!state.isListening) return undefined;
-
-      const blockKeyboardEvents = (e: KeyboardEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
-      };
-
-      const blockMouseEvents = (e: MouseEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
-      };
-
-      const blockContextMenu = (e: Event) => {
-        e.preventDefault();
-        e.stopPropagation();
-      };
-
-      // 캡처 단계에서 모든 키보드/마우스 이벤트 차단
-      window.addEventListener('keydown', blockKeyboardEvents, true);
-      window.addEventListener('keyup', blockKeyboardEvents, true);
-      window.addEventListener('keypress', blockKeyboardEvents, true);
-      window.addEventListener('mousedown', blockMouseEvents, true);
-      window.addEventListener('contextmenu', blockContextMenu, true);
-
-      return () => {
-        window.removeEventListener('keydown', blockKeyboardEvents, true);
-        window.removeEventListener('keyup', blockKeyboardEvents, true);
-        window.removeEventListener('keypress', blockKeyboardEvents, true);
-        window.removeEventListener('mousedown', blockMouseEvents, true);
-        window.removeEventListener('contextmenu', blockContextMenu, true);
-      };
-    }, [state.isListening]);
-
-    // 키 리스닝 effect
-    useEffect(() => {
-      if (!state.isListening) return undefined;
-      if (typeof window === 'undefined' || !window.api?.keys?.onRawInput) {
-        return undefined;
-      }
-
-      const unsubscribe = window.api.keys.onRawInput((payload) => {
-        if (isHistoryEditorFlushLocked()) return;
-        if (!payload || payload.state !== 'DOWN') return;
-        const targetLabel =
-          payload.label ||
-          (Array.isArray(payload.labels) ? payload.labels[0] : null);
-        if (!targetLabel) return;
-
-        const info = getKeyInfoByGlobalKey(targetLabel);
-
-        // 마우스 클릭으로 할당 시 버튼 재클릭 방지를 위한 플래그
-        justAssignedRef.current = true;
-        setTimeout(() => {
-          justAssignedRef.current = false;
-        }, 100);
-
-        setState((prev) => ({
-          ...prev,
-          key: info.globalKey,
-          displayKey: info.displayName,
-          isListening: false,
-        }));
+            if (target !== null) {
+              // 리스닝 중 제거로 인덱스가 밀린 경우 방어
+              if (target >= members.length) return prev;
+              if (duplicateAt !== -1 && duplicateAt !== target) return prev;
+              members[target] = captured;
+            } else {
+              if (duplicateAt !== -1 || members.length >= MAX_SLOT_KEYS) {
+                return prev;
+              }
+              members.push(captured);
+              // 단일 상태에서 키가 늘면 개별 판정으로 승격
+              if (prev.mode === 'single') {
+                return { ...prev, members, mode: 'any' };
+              }
+            }
+            return { ...prev, members };
+          });
+        },
       });
 
-      return () => {
-        try {
-          unsubscribe?.();
-        } catch (error) {
-          console.error('Failed to unsubscribe raw input listener', error);
-        }
-      };
-    }, [state.isListening, setState]);
+    // 멤버 제거 (진행 중 리스닝 취소)
+    const handleRemoveMember = (index: number) => {
+      stopListen();
+      setState((prev) => ({
+        ...prev,
+        members: prev.members.filter((_, i) => i !== index),
+      }));
+    };
 
-    // 키 리스닝 핸들러
-    const handleKeyListen = () => {
-      // 방금 키가 할당된 직후라면 무시 (마우스 클릭 할당 시 버튼 재클릭 방지)
-      if (justAssignedRef.current) return;
-      setState((prev) => ({ ...prev, isListening: true }));
+    // 입력 방식 변경 - 단일로 바꾸면 첫 키만 유지
+    const handleModeChange = (mode: KeySlotUiMode) => {
+      setState((prev) => ({
+        ...prev,
+        mode,
+        members: mode === 'single' ? prev.members.slice(0, 1) : prev.members,
+      }));
+    };
+
+    // 멀티 키 편집 팝업
+    const [slotPickerOpen, setSlotPickerOpen] = useState(false);
+    const slotEditButtonRef = useRef<HTMLButtonElement>(null);
+    const slotParts = slotCompactParts(
+      buildSlot(state.members, state.mode === 'all' ? 'all' : 'any'),
+    );
+    // 팝업이 닫혀 있을 때의 리스닝 = 행 버튼 빠른 재지정
+    const quickListening = isListening && !slotPickerOpen;
+
+    // 행 버튼: 기존처럼 즉시 캡처 (멀티 슬롯이면 첫 키 교체)
+    const handleMainSlotClick = () => {
+      startListen(state.members.length === 0 ? null : 0);
+    };
+
+    const closeSlotPicker = () => {
+      setSlotPickerOpen(false);
+      stopListen();
     };
 
     // 이미지 변경 핸들러
@@ -182,35 +128,6 @@ const KeyTabContent = forwardRef<KeyTabContentRef, KeyTabContentProps>(
     const _handleActiveImageChange = (imageUrl: string) => {
       setState((prev) => ({ ...prev, activeImage: imageUrl }));
       onPreview({ activeImage: imageUrl });
-    };
-
-    // 크기 변경 핸들러
-    const handleWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = e.target.value;
-      if (newValue === '') {
-        setState((prev) => ({ ...prev, width: '' }));
-      } else {
-        const numValue = parseInt(newValue, 10);
-        if (!Number.isNaN(numValue)) {
-          const clamped = Math.min(Math.max(numValue, 1), 999);
-          setState((prev) => ({ ...prev, width: clamped }));
-          onPreview({ width: clamped });
-        }
-      }
-    };
-
-    const handleHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = e.target.value;
-      if (newValue === '') {
-        setState((prev) => ({ ...prev, height: '' }));
-      } else {
-        const numValue = parseInt(newValue, 10);
-        if (!Number.isNaN(numValue)) {
-          const clamped = Math.min(Math.max(numValue, 1), 999);
-          setState((prev) => ({ ...prev, height: clamped }));
-          onPreview({ height: clamped });
-        }
-      }
     };
 
     // 투명 토글 핸들러
@@ -237,85 +154,87 @@ const KeyTabContent = forwardRef<KeyTabContentRef, KeyTabContentProps>(
         <PropertySection>
           <PropertyRow label={t('keySetting.keyMapping')}>
             <button
-              onClick={handleKeyListen}
-              className={`flex items-center justify-center h-[23px] min-w-[0px] px-[8px] bg-fill hover:bg-fill-hover active:bg-fill-active transition-colors duration-fast rounded-md ${
-                state.isListening ? 'shadow-focus-ring' : ''
+              onClick={handleMainSlotClick}
+              className={`flex items-center justify-center h-[23px] min-w-[0px] max-w-[120px] px-[8px] bg-fill hover:bg-fill-hover active:bg-fill-active transition-colors duration-fast rounded-md ${
+                quickListening ? 'shadow-focus-ring' : ''
               } text-fg text-label`}
             >
-              {state.isListening
-                ? t('keySetting.pressAnyKey')
-                : state.displayKey || t('keySetting.clickToSet')}
+              <span className="truncate">
+                {quickListening
+                  ? t('keySetting.pressAnyKey')
+                  : slotParts.label || t('keySetting.clickToSet')}
+              </span>
+              {!quickListening && slotParts.extra && (
+                // case 피처: +를 숫자 중심에 맞춘 글리프로 치환.
+                // tracking은 +와 숫자 사이 0.25px 확보용, 끝 글자 뒤 여분은 -mr로 상쇄 (배지는 한 자리 전제)
+                <span className="pl-[3px] tracking-[0.25px] -mr-[0.25px] text-fg-faint [font-feature-settings:'case']">
+                  {slotParts.extra}
+                </span>
+              )}
             </button>
           </PropertyRow>
 
+          {/* 다중 키·판정 방식 편집 - 그림자 행과 같은 설정하기 패턴 */}
+          <PropertyRow label={t('keySetting.multiKey')}>
+            <button
+              ref={slotEditButtonRef}
+              onClick={() => setSlotPickerOpen((prev) => !prev)}
+              className={`px-[8px] h-[23px] bg-fill hover:bg-fill-hover active:bg-fill-active transition-colors duration-fast rounded-md flex items-center justify-center ${
+                slotPickerOpen ? 'shadow-focus-ring' : ''
+              } text-fg text-body`}
+            >
+              {t('keySetting.configure')}
+            </button>
+          </PropertyRow>
+
+          <KeySlotPicker
+            open={slotPickerOpen}
+            referenceRef={slotEditButtonRef}
+            onClose={closeSlotPicker}
+            members={state.members}
+            mode={state.mode}
+            isListening={isListening}
+            listenIndex={listenIndex}
+            onChipClick={(index) => startListen(index)}
+            onAddClick={() => startListen(null)}
+            onRemove={handleRemoveMember}
+            onModeChange={handleModeChange}
+            labels={{
+              title: t('keySetting.multiKeyEdit'),
+              modeAny: t('keySetting.matchAny'),
+              modeAll: t('keySetting.matchAll'),
+              pressAnyKey: t('keySetting.pressAnyKey'),
+              addKey: t('keySetting.addKey'),
+              removeKey: t('keySetting.removeKey'),
+            }}
+          />
+
           {/* 키 사이즈 */}
-          <div className="flex justify-between items-center w-full min-h-[32px]">
-            <p className="text-fg-muted text-label">
-              {t('keySetting.keySize')}
-            </p>
-            <div className="flex items-center gap-[10.5px]">
-              <div
-                className={`relative w-[54px] h-[23px] bg-inset rounded-md ${
-                  state.widthFocused ? 'shadow-focus-ring' : ''
-                }`}
-              >
-                <span className="absolute left-[5px] top-[50%] transform -translate-y-1/2 text-fg-muted text-body pointer-events-none">
-                  X
-                </span>
-                <input
-                  type="number"
-                  value={state.width}
-                  onChange={handleWidthChange}
-                  onFocus={() =>
-                    setState((prev) => ({ ...prev, widthFocused: true }))
-                  }
-                  onBlur={(e) => {
-                    setState((prev) => {
-                      const val = e.target.value;
-                      const finalVal =
-                        val === '' || Number.isNaN(parseInt(val, 10))
-                          ? 60
-                          : parseInt(val, 10);
-                      return { ...prev, width: finalVal, widthFocused: false };
-                    });
-                  }}
-                  className="absolute left-[20px] top-0 h-[23px] w-[26px] bg-transparent text-body tabular-nums text-fg text-left"
-                />
-              </div>
-              <div
-                className={`relative w-[54px] h-[23px] bg-inset rounded-md ${
-                  state.heightFocused ? 'shadow-focus-ring' : ''
-                }`}
-              >
-                <span className="absolute left-[5px] top-[50%] transform -translate-y-1/2 text-fg-muted text-body pointer-events-none">
-                  Y
-                </span>
-                <input
-                  type="number"
-                  value={state.height}
-                  onChange={handleHeightChange}
-                  onFocus={() =>
-                    setState((prev) => ({ ...prev, heightFocused: true }))
-                  }
-                  onBlur={(e) => {
-                    setState((prev) => {
-                      const val = e.target.value;
-                      const finalVal =
-                        val === '' || Number.isNaN(parseInt(val, 10))
-                          ? 60
-                          : parseInt(val, 10);
-                      return {
-                        ...prev,
-                        height: finalVal,
-                        heightFocused: false,
-                      };
-                    });
-                  }}
-                  className="absolute left-[20px] top-0 h-[23px] w-[26px] bg-transparent text-body tabular-nums text-fg text-left"
-                />
-              </div>
-            </div>
-          </div>
+          <PropertyRow label={t('keySetting.keySize')}>
+            <NumberInput
+              value={state.width}
+              min={1}
+              max={999}
+              prefix="X"
+              onChange={(value) => {
+                setState((prev) => ({ ...prev, width: value }));
+                onPreview({ width: value });
+              }}
+              // Escape 시 값 원복 후 이벤트 전파 - 모달 닫힘 경로 유지
+              onCancel={() => {}}
+            />
+            <NumberInput
+              value={state.height}
+              min={1}
+              max={999}
+              prefix="Y"
+              onChange={(value) => {
+                setState((prev) => ({ ...prev, height: value }));
+                onPreview({ height: value });
+              }}
+              onCancel={() => {}}
+            />
+          </PropertyRow>
         </PropertySection>
 
         {/* 외형 커스터마이징 카드 */}

--- a/src/renderer/components/main/common/KeySlotPicker.tsx
+++ b/src/renderer/components/main/common/KeySlotPicker.tsx
@@ -1,0 +1,139 @@
+import React, { useCallback } from 'react';
+import PickerSurface from '@components/main/Grid/PropertiesPanel/PickerSurface';
+import TabSwitch from '@components/main/common/TabSwitch';
+import { getKeyInfoByGlobalKey } from '@utils/core/KeyMaps';
+import { MAX_SLOT_KEYS } from '@utils/keySlot';
+import type { KeySlotUiMode } from '@utils/keySlot';
+
+interface KeySlotPickerLabels {
+  title: string;
+  modeAny: string;
+  modeAll: string;
+  pressAnyKey: string;
+  addKey: string;
+  removeKey: string;
+}
+
+interface KeySlotPickerProps {
+  open: boolean;
+  referenceRef: React.RefObject<HTMLElement | null>;
+  panelElement?: HTMLElement | null;
+  onClose: () => void;
+  members: string[];
+  mode: KeySlotUiMode;
+  isListening: boolean;
+  listenIndex: number | null;
+  onChipClick: (index: number) => void;
+  onAddClick: () => void;
+  onRemove: (index: number) => void;
+  onModeChange: (mode: KeySlotUiMode) => void;
+  labels: KeySlotPickerLabels;
+}
+
+// 멀티 키 매핑 편집 팝업 - ImagePicker와 같은 피커 표면 문법 사용
+const KeySlotPicker = ({
+  open,
+  referenceRef,
+  panelElement = null,
+  onClose,
+  members,
+  mode,
+  isListening,
+  listenIndex,
+  onChipClick,
+  onAddClick,
+  onRemove,
+  onModeChange,
+  labels,
+}: KeySlotPickerProps) => {
+  // 캡처 대기 행이 스크롤 밖이면 보이는 위치로
+  const listeningRowRef = useCallback((node: HTMLElement | null) => {
+    node?.scrollIntoView({ block: 'nearest' });
+  }, []);
+
+  return (
+    <PickerSurface
+      open={open}
+      ariaLabel={labels.title}
+      referenceRef={referenceRef as React.RefObject<HTMLElement>}
+      panelElement={panelElement}
+      fallbackWidth={172}
+      fallbackHeight={150}
+      cardClassName="flex flex-col p-[8px] gap-[8px] w-[172px] bg-glass-heavy backdrop-glass rounded-popup shadow-elevation-3"
+      onClose={onClose}
+    >
+      {/* 판정 방식 - 개별(any) / 동시(all), 키 2개부터 의미가 생김 */}
+      {members.length >= 2 && (
+        <TabSwitch
+          tabs={[
+            { id: 'any', label: labels.modeAny },
+            { id: 'all', label: labels.modeAll },
+          ]}
+          activeTab={mode === 'all' ? 'all' : 'any'}
+          onTabChange={(tab) => onModeChange(tab as KeySlotUiMode)}
+        />
+      )}
+
+      {/* 멤버 키 리스트 - 드롭다운 메뉴와 같은 플랫 행 문법, 클릭 시 재캡처.
+          6행 초과부터 내부 스크롤로 팝업 높이 고정 */}
+      <div className="flex flex-col gap-[4px] max-h-[158px] overflow-y-auto">
+        {members.map((member, index) => (
+          <div
+            key={`${member}-${index}`}
+            ref={
+              isListening && listenIndex === index ? listeningRowRef : undefined
+            }
+            className={`group flex items-center shrink-0 h-[23px] rounded-md transition-colors duration-fast ${
+              isListening && listenIndex === index
+                ? 'bg-surface-active'
+                : 'hover:bg-surface-hover'
+            }`}
+          >
+            <button
+              onClick={() => onChipClick(index)}
+              className="flex-1 min-w-0 flex items-center h-full px-[8px] text-left text-body text-fg"
+            >
+              <span className="truncate">
+                {isListening && listenIndex === index
+                  ? labels.pressAnyKey
+                  : getKeyInfoByGlobalKey(member).displayName}
+              </span>
+            </button>
+            {members.length > 1 && (
+              <button
+                onClick={() => onRemove(index)}
+                aria-label={labels.removeKey}
+                className="flex items-center justify-center h-full w-[20px] shrink-0 opacity-0 group-hover:opacity-100 text-fg-muted hover:text-fg transition-opacity duration-fast text-body"
+              >
+                ×
+              </button>
+            )}
+          </div>
+        ))}
+        {/* 추가 행 - 캡처 대기 시 같은 자리에서 문구만 교체되어 레이아웃 점프 없음 */}
+        {members.length < MAX_SLOT_KEYS && (
+          <button
+            onClick={onAddClick}
+            aria-label={labels.addKey}
+            ref={
+              isListening && listenIndex === null ? listeningRowRef : undefined
+            }
+            className={`flex items-center shrink-0 h-[23px] px-[8px] rounded-md text-body text-left transition-colors duration-fast ${
+              isListening && listenIndex === null
+                ? 'bg-surface-active text-fg'
+                : 'text-fg-muted hover:bg-surface-hover hover:text-fg'
+            }`}
+          >
+            <span className="truncate">
+              {isListening && listenIndex === null
+                ? labels.pressAnyKey
+                : `+ ${labels.addKey}`}
+            </span>
+          </button>
+        )}
+      </div>
+    </PickerSurface>
+  );
+};
+
+export default KeySlotPicker;

--- a/src/renderer/components/shared/Key.tsx
+++ b/src/renderer/components/shared/Key.tsx
@@ -6,7 +6,6 @@ import { useSignals } from '@preact/signals-react/runtime';
 import { isMac } from '@utils/core/platform';
 import { useDraggable } from '@hooks/Grid';
 import { useSelectionDrag } from '@hooks/Grid/useSelectionDrag';
-import { getKeyInfoByGlobalKey } from '@utils/core/KeyMaps';
 import {
   createDefaultCounterSettings,
   normalizeCounterSettings,
@@ -103,7 +102,8 @@ const DraggableKey = React.memo(
     useSignals();
 
     const macOS = isMac();
-    const { displayName } = getKeyInfoByGlobalKey(keyName);
+    // keyName은 호출부에서 합성이 끝난 표시 라벨
+    const displayName = keyName;
     const { dx, dy, width, height = 60, className, counter } = position;
 
     const counterSettings = normalizeCounterSettings(

--- a/src/renderer/components/shared/OverlayScene.tsx
+++ b/src/renderer/components/shared/OverlayScene.tsx
@@ -96,7 +96,7 @@ interface OverlaySceneProps {
   // 키/위치 데이터 (currentKeys = canonical 문자열)
   currentKeys: string[];
   // 인덱스 정렬된 표시 라벨 (멀티 슬롯 합성 라벨용)
-  currentKeyLabels?: string[];
+  currentKeyLabels: string[];
   displayPositions: KeyPosition[];
   currentPositions: KeyPosition[];
   displayStatPositions: Record<string, unknown>[];
@@ -176,9 +176,9 @@ const OverlayScene = ({
       )}
 
       {currentKeys.map((key, index) => {
-        // 멀티 슬롯은 합성 라벨, 단일 키는 기존 displayName
+        // 멀티 슬롯은 합성 라벨, 라벨 배열이 짧으면 단일 키 displayName 폴백
         const displayName =
-          currentKeyLabels?.[index] ?? getKeyInfoByGlobalKey(key).displayName;
+          currentKeyLabels[index] ?? getKeyInfoByGlobalKey(key).displayName;
         const basePosition =
           displayPositions[index] ??
           currentPositions[index] ??

--- a/src/renderer/components/shared/OverlayScene.tsx
+++ b/src/renderer/components/shared/OverlayScene.tsx
@@ -93,8 +93,10 @@ const Tracks = lazy(async () => {
 type NoteSubscriber = (event: any) => void;
 
 interface OverlaySceneProps {
-  // 키/위치 데이터
+  // 키/위치 데이터 (currentKeys = canonical 문자열)
   currentKeys: string[];
+  // 인덱스 정렬된 표시 라벨 (멀티 슬롯 합성 라벨용)
+  currentKeyLabels?: string[];
   displayPositions: KeyPosition[];
   currentPositions: KeyPosition[];
   displayStatPositions: Record<string, unknown>[];
@@ -125,6 +127,7 @@ interface OverlaySceneProps {
 
 const OverlayScene = ({
   currentKeys,
+  currentKeyLabels,
   displayPositions,
   currentPositions,
   displayStatPositions,
@@ -173,7 +176,9 @@ const OverlayScene = ({
       )}
 
       {currentKeys.map((key, index) => {
-        const { displayName } = getKeyInfoByGlobalKey(key);
+        // 멀티 슬롯은 합성 라벨, 단일 키는 기존 displayName
+        const displayName =
+          currentKeyLabels?.[index] ?? getKeyInfoByGlobalKey(key).displayName;
         const basePosition =
           displayPositions[index] ??
           currentPositions[index] ??

--- a/src/renderer/components/shared/PluginElement.tsx
+++ b/src/renderer/components/shared/PluginElement.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { isMac } from '@utils/core/platform';
+import { slotCanonical } from '@utils/keySlot';
 import {
   PluginDisplayElementInternal,
   ElementResizeAnchor,
@@ -387,8 +388,9 @@ const PluginElementImpl: React.FC<PluginElementProps> = ({
     if (element.anchor?.keyCode && positions && selectedKeyType) {
       const keyMappings = useKeyStore.getState().keyMappings;
       const modeKeys = keyMappings[selectedKeyType] || [];
+      // 앵커 keyCode는 canonical 문자열 (멀티 슬롯 포함 매칭)
       const keyIndex = modeKeys.findIndex(
-        (key) => key === element.anchor?.keyCode,
+        (key) => slotCanonical(key) === element.anchor?.keyCode,
       );
 
       if (keyIndex >= 0 && positions[selectedKeyType]?.[keyIndex]) {

--- a/src/renderer/constants/inputTiming.ts
+++ b/src/renderer/constants/inputTiming.ts
@@ -1,0 +1,3 @@
+// 표시 시각 보정 및 canonical hold 폴백에 공통으로 적용하는 입력 지연 허용치
+export const MAX_EVENT_AGE_MS = 250;
+export const MAX_FALLBACK_CLOCK_SKEW_MS = MAX_EVENT_AGE_MS;

--- a/src/renderer/editor/model/keys.ts
+++ b/src/renderer/editor/model/keys.ts
@@ -16,6 +16,7 @@ import {
   createDefaultCounterSettings,
   normalizeCounterSettings,
 } from '@src/types/key/keys';
+import { cloneSlot } from '@utils/keySlot';
 
 // ----------------------------------------------------------------------------
 // 기본 키 포지션 생성
@@ -172,7 +173,7 @@ export function duplicateKey(
   return {
     mappings: {
       ...mappings,
-      [mode]: [...mapping, sourceKey],
+      [mode]: [...mapping, cloneSlot(sourceKey)],
     },
     positions: {
       ...positions,

--- a/src/renderer/editor/model/keys.ts
+++ b/src/renderer/editor/model/keys.ts
@@ -7,6 +7,7 @@ import type {
   KeyMappings,
   KeyPositions,
   KeyPosition,
+  KeySlot,
   NoteColor,
   KeyCounterSettings,
   CounterAnimationBezier,
@@ -329,11 +330,11 @@ export function updateKeyMapping(
   mappings: KeyMappings,
   mode: string,
   index: number,
-  newKey: string,
+  newSlot: KeySlot,
 ): KeyMappings {
   const mapping = mappings[mode] || [];
   return {
     ...mappings,
-    [mode]: mapping.map((key, i) => (i === index ? newKey : key)),
+    [mode]: mapping.map((key, i) => (i === index ? newSlot : key)),
   };
 }

--- a/src/renderer/editor/runtime/editorCoordinator.test.ts
+++ b/src/renderer/editor/runtime/editorCoordinator.test.ts
@@ -24,6 +24,7 @@ import type {
   EditorDocumentV1,
   EditorGetResult,
 } from '@src/types/editor';
+import type { KeySlot } from '@src/types/key/keys';
 import type {
   EditorApplyReason,
   EditorCoordinatorOptions,
@@ -349,6 +350,67 @@ describe('editor document helpers', () => {
 });
 
 describe('EditorSaveCoordinator', () => {
+  it('settles same-tick gesture and isolated plugin commits without deadlock', async () => {
+    const base = makeDocument('A');
+    const harness = createHarness(base);
+    await harness.coordinator.start();
+
+    // 같은 tick에 gesture 커밋 직후 플러그인 격리 커밋 - 상호 대기 교착 회귀 방지
+    const gesture = harness.coordinator.commitGesture(
+      { schemaVersion: 1, keys: { '4key': ['B'] } },
+      'gesture-a',
+      async (context) =>
+        harness.transport.commit({
+          baseRevision: context.editorBaseRevision,
+          mutationId: context.mutationId,
+          changes: context.editorChanges!,
+        }),
+    );
+    const isolated = harness.coordinator.commitIsolatedPluginPatch(
+      {
+        schemaVersion: 1,
+        keys: { '4key': [{ keys: ['C', 'D'], match: 'any' }] },
+      },
+      { multiKey: true },
+    );
+
+    await expect(gesture).resolves.toBeTruthy();
+    const isolatedDocument = await isolated;
+    expect(isolatedDocument.keys['4key']).toEqual([
+      { keys: ['C', 'D'], match: 'any' },
+    ]);
+
+    // 실행 창 로컬 문서도 canonical로 갱신됨 (이후 flush의 되돌림 방지)
+    expect(harness.getLocal().keys['4key']).toEqual([
+      { keys: ['C', 'D'], match: 'any' },
+    ]);
+
+    // 성공 후 코디네이터 상태 완전 정리 (inFlight 잔존 시 가짜 충돌 유발)
+    const stateAfterIsolated = harness.coordinator.getState();
+    expect(stateAfterIsolated.phase).toBe('idle');
+    expect(stateAfterIsolated.dirty).toBe(false);
+    expect(stateAfterIsolated.inFlightMutationId).toBeNull();
+
+    const callsAfterIsolated = harness.transport.commitMock.mock.calls.length;
+    await harness.coordinator.commitEditorState();
+    expect(harness.transport.commitMock.mock.calls.length).toBe(
+      callsAfterIsolated,
+    );
+
+    // 격리 커밋 envelope는 플러그인이 선언한 multiKey 값을 그대로 전달
+    const isolatedRequest = harness.transport.commitMock.mock.calls.at(-1)?.[0];
+    expect(isolatedRequest?.multiKey).toBe(true);
+
+    // 이후 자사 커밋도 정상 진행 (큐 고착 없음)
+    await expect(
+      harness.coordinator.commitPatch({
+        schemaVersion: 1,
+        keys: { '4key': ['E'] },
+      }),
+    ).resolves.toBeTruthy();
+    harness.coordinator.stop();
+  });
+
   it('keeps queued mixed gestures as separate ordered transactions', async () => {
     const base = makeDocument('A');
     const harness = createHarness(base);
@@ -358,7 +420,7 @@ describe('EditorSaveCoordinator', () => {
       gestureId: string;
       editorBaseRevision: number;
       mutationId: string;
-      keys: string[] | undefined;
+      keys: KeySlot[] | undefined;
     }> = [];
 
     const first = harness.coordinator.commitGesture(

--- a/src/renderer/editor/runtime/editorCoordinator.ts
+++ b/src/renderer/editor/runtime/editorCoordinator.ts
@@ -424,6 +424,108 @@ export class EditorSaveCoordinator {
     );
   }
 
+  // 플러그인 발신 커밋을 gesture 커밋과 같은 단일 직렬 큐에 태운다.
+  // 별도 게이트를 두면 gesture 큐와 상호 대기 교착이 생기므로 큐는 하나만 유지
+  private enqueueSerialized<T>(task: () => Promise<T>): Promise<T> {
+    const previous = this.gestureCommitTail;
+    // 앞선 작업 실패가 다음 작업으로 전파되지 않게 양쪽 경로 모두 실행
+    const run = previous.then(task, task);
+    this.gestureCommitTail = run;
+    return run;
+  }
+
+  // 플러그인 발신 keys 쓰기 전용 격리 커밋 (계약 §10)
+  // 공유 snapshot 병합(queueSnapshot/drain)에 합류시키지 않고, 현재 드레인이
+  // 끝난 뒤 독점 요청 1건으로 직렬화한다. 자사 커밋 진입점들은
+  // waitForGestureCommits로 같은 큐를 기다리므로 multiKey provenance가
+  // false → true로 승격되는 병합 경로가 구조적으로 없다
+  commitIsolatedPluginPatch(
+    changes: EditorPatchV1,
+    options: { multiKey: boolean },
+  ): Promise<EditorDocumentV1> {
+    this.assertWritable();
+    return this.enqueueSerialized(() =>
+      this.commitIsolatedPluginPatchInner(changes, options),
+    );
+  }
+
+  private async commitIsolatedPluginPatchInner(
+    changes: EditorPatchV1,
+    options: { multiKey: boolean },
+  ): Promise<EditorDocumentV1> {
+    await this.start();
+    await this.drainUntilSettled();
+    await this.eventQueue;
+    if (this.conflict) {
+      throw this.error ?? new Error('editor conflict pending');
+    }
+
+    const canonicalChanges = canonicalizeEditorGradients(changes);
+    assertEditorPatch(canonicalChanges);
+    const baseDocument = clone(this.requireLastAck());
+    const target = applyEditorPatch(baseDocument, canonicalChanges);
+    const requestFields = EDITOR_FIELDS.filter(
+      (field) => canonicalChanges[field] !== undefined,
+    );
+    if (requestFields.length === 0) return clone(this.requireLastAck());
+
+    const baseRevision = this.requireRevision();
+    const mutationId = this.createMutationId();
+    const inFlight: InFlightCommit = {
+      mutationId,
+      baseRevision,
+      baseDocument,
+      target: clone(target),
+      localFields: getChangedEditorFields(baseDocument, target),
+      requestFields,
+      gestureIds: [],
+    };
+    this.inFlight = inFlight;
+    this.rememberOwnMutation(inFlight);
+    this.phase = 'saving';
+    this.notify();
+
+    try {
+      const result = await this.transport.commit({
+        baseRevision,
+        mutationId,
+        changes: patchForFields(target, requestFields),
+        // provenance 명시 전달 - 기본값 승격 경로 없음
+        multiKey: options.multiKey === true,
+      });
+      assertEditorCommitResult(result);
+      await this.applyCommitResult(inFlight, result);
+      // 실행 창의 로컬 문서도 canonical로 갱신 - 격리 커밋은 낙관 적용을
+      // 거치지 않으므로 여기서 반영하지 않으면 이후 flush가 낡은 로컬을
+      // 새 편집으로 계산해 방금 성공한 변경을 되돌린다
+      this.applyDocument(clone(this.requireLastAck()), 'localPatch');
+      this.error = null;
+      this.failureKind = null;
+      this.phase = 'idle';
+      this.notify();
+      return clone(this.requireLastAck());
+    } catch (error) {
+      // 거절돼도 코디네이터는 건강한 상태 유지 - 오류는 플러그인 호출자에게만
+      // 전파하고 pending은 보존하지 않음 (store·로컬 모두 불변)
+      if (!this.conflict && !this.stopped) this.phase = 'idle';
+      this.notify();
+      throw error;
+    } finally {
+      if (this.inFlight?.mutationId === mutationId) this.inFlight = null;
+    }
+  }
+
+  // 플러그인이 자체 envelope로 직접 editor_commit을 수행할 때도 같은 큐로
+  // 직렬화 (계약 §10: coordinator에 예약된 변경보다 먼저 lock을 잡는 경합 차단)
+  runSerializedPluginCommit<T>(task: () => Promise<T>): Promise<T> {
+    return this.enqueueSerialized(async () => {
+      await this.start();
+      await this.drainUntilSettled();
+      await this.eventQueue;
+      return task();
+    });
+  }
+
   commitGesture(
     changes: EditorPatchV1 | undefined,
     gestureId: string,

--- a/src/renderer/hooks/Grid/useGridContextMenu.ts
+++ b/src/renderer/hooks/Grid/useGridContextMenu.ts
@@ -8,7 +8,8 @@ import { usePluginMenuStore } from '@stores/plugin/usePluginMenuStore';
 import { usePluginDisplayElementStore } from '@stores/plugin/usePluginDisplayElementStore';
 import { useSettingsStore } from '@stores/useSettingsStore';
 import { translatePluginMessage } from '@utils/plugin/pluginI18n';
-import type { KeyPosition } from '@src/types/key/keys';
+import type { KeyMappings, KeyPosition } from '@src/types/key/keys';
+import { slotCanonical } from '@utils/keySlot';
 import type {
   PluginMenuItemInternal,
   KeyMenuContext,
@@ -37,7 +38,7 @@ interface GridContext {
 
 interface UseGridContextMenuParams {
   selectedKeyType: string;
-  keyMappings: Record<string, string[]>;
+  keyMappings: KeyMappings;
   positions: Record<string, KeyPosition[]>;
   locale: string;
   t: (key: string) => string;
@@ -118,7 +119,10 @@ export function useGridContextMenu({
     const context: KeyContext | null =
       contextIndex !== null && keyPosition
         ? {
-            keyCode: keyMappings[selectedKeyType]?.[contextIndex] || '',
+            // 플러그인 메뉴 표면은 canonical 문자열 유지
+            keyCode: slotCanonical(
+              keyMappings[selectedKeyType]?.[contextIndex] ?? '',
+            ),
             index: contextIndex,
             position: keyPosition,
             mode: selectedKeyType,

--- a/src/renderer/hooks/Grid/useGridSelection.ts
+++ b/src/renderer/hooks/Grid/useGridSelection.ts
@@ -21,7 +21,9 @@ import type {
   KeyMappings,
   KeyPositions,
   KeyPosition,
+  KeySlot,
 } from '@src/types/key/keys';
+import { cloneSlot } from '@utils/keySlot';
 import type {
   StatItemPosition,
   StatItemPositions,
@@ -506,7 +508,7 @@ export function useGridSelection({
         if (keyCode && position) {
           clipboardItems.push({
             type: 'key',
-            keyCode,
+            keyCode: cloneSlot(keyCode),
             position: { ...position },
           });
         }
@@ -632,7 +634,7 @@ export function useGridSelection({
       return modeGroups.some((g) => g.id === groupId) ? groupId : undefined;
     };
 
-    const keysToAdd: { keyCode: string; position: KeyPosition }[] = [];
+    const keysToAdd: { keyCode: KeySlot; position: KeyPosition }[] = [];
     const statsToAdd: { position: StatItemPosition }[] = [];
     const graphsToAdd: { position: GraphItemPosition }[] = [];
     const knobsToAdd: { position: KnobItemPosition }[] = [];
@@ -641,7 +643,7 @@ export function useGridSelection({
     for (const item of currentClipboard) {
       if (item.type === 'key') {
         keysToAdd.push({
-          keyCode: item.keyCode,
+          keyCode: cloneSlot(item.keyCode),
           position: {
             ...item.position,
             groupId: remapGroupId(item.position.groupId),

--- a/src/renderer/hooks/Modal/useUnifiedKeySettingState.ts
+++ b/src/renderer/hooks/Modal/useUnifiedKeySettingState.ts
@@ -1,12 +1,17 @@
 import { useState, useRef, useEffect } from 'react';
 import { listen } from '@tauri-apps/api/event';
-import { getKeyInfoByGlobalKey } from '@utils/core/KeyMaps';
 import { isGradientColor, normalizeColorInput } from '@utils/color/colorUtils';
+import { slotMembers, slotUiMode, buildSlot } from '@utils/keySlot';
+import type { KeySlotUiMode } from '@utils/keySlot';
 import {
   createDefaultCounterSettings,
   normalizeCounterSettings,
 } from '@src/types/key/keys';
-import type { NoteColor, KeyCounterSettings } from '@src/types/key/keys';
+import type {
+  NoteColor,
+  KeyCounterSettings,
+  KeySlot,
+} from '@src/types/key/keys';
 import { toCompactRgba } from '@src/types/color';
 
 // ============================================================================
@@ -42,7 +47,7 @@ export const toGradient = (top: string, bottom: string): GradientColor => ({
 
 // 키 데이터 타입
 export interface KeyData {
-  key: string;
+  key: KeySlot;
   activeImage?: string;
   inactiveImage?: string;
   activeTransparent?: boolean;
@@ -62,9 +67,10 @@ export interface KeyData {
 
 // 키 탭 상태 타입
 export interface KeyTabState {
-  key: string;
-  displayKey: string;
-  isListening: boolean;
+  // 슬롯 멤버 키 목록 (칩 UI), 빈 배열 = 미할당
+  members: string[];
+  // 입력 방식: 단일 / 개별(any) / 동시(all)
+  mode: KeySlotUiMode;
   activeImage: string;
   inactiveImage: string;
   width: number | string;
@@ -73,8 +79,6 @@ export interface KeyTabState {
   activeTransparent: boolean;
   className: string;
   showImagePicker: boolean;
-  widthFocused: boolean;
-  heightFocused: boolean;
 }
 
 // 노트 탭 상태 타입
@@ -167,7 +171,7 @@ export type PreviewData =
 
 // 저장 데이터 타입
 export interface SaveData {
-  key: string;
+  key: KeySlot;
   activeImage: string;
   inactiveImage: string;
   width: number;
@@ -192,9 +196,8 @@ export interface SaveData {
 
 export function createInitialKeyState(keyData: KeyData): KeyTabState {
   return {
-    key: keyData.key,
-    displayKey: getKeyInfoByGlobalKey(keyData.key).displayName,
-    isListening: false,
+    members: slotMembers(keyData.key),
+    mode: slotUiMode(keyData.key),
     activeImage: keyData.activeImage || '',
     inactiveImage: keyData.inactiveImage || '',
     width: keyData.width || 60,
@@ -203,8 +206,6 @@ export function createInitialKeyState(keyData: KeyData): KeyTabState {
     activeTransparent: keyData.activeTransparent || false,
     className: keyData.className || '',
     showImagePicker: false,
-    widthFocused: false,
-    heightFocused: false,
   };
 }
 
@@ -425,8 +426,13 @@ export function useUnifiedKeySettingState({
         : noteState.glowColor;
 
     onSave({
-      // 키 데이터
-      key: keyState.key,
+      // 키 데이터 - 단일 모드는 첫 키만 유지
+      key: buildSlot(
+        keyState.mode === 'single'
+          ? keyState.members.slice(0, 1)
+          : keyState.members,
+        keyState.mode === 'all' ? 'all' : 'any',
+      ),
       activeImage: keyState.activeImage,
       inactiveImage: keyState.inactiveImage,
       width:

--- a/src/renderer/hooks/overlay/useNoteSystem.continuity.test.tsx
+++ b/src/renderer/hooks/overlay/useNoteSystem.continuity.test.tsx
@@ -146,6 +146,7 @@ describe('노트 길이 연속성 계약 독립 검증', () => {
     h: number,
     s: Settings,
     upBeforeStart: boolean,
+    includeDaemonHold = true,
   ) => {
     const down = nowMs;
     result.handleKeyDown(key, { displayTime: down, physTime: down });
@@ -157,7 +158,7 @@ describe('노트 길이 연속성 계약 독립 검증', () => {
     result.handleKeyUp(key, {
       displayTime: down + h,
       physTime: down + h,
-      holdDurationMs: h,
+      ...(includeDaemonHold ? { holdDurationMs: h } : {}),
     });
     // 완료될 때까지만 전진 - 더 가면 cleanup이 노트를 회수한다
     const cap =
@@ -281,6 +282,15 @@ describe('노트 길이 연속성 계약 독립 검증', () => {
       root = createRoot(container);
       nowMs += 1000;
     }
+  });
+
+  it('holdDurationMs가 생략되면 canonical DOWN·UP 시각으로 같은 길이를 계산한다', async () => {
+    await render(USER);
+    const h = 150;
+    const result = await play('FALLBACK', h, USER, false, false);
+
+    expect(result).not.toBeNull();
+    expect(result!.end - result!.start).toBeCloseTo(oracle(USER).L(h), 3);
   });
 
   it('실수 D와 동일한 램프 폭을 보존한다', () => {

--- a/src/renderer/hooks/overlay/useNoteSystem.test.tsx
+++ b/src/renderer/hooks/overlay/useNoteSystem.test.tsx
@@ -1,7 +1,7 @@
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useNoteSystem } from './useNoteSystem';
+import { resolveCanonicalFallbackHoldMs, useNoteSystem } from './useNoteSystem';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -43,6 +43,41 @@ const REFERENCE_LENGTHS = [
   { holdMs: 100, lengthMs: 100 },
   { holdMs: 150, lengthMs: 150 },
 ] as const;
+
+describe('canonical hold fallback 시각 방어', () => {
+  it('비클램프 시각 차가 과도하면 display 경과와 clock-skew 허용치로 제한한다', () => {
+    expect(
+      resolveCanonicalFallbackHoldMs({
+        displayDownTime: 0,
+        displayReleaseTime: 100,
+        physicalDownTime: -10_000,
+        physicalReleaseTime: 100,
+      }),
+    ).toBe(350);
+  });
+
+  it('정상적인 장시간 hold는 고정 상한으로 자르지 않는다', () => {
+    expect(
+      resolveCanonicalFallbackHoldMs({
+        displayDownTime: 0,
+        displayReleaseTime: 60_000,
+        physicalDownTime: 0,
+        physicalReleaseTime: 60_000,
+      }),
+    ).toBe(60_000);
+  });
+
+  it('역전된 물리 시각 차는 0으로 제한한다', () => {
+    expect(
+      resolveCanonicalFallbackHoldMs({
+        displayDownTime: 0,
+        displayReleaseTime: 100,
+        physicalDownTime: 200,
+        physicalReleaseTime: 100,
+      }),
+    ).toBe(0);
+  });
+});
 
 describe('useNoteSystem 길이 연속성', () => {
   let container: HTMLDivElement;

--- a/src/renderer/hooks/overlay/useNoteSystem.ts
+++ b/src/renderer/hooks/overlay/useNoteSystem.ts
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/purity */
 import { useRef, useEffect } from 'react';
 import { DEFAULT_NOTE_SETTINGS } from '@constants/overlayDefaults';
+import { MAX_FALLBACK_CLOCK_SKEW_MS } from '@constants/inputTiming';
 import {
   createNoteBuffer,
   NoteBuffer,
@@ -87,6 +88,32 @@ interface UseNoteSystemReturn {
   noteBuffer: NoteBuffer;
   updateTrackLayouts: (layouts: TrackLayoutInput[]) => void;
 }
+
+interface CanonicalFallbackTiming {
+  displayDownTime?: number;
+  displayReleaseTime: number;
+  physicalDownTime?: number;
+  physicalReleaseTime: number;
+}
+
+export const resolveCanonicalFallbackHoldMs = ({
+  displayDownTime,
+  displayReleaseTime,
+  physicalDownTime,
+  physicalReleaseTime,
+}: CanonicalFallbackTiming): number => {
+  const displayHold =
+    displayDownTime == null
+      ? 0
+      : Math.max(0, displayReleaseTime - displayDownTime);
+  const physicalHold =
+    physicalDownTime == null
+      ? displayHold
+      : Math.max(0, physicalReleaseTime - physicalDownTime);
+
+  // 비클램프 event age의 시계 이상만 제한하고 정상적인 장시간 hold는 보존
+  return Math.min(physicalHold, displayHold + MAX_FALLBACK_CLOCK_SKEW_MS);
+};
 
 // 렌더마다 재생성되는 내부 구현 중 안정 래퍼가 위임하는 대상
 type LatestNoteSystemFns = Pick<
@@ -495,8 +522,12 @@ export function useNoteSystem({
     // 판정용 물리 hold: 데몬 authoritative 값 우선, 없으면 비클램프 보정 시각 차 폴백
     const physDown = state.physDownTime ?? state.downTime;
     const physRelease = state.physReleaseTime ?? releaseTime;
-    const fallbackHold =
-      physDown != null ? Math.max(0, physRelease - physDown) : 0;
+    const fallbackHold = resolveCanonicalFallbackHoldMs({
+      displayDownTime: state.downTime,
+      displayReleaseTime: releaseTime,
+      physicalDownTime: physDown,
+      physicalReleaseTime: physRelease,
+    });
     const holdMs = state.holdDurationMs ?? fallbackHold;
     // 데몬 hold와 press 시점 정책으로만 길이 결정
     const computedNoteLengthMs = computeNoteLengthMs(

--- a/src/renderer/hooks/shared/useLayoutComputation.ts
+++ b/src/renderer/hooks/shared/useLayoutComputation.ts
@@ -22,6 +22,7 @@ interface PluginElement {
 }
 
 interface LayoutInput {
+  // canonical 슬롯 식별자 배열 (slotCanonical 결과, 원본 KeySlot 아님)
   currentKeys: string[];
   currentPositions: KeyPosition[];
   currentStatPositions: StatItemPosition[];

--- a/src/renderer/hooks/useKeyManager.ts
+++ b/src/renderer/hooks/useKeyManager.ts
@@ -18,6 +18,7 @@ import { removeDisplayElementsInternal } from '@plugins/runtime/displayElement/d
 import type {
   KeyMappings,
   KeyPositions,
+  KeySlot,
   NoteColor,
   KeyCounterSettings,
   ImageFit,
@@ -53,10 +54,10 @@ import {
   persistPositionsWithFlag,
 } from '@src/renderer/editor/runtime/persistState';
 
-type SelectedKey = { key: string; index: number } | null;
+type SelectedKey = { key: KeySlot; index: number } | null;
 
 type KeyUpdatePayload = {
-  key: string;
+  key: KeySlot;
   activeImage?: string;
   inactiveImage?: string;
   activeTransparent?: boolean;
@@ -521,12 +522,12 @@ export function useKeyManager() {
   // 키 스타일 업데이트 (속성 패널)
   // ────────────────────────────────────────────────────────────────────────
 
-  const handleKeyMappingChange = (index: number, newKey: string) => {
+  const handleKeyMappingChange = (index: number, newSlot: KeySlot) => {
     const updatedMappings = updateKeyMapping(
       keyMappings,
       selectedKeyType,
       index,
-      newKey,
+      newSlot,
     );
     setKeyMappings(updatedMappings);
     window.api.keys.update(updatedMappings).catch((error) => {

--- a/src/renderer/hooks/useKeyManager.ts
+++ b/src/renderer/hooks/useKeyManager.ts
@@ -530,6 +530,8 @@ export function useKeyManager() {
       newSlot,
     );
     setKeyMappings(updatedMappings);
+    // 실패 투영은 coordinator 소유: retryable은 pending 재시도로 수렴,
+    // 비재시도 거절은 discardRejectedPending이 권위 문서를 동기 복원
     window.api.keys.update(updatedMappings).catch((error) => {
       console.error('Failed to update key mapping', error);
     });

--- a/src/renderer/hooks/useKeySlotCapture.ts
+++ b/src/renderer/hooks/useKeySlotCapture.ts
@@ -1,0 +1,164 @@
+import { useEffect, useRef, useState } from 'react';
+import { getKeyInfoByGlobalKey } from '@utils/core/KeyMaps';
+import { isHistoryEditorFlushLocked } from '@src/renderer/editor/runtime/historyEditorFlushLock';
+
+interface UseKeySlotCaptureOptions {
+  // 캡처 완료 콜백. listenIndex가 number면 해당 멤버 교체, null이면 추가
+  onCapture: (globalKey: string, listenIndex: number | null) => void;
+  // Escape로 리스닝 취소 (속성 패널 기존 동작)
+  escapeCancels?: boolean;
+}
+
+// 키 슬롯 캡처 리스닝 공통 훅
+// 전역 리스닝 플래그, 브라우저 이벤트 차단, raw input 구독을 관리
+export function useKeySlotCapture({
+  onCapture,
+  escapeCancels = false,
+}: UseKeySlotCaptureOptions) {
+  const [isListening, setIsListening] = useState(false);
+  const [listenIndex, setListenIndex] = useState<number | null>(null);
+  const justAssignedRef = useRef(false);
+  const flagTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onCaptureRef = useRef(onCapture);
+
+  useEffect(() => {
+    onCaptureRef.current = onCapture;
+  }, [onCapture]);
+
+  // 키 리스닝 플래그를 전역으로 노출 (Grid 단축키 등에서 체크)
+  useEffect(() => {
+    if (flagTimerRef.current !== null) {
+      clearTimeout(flagTimerRef.current);
+      flagTimerRef.current = null;
+    }
+
+    if (isListening) {
+      window.__dmn_isKeyListening = true;
+    } else {
+      // macOS: raw input이 브라우저 keydown보다 먼저 도착할 수 있어 지연 해제
+      flagTimerRef.current = setTimeout(() => {
+        window.__dmn_isKeyListening = false;
+        flagTimerRef.current = null;
+      }, 150);
+    }
+
+    return () => {
+      if (flagTimerRef.current !== null) {
+        clearTimeout(flagTimerRef.current);
+        flagTimerRef.current = null;
+      }
+    };
+  }, [isListening]);
+
+  // 언마운트 시 반드시 플래그 해제
+  useEffect(() => {
+    return () => {
+      window.__dmn_isKeyListening = false;
+      if (flagTimerRef.current !== null) {
+        clearTimeout(flagTimerRef.current);
+        flagTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  // 리스닝 중 브라우저 기본 동작 차단
+  useEffect(() => {
+    if (!isListening) return undefined;
+
+    const blockKeyboardEvents = (e: KeyboardEvent) => {
+      if (
+        escapeCancels &&
+        e.key === 'Escape' &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.shiftKey
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsListening(false);
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
+    const blockMouseEvents = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
+    const blockContextMenu = (e: Event) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
+    window.addEventListener('keydown', blockKeyboardEvents, true);
+    window.addEventListener('keyup', blockKeyboardEvents, true);
+    window.addEventListener('keypress', blockKeyboardEvents, true);
+    window.addEventListener('mousedown', blockMouseEvents, true);
+    window.addEventListener('contextmenu', blockContextMenu, true);
+
+    return () => {
+      window.removeEventListener('keydown', blockKeyboardEvents, true);
+      window.removeEventListener('keyup', blockKeyboardEvents, true);
+      window.removeEventListener('keypress', blockKeyboardEvents, true);
+      window.removeEventListener('mousedown', blockMouseEvents, true);
+      window.removeEventListener('contextmenu', blockContextMenu, true);
+    };
+  }, [isListening, escapeCancels]);
+
+  // raw input 구독
+  useEffect(() => {
+    if (!isListening) return undefined;
+    if (typeof window === 'undefined' || !window.api?.keys?.onRawInput) {
+      return undefined;
+    }
+
+    const unsubscribe = window.api.keys.onRawInput((payload) => {
+      if (isHistoryEditorFlushLocked()) return;
+      if (!payload || payload.state !== 'DOWN') return;
+      const targetLabel =
+        payload.label ||
+        (Array.isArray(payload.labels) ? payload.labels[0] : null);
+      if (!targetLabel) return;
+
+      const info = getKeyInfoByGlobalKey(targetLabel);
+
+      if (escapeCancels && info.globalKey === 'ESCAPE') {
+        setIsListening(false);
+        return;
+      }
+
+      // 마우스 클릭으로 할당 시 버튼 재클릭 방지를 위한 플래그
+      justAssignedRef.current = true;
+      setTimeout(() => {
+        justAssignedRef.current = false;
+      }, 100);
+
+      setIsListening(false);
+      onCaptureRef.current(info.globalKey, listenIndex);
+    });
+
+    return () => {
+      try {
+        unsubscribe?.();
+      } catch (error) {
+        console.error('Failed to unsubscribe raw input listener', error);
+      }
+    };
+  }, [isListening, listenIndex, escapeCancels]);
+
+  // 리스닝 시작. index가 number면 해당 멤버 교체, null이면 추가
+  const startListen = (index: number | null) => {
+    if (justAssignedRef.current) return;
+    setListenIndex(index);
+    setIsListening(true);
+  };
+
+  const stopListen = () => {
+    setIsListening(false);
+  };
+
+  return { isListening, listenIndex, startListen, stopListen };
+}

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -172,7 +172,16 @@
     "noteBorderColor": "Border Color",
     "borderSideAll": "All",
     "borderSideVertical": "Vertical",
-    "borderSideHorizontal": "Horizontal"
+    "borderSideHorizontal": "Horizontal",
+    "addKey": "Add key",
+    "removeKey": "Remove key",
+    "matchMode": "Trigger",
+    "matchAny": "Individual",
+    "matchAll": "Combined",
+    "matchAnyHint": "Triggers when any key is pressed",
+    "matchAllHint": "Triggers only while all keys are held",
+    "multiKeyEdit": "Multi-key mapping",
+    "multiKey": "Binding details"
   },
   "imagePicker": {
     "idle": "Idle",
@@ -574,7 +583,16 @@
     "selectedSound": "Selected Sound",
     "soundVolume": "Sound Volume",
     "import": "Import",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "addKey": "Add key",
+    "removeKey": "Remove key",
+    "matchMode": "Trigger",
+    "matchAny": "Individual",
+    "matchAll": "Combined",
+    "matchAnyHint": "Triggers when any key is pressed",
+    "matchAllHint": "Triggers only while all keys are held",
+    "multiKeyEdit": "Multi-key mapping",
+    "multiKey": "Mapping details"
   },
   "fontPicker": {
     "searchPlaceholder": "Search...",

--- a/src/renderer/locales/ko.json
+++ b/src/renderer/locales/ko.json
@@ -172,7 +172,16 @@
     "noteBorderColor": "테두리 색상",
     "borderSideAll": "전체",
     "borderSideVertical": "수직",
-    "borderSideHorizontal": "수평"
+    "borderSideHorizontal": "수평",
+    "addKey": "키 추가",
+    "removeKey": "키 제거",
+    "matchMode": "반응 방식",
+    "matchAny": "개별 입력",
+    "matchAll": "동시 입력",
+    "matchAnyHint": "하나만 눌러도 반응",
+    "matchAllHint": "모두 동시에 눌러야 반응",
+    "multiKeyEdit": "여러 키 매핑",
+    "multiKey": "매핑 상세"
   },
   "imagePicker": {
     "idle": "대기",
@@ -574,7 +583,16 @@
     "selectedSound": "선택 파일",
     "soundVolume": "사운드 볼륨",
     "import": "가져오기",
-    "loading": "로딩..."
+    "loading": "로딩...",
+    "addKey": "키 추가",
+    "removeKey": "키 제거",
+    "matchMode": "반응 방식",
+    "matchAny": "개별 입력",
+    "matchAll": "동시 입력",
+    "matchAnyHint": "하나만 눌러도 반응",
+    "matchAllHint": "모두 동시에 눌러야 반응",
+    "multiKeyEdit": "여러 키 매핑",
+    "multiKey": "매핑 상세"
   },
   "fontPicker": {
     "searchPlaceholder": "검색",

--- a/src/renderer/locales/ru.json
+++ b/src/renderer/locales/ru.json
@@ -172,7 +172,16 @@
     "noteBorderColor": "Цвет обводки",
     "borderSideAll": "Все",
     "borderSideVertical": "Вертикально",
-    "borderSideHorizontal": "Горизонтально"
+    "borderSideHorizontal": "Горизонтально",
+    "addKey": "Добавить клавишу",
+    "removeKey": "Удалить клавишу",
+    "matchMode": "Срабатывание",
+    "matchAny": "Отдельно",
+    "matchAll": "Вместе",
+    "matchAnyHint": "Срабатывает при нажатии любой клавиши",
+    "matchAllHint": "Срабатывает, только когда зажаты все клавиши",
+    "multiKeyEdit": "Несколько клавиш",
+    "multiKey": "Детали привязки"
   },
   "imagePicker": {
     "idle": "Покой",
@@ -574,7 +583,16 @@
     "selectedSound": "Выбранный звук",
     "soundVolume": "Громкость",
     "import": "Импорт",
-    "loading": "Загрузка..."
+    "loading": "Загрузка...",
+    "addKey": "Добавить клавишу",
+    "removeKey": "Удалить клавишу",
+    "matchMode": "Срабатывание",
+    "matchAny": "Отдельно",
+    "matchAll": "Вместе",
+    "matchAnyHint": "Срабатывает при нажатии любой клавиши",
+    "matchAllHint": "Срабатывает, только когда зажаты все клавиши",
+    "multiKeyEdit": "Несколько клавиш",
+    "multiKey": "Детали привязки"
   },
   "fontPicker": {
     "searchPlaceholder": "Поиск...",

--- a/src/renderer/locales/zh-Hant.json
+++ b/src/renderer/locales/zh-Hant.json
@@ -172,7 +172,16 @@
     "noteBorderColor": "邊框顏色",
     "borderSideAll": "全部",
     "borderSideVertical": "垂直",
-    "borderSideHorizontal": "水平"
+    "borderSideHorizontal": "水平",
+    "addKey": "新增按鍵",
+    "removeKey": "移除按鍵",
+    "matchMode": "觸發方式",
+    "matchAny": "單獨輸入",
+    "matchAll": "同時輸入",
+    "matchAnyHint": "按下任意一鍵即觸發",
+    "matchAllHint": "需同時按住全部按鍵才觸發",
+    "multiKeyEdit": "多鍵映射",
+    "multiKey": "綁定詳情"
   },
   "imagePicker": {
     "idle": "閒置",
@@ -574,7 +583,16 @@
     "selectedSound": "已選音檔",
     "soundVolume": "音量",
     "import": "匯入",
-    "loading": "載入中..."
+    "loading": "載入中...",
+    "addKey": "新增按鍵",
+    "removeKey": "移除按鍵",
+    "matchMode": "觸發方式",
+    "matchAny": "單獨輸入",
+    "matchAll": "同時輸入",
+    "matchAnyHint": "按下任意一鍵即觸發",
+    "matchAllHint": "需同時按住全部按鍵才觸發",
+    "multiKeyEdit": "多鍵映射",
+    "multiKey": "映射詳情"
   },
   "fontPicker": {
     "searchPlaceholder": "搜尋",

--- a/src/renderer/locales/zh-cn.json
+++ b/src/renderer/locales/zh-cn.json
@@ -172,7 +172,16 @@
     "noteBorderColor": "边框颜色",
     "borderSideAll": "全部",
     "borderSideVertical": "垂直",
-    "borderSideHorizontal": "水平"
+    "borderSideHorizontal": "水平",
+    "addKey": "添加按键",
+    "removeKey": "移除按键",
+    "matchMode": "触发方式",
+    "matchAny": "单独输入",
+    "matchAll": "同时输入",
+    "matchAnyHint": "按下任意一键即触发",
+    "matchAllHint": "需同时按住全部按键才触发",
+    "multiKeyEdit": "多键映射",
+    "multiKey": "绑定详情"
   },
   "imagePicker": {
     "idle": "闲置",
@@ -574,7 +583,16 @@
     "selectedSound": "已选音频",
     "soundVolume": "音量",
     "import": "导入",
-    "loading": "加载中..."
+    "loading": "加载中...",
+    "addKey": "添加按键",
+    "removeKey": "移除按键",
+    "matchMode": "触发方式",
+    "matchAny": "单独输入",
+    "matchAll": "同时输入",
+    "matchAnyHint": "按下任意一键即触发",
+    "matchAllHint": "需同时按住全部按键才触发",
+    "multiKeyEdit": "多键映射",
+    "multiKey": "映射详情"
   },
   "fontPicker": {
     "searchPlaceholder": "搜索",

--- a/src/renderer/plugins/runtime/api/pluginApiProxy.ts
+++ b/src/renderer/plugins/runtime/api/pluginApiProxy.ts
@@ -10,6 +10,11 @@ import {
 } from '../context';
 import { createDefineElement } from './defineElement';
 import { createDefineSettings } from './defineSettings';
+import {
+  pluginEditorCommit,
+  pluginKeysUpdate,
+  pluginKeysUpdateWithPositions,
+} from './pluginWriteGateway';
 
 interface CreatePluginApiProxyOptions {
   pluginId: string;
@@ -57,6 +62,30 @@ export const createPluginApiProxy = (
 
   const proxiedApi = {
     ...wrappedApi,
+    // 플러그인 발신 keys·editor 쓰기는 게이트웨이로 명시 라우팅 (계약 §10)
+    // provenance를 전역 상태가 아니라 프록시 클로저로 결정
+    keys: {
+      ...((wrappedApi.keys as Record<string, unknown>) ?? {}),
+      update: wrapWithContext((...args: unknown[]) =>
+        pluginKeysUpdate(
+          args[0] as Parameters<typeof pluginKeysUpdate>[0],
+          args[1] as Parameters<typeof pluginKeysUpdate>[1],
+        ),
+      ),
+      updateWithPositions: wrapWithContext((...args: unknown[]) =>
+        pluginKeysUpdateWithPositions(
+          args[0] as Parameters<typeof pluginKeysUpdateWithPositions>[0],
+          args[1] as Parameters<typeof pluginKeysUpdateWithPositions>[1],
+          args[2] as Parameters<typeof pluginKeysUpdateWithPositions>[2],
+        ),
+      ),
+    },
+    editor: {
+      ...((wrappedApi.editor as Record<string, unknown>) ?? {}),
+      commit: wrapWithContext((...args: unknown[]) =>
+        pluginEditorCommit(args[0] as Parameters<typeof pluginEditorCommit>[0]),
+      ),
+    },
     window: {
       ...(wrappedApi.window ?? {}),
       type: window.__dmn_window_type as 'main' | 'overlay',

--- a/src/renderer/plugins/runtime/api/pluginWriteGateway.test.ts
+++ b/src/renderer/plugins/runtime/api/pluginWriteGateway.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const {
+  commitIsolatedPluginPatch,
+  runSerializedPluginCommit,
+  editorCommitRaw,
+} = vi.hoisted(() => ({
+  commitIsolatedPluginPatch: vi.fn(),
+  runSerializedPluginCommit: vi.fn(),
+  editorCommitRaw: vi.fn(),
+}));
+
+vi.mock('@src/renderer/editor/runtime/editorStateCoordinator', () => ({
+  editorCoordinator: { commitIsolatedPluginPatch, runSerializedPluginCommit },
+}));
+vi.mock('@api/modules/editorApi', () => ({ editorCommitRaw }));
+
+import {
+  pluginKeysUpdate,
+  pluginKeysUpdateWithPositions,
+} from './pluginWriteGateway';
+import type { KeyMappings, KeyPositions } from '@src/types/key/keys';
+
+describe('pluginWriteGateway', () => {
+  beforeEach(() => {
+    commitIsolatedPluginPatch.mockReset();
+    commitIsolatedPluginPatch.mockResolvedValue({
+      keys: {},
+      keyPositions: {},
+    });
+  });
+
+  it('rejects containers whose wire form is not an object map', async () => {
+    // Date는 객체 검사를 통과해도 wire에서는 문자열 - transport 전에 거절
+    await expect(
+      pluginKeysUpdateWithPositions(
+        new Date() as unknown as KeyMappings,
+        {} as KeyPositions,
+      ),
+    ).rejects.toThrow(TypeError);
+    await expect(
+      pluginKeysUpdate(null as unknown as KeyMappings),
+    ).rejects.toThrow(TypeError);
+    await expect(
+      pluginKeysUpdate([] as unknown as KeyMappings),
+    ).rejects.toThrow(TypeError);
+    await expect(
+      pluginKeysUpdate({ '4key': 'Z' } as unknown as KeyMappings),
+    ).rejects.toThrow(TypeError);
+    expect(commitIsolatedPluginPatch).not.toHaveBeenCalled();
+  });
+
+  it('normalizes slots like the backend before transport', async () => {
+    await pluginKeysUpdate(
+      {
+        '4key': [
+          'Z',
+          // 중복 멤버 제거, 구분자 포함 멤버 탈락 후 2개 유지
+          { keys: ['A', 'A', 'B', 'C+D'], match: 'any' },
+          // 정제 후 1개 남으면 Single로 축약
+          { keys: ['E', 'E'], match: 'all' },
+        ],
+      } as KeyMappings,
+      { multiKey: true },
+    );
+
+    expect(commitIsolatedPluginPatch).toHaveBeenCalledWith(
+      {
+        schemaVersion: 1,
+        keys: {
+          '4key': ['Z', { keys: ['A', 'B'], match: 'any' }, 'E'],
+        },
+      },
+      { multiKey: true },
+    );
+  });
+
+  it('passes the declared multiKey value through without promotion', async () => {
+    await pluginKeysUpdate({ '4key': ['Z'] });
+    expect(commitIsolatedPluginPatch).toHaveBeenLastCalledWith(
+      expect.anything(),
+      { multiKey: false },
+    );
+  });
+});

--- a/src/renderer/plugins/runtime/api/pluginWriteGateway.ts
+++ b/src/renderer/plugins/runtime/api/pluginWriteGateway.ts
@@ -1,0 +1,91 @@
+/**
+ * 플러그인 발신 keys·editor 쓰기 게이트웨이 (계약 §10)
+ * provenance는 전역 상태가 아니라 플러그인 프록시가 이 모듈을 명시 호출하는
+ * 것으로 결정된다. keys 쓰기는 coordinator의 공유 snapshot 병합에 합류하지
+ * 않고 단일 직렬 큐의 격리 커밋으로 처리한다.
+ */
+
+import { editorCommitRaw } from '@api/modules/editorApi';
+import { editorCoordinator } from '@src/renderer/editor/runtime/editorStateCoordinator';
+import type {
+  EditorCommitRequest,
+  EditorCommitResult,
+} from '@src/types/editor';
+import { normalizeSlot } from '@utils/keySlot';
+import type { KeyMappings, KeyPositions } from '@src/types/key/keys';
+
+interface PluginWriteOptions {
+  multiKey?: boolean;
+}
+
+// 계약 §2: 플러그인 입력도 무실패 정규화를 통과시켜 Rust normalize_key_slot과
+// 동일한 결과를 assert·diff·transport·반환값에 사용 (모드·슬롯 인덱스 보존).
+// 컨테이너 검증은 실제 wire(JSON) 표현 기준 - Date·URL·custom toJSON 객체가
+// 객체 검사를 통과한 채 빈 매핑으로 축약되면 기존 키 매핑 전체가 삭제될 수
+// 있으므로 Rust 역직렬화처럼 엄격 거절한다
+const normalizeMappings = (raw: unknown): KeyMappings => {
+  let wire: unknown;
+  try {
+    wire = raw === undefined ? undefined : JSON.parse(JSON.stringify(raw));
+  } catch {
+    throw new TypeError('keys mappings must be JSON-serializable');
+  }
+  if (
+    wire === null ||
+    wire === undefined ||
+    typeof wire !== 'object' ||
+    Array.isArray(wire)
+  ) {
+    throw new TypeError('keys mappings must be an object of mode arrays');
+  }
+  return Object.fromEntries(
+    Object.entries(wire as Record<string, unknown>).map(([mode, slots]) => {
+      if (!Array.isArray(slots)) {
+        throw new TypeError(`keys mappings['${mode}'] must be an array`);
+      }
+      return [mode, slots.map((slot) => normalizeSlot(slot))];
+    }),
+  );
+};
+
+// async: 검증 실패도 동기 throw가 아닌 rejection으로 전달 (플러그인 호출 관례)
+export const pluginKeysUpdate = async (
+  mappings: KeyMappings,
+  options?: PluginWriteOptions,
+): Promise<KeyMappings> => {
+  const document = await editorCoordinator.commitIsolatedPluginPatch(
+    { schemaVersion: 1, keys: normalizeMappings(mappings) },
+    { multiKey: options?.multiKey === true },
+  );
+  return document.keys;
+};
+
+export const pluginKeysUpdateWithPositions = async (
+  mappings: KeyMappings,
+  positions: KeyPositions,
+  options?: PluginWriteOptions,
+): Promise<{ keys: KeyMappings; positions: KeyPositions }> => {
+  const document = await editorCoordinator.commitIsolatedPluginPatch(
+    {
+      schemaVersion: 1,
+      keys: normalizeMappings(mappings),
+      keyPositions: positions,
+    },
+    { multiKey: options?.multiKey === true },
+  );
+  return { keys: document.keys, positions: document.keyPositions };
+};
+
+// 플러그인의 직접 editor_commit. keys를 포함하면 coordinator 큐로 직렬화해
+// 예약된 자사 변경보다 먼저 lock을 잡는 경합을 차단하고, envelope는 무가공
+// 전달 (multiKey는 플러그인이 선언한 값만 백엔드 게이트에 도달)
+export const pluginEditorCommit = (
+  request: EditorCommitRequest,
+): Promise<EditorCommitResult> => {
+  if (request?.changes?.keys !== undefined) {
+    return editorCoordinator.runSerializedPluginCommit(() =>
+      editorCommitRaw(request),
+    );
+  }
+  return editorCommitRaw(request);
+};

--- a/src/renderer/stores/grid/useGridSelectionStore.ts
+++ b/src/renderer/stores/grid/useGridSelectionStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { KeyPosition } from '@src/types/key/keys';
+import type { KeyPosition, KeySlot } from '@src/types/key/keys';
 import type { PluginDisplayElementInternal } from '@src/types/plugin/api';
 import type { StatItemPosition } from '@src/types/key/statItems';
 import type { GraphItemPosition } from '@src/types/key/graphItems';
@@ -35,7 +35,7 @@ export interface SelectedElement {
 // 클립보드에 저장되는 키 데이터
 export interface ClipboardKeyData {
   type: 'key';
-  keyCode: string;
+  keyCode: KeySlot;
   position: KeyPosition;
 }
 

--- a/src/renderer/utils/keySlot.ts
+++ b/src/renderer/utils/keySlot.ts
@@ -1,0 +1,123 @@
+import type { KeySlot, MultiKeySlot, SlotMatch } from '@src/types/key/keys';
+import { getKeyInfoByGlobalKey } from './core/KeyMaps';
+
+// 계약 v4 §2: 슬롯당 멤버 상한
+export const MAX_SLOT_KEYS = 8;
+// 계약 v4 §2: 모드 내 한 멤버 라벨의 참조 슬롯 상한
+export const MAX_SLOTS_PER_MEMBER = 16;
+
+// canonical 조인 구분자 (생성·비교 전용, 파싱 금지)
+const ALL_SEPARATOR = '+';
+const ANY_SEPARATOR = '|';
+
+export const isMultiSlot = (slot: KeySlot): slot is MultiKeySlot =>
+  typeof slot !== 'string';
+
+export const slotMembers = (slot: KeySlot): string[] => {
+  if (isMultiSlot(slot)) return slot.keys;
+  return slot === '' ? [] : [slot];
+};
+
+export const slotMatch = (slot: KeySlot): SlotMatch | 'single' =>
+  isMultiSlot(slot) ? slot.match : 'single';
+
+export const isSlotAssigned = (slot: KeySlot): boolean =>
+  isMultiSlot(slot) || slot !== '';
+
+// 계약 v4 §3: Rust KeySlot::canonical과 바이트 일치 필수
+export const slotCanonical = (slot: KeySlot): string => {
+  if (!isMultiSlot(slot)) return slot;
+  return slot.keys.join(slot.match === 'all' ? ALL_SEPARATOR : ANY_SEPARATOR);
+};
+
+// 표시 라벨 합성: all → LCtrl+Z, any → Z/B
+export const slotDisplayName = (slot: KeySlot): string => {
+  if (!isMultiSlot(slot)) {
+    return slot === '' ? '' : getKeyInfoByGlobalKey(slot).displayName;
+  }
+  const parts = slot.keys.map((key) => getKeyInfoByGlobalKey(key).displayName);
+  return parts.join(slot.match === 'all' ? '+' : '/');
+};
+
+// 편집 UI의 입력 방식: 단일(키 1개) / 개별(any) / 동시(all)
+export type KeySlotUiMode = 'single' | SlotMatch;
+
+// 슬롯 → UI 입력 방식
+export const slotUiMode = (slot: KeySlot): KeySlotUiMode =>
+  isMultiSlot(slot) ? slot.match : 'single';
+
+// 행 버튼용 축약 라벨: 멀티 슬롯은 첫 키 + "+N" 배지 (키가 많아도 길어지지 않음)
+// extra는 개수 배지라 본문과 다른 색으로 렌더하도록 분리 반환
+export const slotCompactParts = (
+  slot: KeySlot,
+): { label: string; extra: string | null } => {
+  if (!isMultiSlot(slot)) return { label: slotDisplayName(slot), extra: null };
+  return {
+    label: getKeyInfoByGlobalKey(slot.keys[0]).displayName,
+    extra: `+${slot.keys.length - 1}`,
+  };
+};
+
+// 멤버로 쓸 수 없는 문자열 (구분자 포함, canonical 단사성 보장)
+export const isValidSlotMember = (key: string): boolean =>
+  key !== '' && !key.includes(ALL_SEPARATOR) && !key.includes(ANY_SEPARATOR);
+
+// 계약 v4 §2: 무실패 정규화 (Rust normalize_key_slot과 동일 결과)
+export const normalizeSlot = (raw: unknown): KeySlot => {
+  if (typeof raw === 'string') return raw;
+  if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) {
+    const candidate = raw as { keys?: unknown; match?: unknown };
+    if (candidate.match !== 'all' && candidate.match !== 'any') return '';
+    if (!Array.isArray(candidate.keys)) return '';
+    const members: string[] = [];
+    for (const entry of candidate.keys) {
+      if (typeof entry !== 'string' || !isValidSlotMember(entry)) continue;
+      if (members.includes(entry)) continue;
+      members.push(entry);
+      if (members.length >= MAX_SLOT_KEYS) break;
+    }
+    if (members.length >= 2) return { keys: members, match: candidate.match };
+    if (members.length === 1) return members[0];
+    return '';
+  }
+  return '';
+};
+
+// 멤버 목록 + 판정으로 슬롯 구성 (캡처 UI용)
+// 멤버 1개 이하는 문자열 그대로 통과 (레거시 Single 무손실, 계약 §2 규칙 1)
+export const buildSlot = (members: string[], match: SlotMatch): KeySlot => {
+  if (members.length <= 1) return members[0] ?? '';
+  return normalizeSlot({ keys: members, match });
+};
+
+// 슬롯 복제 (클립보드 등 공유 참조 방지)
+export const cloneSlot = (slot: KeySlot): KeySlot =>
+  isMultiSlot(slot) ? { keys: [...slot.keys], match: slot.match } : slot;
+
+// 구분자 포함 Single(수제 데이터)은 매칭 불가한 inert 슬롯 (계약 §3 잔존 edge)
+export const isInertSingle = (slot: KeySlot): boolean =>
+  !isMultiSlot(slot) &&
+  slot !== '' &&
+  slot !== ALL_SEPARATOR &&
+  (slot.includes(ALL_SEPARATOR) || slot.includes(ANY_SEPARATOR));
+
+// canonical → 대표 슬롯 인덱스 (노트 이펙트용, Multi 우선 후 첫 등장)
+export const buildCanonicalIndexMap = (
+  slots: readonly KeySlot[],
+): Map<string, number> => {
+  const map = new Map<string, number>();
+  slots.forEach((slot, index) => {
+    if (!isSlotAssigned(slot)) return;
+    const canonical = slotCanonical(slot);
+    const existing = map.get(canonical);
+    if (existing === undefined) {
+      map.set(canonical, index);
+      return;
+    }
+    // inert Single이 선점한 자리는 실제 Multi가 대체 (계약 §11)
+    if (isInertSingle(slots[existing]) && isMultiSlot(slot)) {
+      map.set(canonical, index);
+    }
+  });
+  return map;
+};

--- a/src/renderer/utils/keyStatsService.ts
+++ b/src/renderer/utils/keyStatsService.ts
@@ -19,6 +19,7 @@ class KeyStatsService {
   private listeners: Set<KeyStatsListener> = new Set();
   private initialized = false;
   private unlistenKeyState: (() => void) | null = null;
+  private unlistenInputPress: (() => void) | null = null;
   private unlistenCounterChanged: (() => void) | null = null;
   private unlistenCountersChanged: (() => void) | null = null;
   private unlistenModeChanged: (() => void) | null = null;
@@ -57,6 +58,15 @@ class KeyStatsService {
         'keys:state',
         ({ payload }) => {
           this.handleKeyState(payload);
+        },
+      );
+
+      // 물리 press 이벤트 구독 (KPS 집계, 계약 §6)
+      // 한 물리 입력이 여러 슬롯을 트리거해도 1회만 발행됨
+      this.unlistenInputPress = await listen<{ label: string; mode: string }>(
+        'input:press',
+        () => {
+          this.timestamps.push(Date.now());
         },
       );
 
@@ -142,12 +152,9 @@ class KeyStatsService {
   private handleKeyState(payload: KeyStatePayload) {
     const { key, state } = payload;
 
+    // KPS 집계는 input:press가 담당, 여기서는 홀드 상태만 추적
     if (state === 'DOWN') {
-      // 키가 이미 눌려있지 않은 경우에만 카운팅 (홀드 방지)
-      if (!this.pressedKeys.has(key)) {
-        this.pressedKeys.add(key);
-        this.timestamps.push(Date.now());
-      }
+      this.pressedKeys.add(key);
     } else if (state === 'UP') {
       this.pressedKeys.delete(key);
     }
@@ -343,6 +350,11 @@ class KeyStatsService {
     if (this.unlistenKeyState) {
       this.unlistenKeyState();
       this.unlistenKeyState = null;
+    }
+
+    if (this.unlistenInputPress) {
+      this.unlistenInputPress();
+      this.unlistenInputPress = null;
     }
 
     if (this.unlistenCounterChanged) {

--- a/src/renderer/windows/overlay/App.test.tsx
+++ b/src/renderer/windows/overlay/App.test.tsx
@@ -491,6 +491,24 @@ describe('note timing payload and loss recovery', () => {
     expect(timing.displayTime - timing.physTime).toBeCloseTo(250, 0);
   });
 
+  it('UP payload에 holdDurationMs가 없으면 optional 값으로 전달한다', async () => {
+    await act(async () => {
+      mocks.keyEventListener?.({
+        key: 'KeyJ',
+        state: 'UP',
+        mode: '4key',
+        eventAgeMs: 30,
+      });
+    });
+
+    expect(mocks.handleKeyUp).toHaveBeenCalledTimes(1);
+    const [, timing] = mocks.handleKeyUp.mock.calls[0] as [
+      string,
+      { holdDurationMs?: number },
+    ];
+    expect(timing.holdDurationMs).toBeUndefined();
+  });
+
   it('keys:reset 수신 시 활성 노트를 강제 완료하고 눌림 상태를 재수화한다', async () => {
     mocks.bootstrap.mockResolvedValue({ activeKeys: ['KeyJ'] });
 

--- a/src/renderer/windows/overlay/App.tsx
+++ b/src/renderer/windows/overlay/App.tsx
@@ -28,6 +28,13 @@ import { useSettingsStore } from '@stores/useSettingsStore';
 import { usePluginDisplayElementStore } from '@stores/plugin/usePluginDisplayElementStore';
 import OverlayScene from '@components/shared/OverlayScene';
 import { computeLayout } from '@hooks/shared/useLayoutComputation';
+import {
+  buildCanonicalIndexMap,
+  isSlotAssigned,
+  slotCanonical,
+  slotDisplayName,
+} from '@utils/keySlot';
+import type { KeySlot } from '@src/types/key/keys';
 
 type KeyDelayTimerHandle = ReturnType<typeof setTimeout>;
 type KeyDelayTimerEntry = {
@@ -63,11 +70,11 @@ const flushKeyDelayTimers = (
 // 값이 와도 노트가 화면 위로 튀지 않도록 제한
 const MAX_EVENT_AGE_MS = 250;
 
-const validKeySet = (keys: readonly string[]) =>
-  new Set(keys.filter((key) => key.length > 0));
+const validKeySet = (slots: readonly KeySlot[]) =>
+  new Set(slots.filter(isSlotAssigned).map((slot) => slotCanonical(slot)));
 
-const validKeySignature = (keys: readonly string[]) =>
-  JSON.stringify([...validKeySet(keys)].sort());
+const validKeySignature = (slots: readonly KeySlot[]) =>
+  JSON.stringify([...validKeySet(slots)].sort());
 
 export default function App() {
   const isBootstrapped = useKeyStore((state) => state.isBootstrapped);
@@ -526,9 +533,11 @@ export default function App() {
 
               if (isDown) {
                 // 개별 키의 noteEffectEnabled는 DOWN에만 적용
-                const currentKeys = keyMappings[selectedKeyType] ?? [];
+                // canonical → 대표 슬롯 인덱스 (Multi 우선, 계약 §11)
+                const currentSlots = keyMappings[selectedKeyType] ?? [];
                 const currentPositions = positions[selectedKeyType] ?? [];
-                const keyIndex = currentKeys.indexOf(key);
+                const keyIndex =
+                  buildCanonicalIndexMap(currentSlots).get(key) ?? -1;
                 const keyPosition = currentPositions[keyIndex];
                 if (keyPosition?.noteEffectEnabled !== false) {
                   handleKeyDown(key, timing);
@@ -692,8 +701,11 @@ export default function App() {
     // 콜백이 읽는 값은 keyEventContextRef로 공급 - 구독은 창 수명과 동일
   }, []);
 
-  const currentKeys = keyMappings[selectedKeyType] ?? [];
-  const currentValidKeySignature = validKeySignature(currentKeys);
+  const currentSlots = keyMappings[selectedKeyType] ?? [];
+  // 시그널·트랙 키는 canonical, 표시는 합성 라벨 (계약 §3, §11)
+  const currentKeys = currentSlots.map((slot) => slotCanonical(slot));
+  const currentKeyLabels = currentSlots.map((slot) => slotDisplayName(slot));
+  const currentValidKeySignature = validKeySignature(currentSlots);
 
   // 탭·현재 키 집합 전환 시 예약 타이머와 눌림 신호를 권위 상태로 정합
   // positions와 다른 탭의 매핑 변경은 signature가 같아 이 effect를 건드리지 않음
@@ -843,6 +855,7 @@ export default function App() {
   return (
     <OverlayScene
       currentKeys={currentKeys}
+      currentKeyLabels={currentKeyLabels}
       displayPositions={displayPositions}
       currentPositions={currentPositions}
       displayStatPositions={displayStatPositions}

--- a/src/renderer/windows/overlay/App.tsx
+++ b/src/renderer/windows/overlay/App.tsx
@@ -8,6 +8,7 @@ import { LogicalPosition, PhysicalPosition } from '@tauri-apps/api/dpi';
 import { Menu } from '@tauri-apps/api/menu';
 import { useTranslation } from '@contexts/useTranslation';
 import { DEFAULT_NOTE_SETTINGS } from '@constants/overlayDefaults';
+import { MAX_EVENT_AGE_MS } from '@constants/inputTiming';
 import { mergeNoteSettings } from '@src/types/settings/noteSettings';
 import { useCustomCssInjection } from '@hooks/app/useCustomCssInjection';
 import { useCustomJsInjection } from '@hooks/app/useCustomJsInjection';
@@ -74,10 +75,6 @@ const flushKeyDelayTimers = (
     apply();
   });
 };
-
-// 입력 시각 보정용 age 상한(ms). 백엔드 stall/클럭 이상으로 비정상적으로 큰
-// 값이 와도 노트가 화면 위로 튀지 않도록 제한
-const MAX_EVENT_AGE_MS = 250;
 
 const validKeySet = (slots: readonly KeySlot[]) =>
   new Set(slots.filter(isSlotAssigned).map((slot) => slotCanonical(slot)));

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -1,6 +1,7 @@
 import type { GraphItemPositions } from '@src/types/key/graphItems';
 import {
   keyPositionSchema,
+  keySlotSchema,
   type KeyMappings,
   type KeyPositions,
 } from '@src/types/key/keys';
@@ -47,6 +48,9 @@ export interface EditorCommitRequest {
   gestureId?: string;
   // 한 요청으로 합쳐진 프리뷰 세션 전체
   gestureIds?: string[];
+  // 멀티 키 슬롯 지원 선언. keys를 포함한 커밋에서 현재 매핑에 멀티 슬롯이
+  // 존재하는데 이 선언이 없으면 백엔드가 MULTI_KEY_UNSUPPORTED로 거절
+  multiKey?: boolean;
 }
 
 export interface EditorCommitResult {
@@ -90,7 +94,9 @@ export type EditorCommitErrorCode =
   // undo/redo barrier 진행 중, retryable
   | 'HISTORY_IN_PROGRESS'
   // observedHistoryEpoch가 낡음, retryable
-  | 'HISTORY_EPOCH_CONFLICT';
+  | 'HISTORY_EPOCH_CONFLICT'
+  // 멀티 키 슬롯 존재 + multiKey 미선언 keys 쓰기, 비 retryable
+  | 'MULTI_KEY_UNSUPPORTED';
 
 export interface EditorCommitErrorDetails {
   currentRevision?: number;
@@ -116,6 +122,7 @@ const EDITOR_ERROR_CODES = new Set<EditorCommitErrorCode>([
   'IO_ERROR',
   'HISTORY_IN_PROGRESS',
   'HISTORY_EPOCH_CONFLICT',
+  'MULTI_KEY_UNSUPPORTED',
 ]);
 
 const EDITOR_FIELD_SET = new Set<string>(EDITOR_FIELDS);
@@ -209,8 +216,12 @@ function assertModeRecord(
 
 const assertKeyMappings = (value: unknown, label: string): void => {
   assertModeRecord(value, label, (item, itemLabel) => {
-    if (typeof item !== 'string') {
-      throw new EditorProtocolError(`${itemLabel} must be a string`);
+    // 슬롯은 문자열 또는 멀티 키 객체 (KeySlot union)
+    if (typeof item === 'string') return;
+    if (!keySlotSchema.safeParse(item).success) {
+      throw new EditorProtocolError(
+        `${itemLabel} must be a string or a multi-key slot`,
+      );
     }
   });
 };

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -102,6 +102,7 @@ export interface EditorCommitErrorDetails {
   currentRevision?: number;
   validationCode?: string;
   field?: string;
+  currentHistoryEpoch?: number;
 }
 
 export interface EditorCommitError {

--- a/src/types/key/keys.ts
+++ b/src/types/key/keys.ts
@@ -207,6 +207,24 @@ export function normalizeCounterSettings(raw: unknown): KeyCounterSettings {
 
 export const keySchema = z.string();
 
+// 슬롯 판정 방식: all = 동시 입력, any = 택일
+export const slotMatchSchema = z.union([z.literal('all'), z.literal('any')]);
+export type SlotMatch = z.infer<typeof slotMatchSchema>;
+
+export const multiKeySlotSchema = z.object({
+  keys: z.array(z.string().min(1)).min(2).max(8),
+  match: slotMatchSchema,
+});
+// z.infer가 match를 optional로 추론하지 않도록 명시 선언
+export interface MultiKeySlot {
+  keys: string[];
+  match: SlotMatch;
+}
+
+// 단일 키는 문자열 그대로 유지 (하위 호환)
+export const keySlotSchema = z.union([keySchema, multiKeySlotSchema]);
+export type KeySlot = string | MultiKeySlot;
+
 export const keyModeSchema = z.union([
   z.literal('4key'),
   z.literal('5key'),
@@ -216,8 +234,8 @@ export const keyModeSchema = z.union([
 
 export type KeyMode = z.infer<typeof keyModeSchema> | string;
 
-export const keyMappingSchema = z.record(z.string(), z.array(keySchema));
-export type KeyMappings = Record<string, string[]>;
+export const keyMappingSchema = z.record(z.string(), z.array(keySlotSchema));
+export type KeyMappings = Record<string, KeySlot[]>;
 
 const gradientNoteColorSchema = z.object({
   type: z.literal('gradient'),

--- a/src/types/obs.ts
+++ b/src/types/obs.ts
@@ -1,6 +1,7 @@
 // OBS WebSocket 프로토콜 타입
 
-export const OBS_PROTOCOL_VERSION = 1;
+// v2: 키 슬롯 와이어 형식이 KeySlot union(string | MultiKeySlot)으로 확장됨
+export const OBS_PROTOCOL_VERSION = 2;
 export const DEFAULT_OBS_PORT = 34891;
 
 export interface ObsEnvelope<T = unknown> {

--- a/src/types/plugin/api.ts
+++ b/src/types/plugin/api.ts
@@ -916,10 +916,16 @@ export interface DMNoteAPI {
   keys: {
     get(): Promise<KeyMappings>;
     getCounters(): Promise<KeyCounters>;
-    update(mappings: KeyMappings): Promise<KeyMappings>;
+    // multiKey: 멀티 키 슬롯 지원 선언. 현재 매핑에 멀티 슬롯이 있는데
+    // 선언 없이 쓰면 MULTI_KEY_UNSUPPORTED로 거절됨
+    update(
+      mappings: KeyMappings,
+      options?: { multiKey?: boolean },
+    ): Promise<KeyMappings>;
     updateWithPositions(
       mappings: KeyMappings,
       positions: KeyPositions,
+      options?: { multiKey?: boolean },
     ): Promise<{ keys: KeyMappings; positions: KeyPositions }>;
     getPositions(): Promise<KeyPositions>;
     updatePositions(positions: KeyPositions): Promise<KeyPositions>;


### PR DESCRIPTION
## 개요

한 슬롯에 여러 키를 매핑하는 기능 추가. 개별 매핑은 멤버 키 중 하나만 눌러도 반응하고, 동시 매핑은 전부 함께 눌러야 반응합니다.

관련 이슈: #71

## 변경 내용

- 저장 스키마를 문자열 또는 멀티 키 객체를 담는 KeySlot union으로 확장, 기존 문자열 슬롯은 무손실 유지
- 시그널·카운터·이벤트는 canonical 식별자 사용, 동시 매핑은 `+`, 개별 매핑은 `|`로 조인
- 슬롯 피커 UI 개편: 키 1개면 단일 자동, 키 추가 시 개별로 승격, 플랫 행 리스트와 +N 배지
- 키음은 물리 다운당 1회로 고정, 한 키가 여러 슬롯에 속해도 중복 재생 없음
- OBS 프로토콜 v2 상향: 스키마가 다른 구버전 오버레이 페이지는 결정적으로 거부, 브라우저 소스 새로고침으로 복구
- 플러그인 keys 쓰기에 multiKey 선언 게이트 도입, 멀티 슬롯을 모르는 플러그인의 파괴적 쓰기 차단
- 구버전 store와 프리셋은 정규화 단일 진입점으로 무손실 로드, 다운그레이드 시 멀티 슬롯만 제자리 빈 슬롯 대체
- en/ko 플러그인 문서 정비: canonical 규칙 문서화, 오류 코드 표 완비, presets 문서를 실제 API 기준으로 재작성