### PR TITLE
fix: 편집 세션을 편집 대상에 결합

### DIFF
--- a/src/renderer/__tests__/previewOverlaySession.test.ts
+++ b/src/renderer/__tests__/previewOverlaySession.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useGraphItemStore } from '@stores/data/useGraphItemStore';
 import { useKeyStore } from '@stores/data/useKeyStore';
+import { useGridSelectionStore } from '@stores/grid/useGridSelectionStore';
 import { useKnobItemStore } from '@stores/data/useKnobItemStore';
 import { useStatItemStore } from '@stores/data/useStatItemStore';
 import {
@@ -403,6 +404,26 @@ describe('editGestureController', () => {
 
     expect(editGestureController.hasActiveGesture()).toBe(true);
     expect(useKeyStore.getState().positions['4key'][0].width).toBe(100);
+  });
+
+  it('settleCommit 실패 뒤 편집 대상이 갈렸으면 세션을 되살리지 않는다', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    useGridSelectionStore.setState({
+      selectedElements: [{ type: 'key', id: 'key-0', index: 0 }],
+    });
+    editGestureController.preview('4key', [
+      { index: 0, patch: { width: 100 } },
+    ]);
+
+    editGestureController.settleCommit(Promise.reject(new Error('io')));
+    // 정산이 끝나기 전에 선택이 다른 요소로 넘어간다 (분리 패널 selection sync)
+    useGridSelectionStore.setState({
+      selectedElements: [{ type: 'key', id: 'key-1', index: 1 }],
+    });
+    await flushPromises();
+
+    // 되살리면 index 0 patch가 다음 커밋 경계에서 남의 값을 덮는다
+    expect(editGestureController.hasActiveGesture()).toBe(false);
   });
 
   it('cancel은 canonical을 건드리지 않고 오버레이만 제거', () => {

--- a/src/renderer/components/main/Grid/PropertiesPanel.detachedContracts.test.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel.detachedContracts.test.tsx
@@ -50,7 +50,7 @@ vi.mock('./PropertiesPanel/index', () => {
   );
   const SingleKeyStatPanel = (props: Record<string, unknown>) => {
     singleKeyStatPropsMock(props);
-    return <div />;
+    return <ScopeProbe id="single-key-stat" />;
   };
   return {
     TABS: { STYLE: 'style', NOTE: 'note', COUNTER: 'counter' },
@@ -70,7 +70,7 @@ vi.mock('./PropertiesPanel/index', () => {
     },
     BatchGraphOnlyPanel: Stub,
     BatchKnobOnlyPanel: Stub,
-    PluginSettingsPanelView: Stub,
+    PluginSettingsPanelView: () => <ScopeProbe id="plugin-settings" />,
     useBatchHandlers: (props: Record<string, unknown>) => {
       batchPropsMock(props);
       return {};
@@ -93,7 +93,14 @@ vi.mock('./PropertiesPanel/PanelToggleButton', () => ({
 vi.mock('@components/main/common/Checkbox', () => ({ default: () => null }));
 vi.mock('@components/main/common/Dropdown', () => ({ default: () => null }));
 
+import { useIsEditSessionScoped } from '@src/renderer/contexts/EditSessionScope';
+
 import PropertiesPanel from './PropertiesPanel';
+
+// 대상 전환 억제는 캔버스 선택 패널 안에서만 걸려야 한다
+const ScopeProbe = ({ id }: { id: string }) => (
+  <div data-testid={id} data-scoped={String(useIsEditSessionScoped())} />
+);
 
 interface MountedPanel {
   container: HTMLDivElement;
@@ -267,6 +274,58 @@ describe('PropertiesPanel detached preview contract', () => {
 
 // 배치 색상 draft는 피커를 열 때 첫 요소에서 한 번만 떠 온다.
 // 그 상태가 편집 트리 바깥(PropertiesPanel)에 있어 리마운트 경계로는 안 걷힌다
+// 대상 전환 억제는 캔버스 선택 패널에서만 걸려야 한다.
+// 플러그인 설정 세션은 캔버스 선택과 무관한데, 그 폼의 색상 피커까지 억제되면
+// 무관한 선택 변경 뒤 피커가 닫힐 때 멀쩡한 색 편집이 폐기된다
+describe('PropertiesPanel 편집 세션 scope 경계', () => {
+  let mounted: MountedPanel;
+
+  const scopedOf = (id: string) =>
+    mounted.container
+      .querySelector(`[data-testid="${id}"]`)
+      ?.getAttribute('data-scoped');
+
+  beforeEach(() => {
+    resetStores();
+  });
+
+  afterEach(() => {
+    act(() => mounted.root.unmount());
+    mounted.container.remove();
+    document
+      .querySelectorAll('[data-dmn-modal-backdrop], [data-dmn-popup-layer]')
+      .forEach((node) => node.remove());
+  });
+
+  it('캔버스 선택 패널은 편집 세션 scope 안이다', () => {
+    useGridSelectionStore.setState({
+      selectedElements: [{ type: 'stat', id: 'stat-0', index: 0 }],
+      selectedGroupIds: [],
+    });
+    mounted = mountPanel(true);
+
+    expect(scopedOf('single-key-stat')).toBe('true');
+  });
+
+  it('플러그인 설정 패널은 편집 세션 scope 밖이다', () => {
+    usePropertiesPanelStore.setState({
+      pluginSettingsPanel: {
+        pluginId: 'scope-test',
+        definition: { settings: {} },
+        settings: {},
+        originalSettings: {},
+        onChange: vi.fn(),
+        onConfirm: vi.fn(),
+        onCancel: vi.fn(),
+        resolve: vi.fn(),
+      } as never,
+    });
+    mounted = mountPanel(true);
+
+    expect(scopedOf('plugin-settings')).toBe('false');
+  });
+});
+
 describe('PropertiesPanel 배치 색상 피커 대상 결합', () => {
   let mounted: MountedPanel;
 

--- a/src/renderer/components/main/Grid/PropertiesPanel.detachedContracts.test.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel.detachedContracts.test.tsx
@@ -13,11 +13,13 @@ import { useKeySlotCapture } from '@hooks/useKeySlotCapture';
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const {
+  batchKeyLikePropsMock,
   batchPropsMock,
   previewMock,
   settleCommitMock,
   singleKeyStatPropsMock,
 } = vi.hoisted(() => ({
+  batchKeyLikePropsMock: vi.fn(),
   batchPropsMock: vi.fn(),
   previewMock: vi.fn(),
   settleCommitMock: vi.fn(),
@@ -62,7 +64,10 @@ vi.mock('./PropertiesPanel/index', () => {
     SingleGraphPanel: Stub,
     SingleKnobPanel: Stub,
     SingleKeyStatPanel,
-    BatchKeyLikePanel: Stub,
+    BatchKeyLikePanel: (props: Record<string, unknown>) => {
+      batchKeyLikePropsMock(props);
+      return <div />;
+    },
     BatchGraphOnlyPanel: Stub,
     BatchKnobOnlyPanel: Stub,
     PluginSettingsPanelView: Stub,
@@ -125,6 +130,7 @@ const resetStores = () => {
   settleCommitMock.mockClear();
   singleKeyStatPropsMock.mockClear();
   batchPropsMock.mockClear();
+  batchKeyLikePropsMock.mockClear();
   useKeyStore.setState({
     selectedKeyType: '4key',
     keyMappings: { '4key': [] },
@@ -256,6 +262,70 @@ describe('PropertiesPanel detached preview contract', () => {
         { domain: 'knobPosition' },
       ],
     ]);
+  });
+});
+
+// 배치 색상 draft는 피커를 열 때 첫 요소에서 한 번만 떠 온다.
+// 그 상태가 편집 트리 바깥(PropertiesPanel)에 있어 리마운트 경계로는 안 걷힌다
+describe('PropertiesPanel 배치 색상 피커 대상 결합', () => {
+  let mounted: MountedPanel;
+
+  const selectKeys = (...indices: number[]) => {
+    useGridSelectionStore.setState({
+      selectedElements: indices.map((index) => ({
+        type: 'key' as const,
+        id: `key-${index}`,
+        index,
+      })),
+      selectedGroupIds: [],
+    });
+  };
+
+  const latestBatchProps = () =>
+    batchKeyLikePropsMock.mock.lastCall?.[0] as {
+      batchPickerFor: string | null;
+      handleBatchPickerToggle: (target: string) => void;
+    };
+
+  beforeEach(() => {
+    resetStores();
+    useKeyStore.setState({
+      selectedKeyType: '4key',
+      keyMappings: { '4key': ['KeyA', 'KeyS', 'KeyD'] as never },
+      positions: {
+        '4key': [
+          { dx: 0, dy: 0, width: 60, height: 60 },
+          { dx: 0, dy: 0, width: 60, height: 60 },
+          { dx: 0, dy: 0, width: 60, height: 60 },
+        ] as never,
+      },
+    });
+    selectKeys(0, 1, 2);
+    mounted = mountPanel(true);
+  });
+
+  afterEach(() => {
+    act(() => mounted.root.unmount());
+    mounted.container.remove();
+  });
+
+  it('선택이 바뀌면 열려 있던 배치 색상 피커를 닫는다', () => {
+    act(() => latestBatchProps().handleBatchPickerToggle('noteColor'));
+    expect(latestBatchProps().batchPickerFor).toBe('noteColor');
+
+    act(() => selectKeys(0, 1));
+
+    expect(latestBatchProps().batchPickerFor).toBeNull();
+  });
+
+  // 선택을 건드리지 않는 재렌더까지 닫으면 피커를 쓸 수가 없다.
+  // 기존 이미지 피커 3종과 같은 조건(선택 store 갱신)에만 반응해야 한다
+  it('선택을 건드리지 않는 재렌더는 피커를 닫지 않는다', () => {
+    act(() => latestBatchProps().handleBatchPickerToggle('noteColor'));
+
+    act(() => mounted.render(true));
+
+    expect(latestBatchProps().batchPickerFor).toBe('noteColor');
   });
 });
 

--- a/src/renderer/components/main/Grid/PropertiesPanel.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel.tsx
@@ -86,6 +86,7 @@ import PanelToggleButton from './PropertiesPanel/PanelToggleButton';
 import Checkbox from '@components/main/common/Checkbox';
 import Dropdown from '@components/main/common/Dropdown';
 import type { NoteColor } from '@src/types/key/keys';
+import { EditSessionScope } from '@src/renderer/contexts/EditSessionScope';
 
 const getStatTypeLabel = (statType?: StatItemType | null): string => {
   switch (statType) {
@@ -2456,49 +2457,8 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
   // 렌더링
   // ============================================================================
 
-  // 선택 상태별 구상 패널 — 프레임(글래스) 안의 루트 페이지 콘텐츠
-  const renderPanelBody = () => {
-    if (pluginSettingsPanel) {
-      return (
-        <PluginSettingsPanelView
-          setPanelElement={setPanelElement}
-          pluginSettingsPanel={pluginSettingsPanel}
-          pluginPanelSettings={pluginPanelSettings}
-          handlePluginSettingsPanelChange={handlePluginSettingsPanelChange}
-          handlePluginSettingsPanelConfirm={handlePluginSettingsPanelConfirm}
-          isSaving={isPluginSettingsSaving}
-          setPluginScrollRef={setPluginScrollRef}
-          renderPluginSettingsForm={renderPluginSettingsForm}
-          reportNormalizationError={reportPluginNormalizationError}
-          t={t}
-        />
-      );
-    }
-
-    // 레이어 모드일 때는 선택 여부와 관계없이 레이어 패널 표시
-    if (panelMode === 'layer') {
-      return (
-        <LayerPanel
-          onSwitchToProperty={handleToggleMode}
-          onSelectionFromPanel={() => {
-            selectionFromLayerPanelRef.current = true;
-          }}
-        />
-      );
-    }
-
-    // 선택된 키 요소가 없으면 레이어 패널 표시
-    if (selectedKeyElements.length === 0 && selectedElements.length === 0) {
-      return (
-        <LayerPanel
-          onSwitchToProperty={handleToggleMode}
-          onSelectionFromPanel={() => {
-            selectionFromLayerPanelRef.current = true;
-          }}
-        />
-      );
-    }
-
+  // 캔버스 선택에 묶인 구상 패널 — 프레임(글래스) 안의 루트 페이지 콘텐츠
+  const renderSelectionPanelBody = () => {
     // 다중 선택인 경우 (키/통계 포함, 또는 그래프+노브 혼합)
     if (
       selectedBatchStyleElements.length > 1 &&
@@ -2855,6 +2815,54 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
         t={t}
       />
     );
+  };
+
+  // 캔버스 선택에 묶이지 않는 뷰는 EditSessionScope 밖에 둔다.
+  // 플러그인 설정 세션의 색상 피커까지 대상 전환 억제를 걸면, 무관한 캔버스 선택
+  // 변경 뒤에 피커가 닫힐 때 멀쩡한 색 편집이 폐기된다
+  const renderPanelBody = () => {
+    if (pluginSettingsPanel) {
+      return (
+        <PluginSettingsPanelView
+          setPanelElement={setPanelElement}
+          pluginSettingsPanel={pluginSettingsPanel}
+          pluginPanelSettings={pluginPanelSettings}
+          handlePluginSettingsPanelChange={handlePluginSettingsPanelChange}
+          handlePluginSettingsPanelConfirm={handlePluginSettingsPanelConfirm}
+          isSaving={isPluginSettingsSaving}
+          setPluginScrollRef={setPluginScrollRef}
+          renderPluginSettingsForm={renderPluginSettingsForm}
+          reportNormalizationError={reportPluginNormalizationError}
+          t={t}
+        />
+      );
+    }
+
+    // 레이어 모드일 때는 선택 여부와 관계없이 레이어 패널 표시
+    if (panelMode === 'layer') {
+      return (
+        <LayerPanel
+          onSwitchToProperty={handleToggleMode}
+          onSelectionFromPanel={() => {
+            selectionFromLayerPanelRef.current = true;
+          }}
+        />
+      );
+    }
+
+    // 선택된 키 요소가 없으면 레이어 패널 표시
+    if (selectedKeyElements.length === 0 && selectedElements.length === 0) {
+      return (
+        <LayerPanel
+          onSwitchToProperty={handleToggleMode}
+          onSelectionFromPanel={() => {
+            selectionFromLayerPanelRef.current = true;
+          }}
+        />
+      );
+    }
+
+    return <EditSessionScope>{renderSelectionPanelBody()}</EditSessionScope>;
   };
 
   // 열림/닫힘과 무관하게 항상 렌더되는 지속 토글 — 리마운트 없이 모프 전환

--- a/src/renderer/components/main/Grid/PropertiesPanel.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel.tsx
@@ -941,6 +941,9 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
     setShowImagePicker(false);
     setShowGraphImagePicker(false);
     setShowBatchImagePicker(false);
+    // 배치 색상 draft는 피커를 열 때 첫 요소에서 한 번만 떠 온다.
+    // 열린 채로 선택이 바뀌면 옛 대상 색이 남아 다음 드래그가 그 값을 새 선택에 쓴다
+    setBatchPickerFor(null);
     closePage();
   }, [
     singleKeyIndex,

--- a/src/renderer/components/main/Grid/PropertiesPanel/EditSessionBoundary.test.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/EditSessionBoundary.test.tsx
@@ -1,0 +1,191 @@
+import React, { act, useEffect } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGridSelectionStore } from '@stores/grid/useGridSelectionStore';
+import { useKeyStore } from '@stores/data/useKeyStore';
+import type { SelectedElement } from '@stores/grid/useGridSelectionStore';
+
+import EditSessionBoundary from './EditSessionBoundary';
+import { TextInput } from './PropertyInputs';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const keyElement = (index: number): SelectedElement => ({
+  type: 'key',
+  id: `key-${index}`,
+  index,
+});
+
+const select = (...elements: SelectedElement[]) => {
+  act(() => {
+    useGridSelectionStore.setState({ selectedElements: elements });
+  });
+};
+
+describe('EditSessionBoundary', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useGridSelectionStore.setState({ selectedElements: [keyElement(0)] });
+    useKeyStore.setState({ selectedKeyType: '4key' });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const renderProbe = (onMount: () => void, onUnmount: () => void) => {
+    const Probe = () => {
+      useEffect(() => {
+        onMount();
+        return onUnmount;
+      }, []);
+      return null;
+    };
+    act(() => {
+      root.render(
+        <EditSessionBoundary>
+          <Probe />
+        </EditSessionBoundary>,
+      );
+    });
+  };
+
+  it('선택 대상이 갈리면 편집 트리를 새로 마운트한다', () => {
+    const mount = vi.fn();
+    const unmount = vi.fn();
+    renderProbe(mount, unmount);
+    expect(mount).toHaveBeenCalledTimes(1);
+
+    select(keyElement(1));
+
+    expect(unmount).toHaveBeenCalledTimes(1);
+    expect(mount).toHaveBeenCalledTimes(2);
+  });
+
+  it('배열만 새로 만들고 대상이 같으면 마운트를 유지한다', () => {
+    const mount = vi.fn();
+    const unmount = vi.fn();
+    renderProbe(mount, unmount);
+
+    select(keyElement(0));
+
+    expect(unmount).not.toHaveBeenCalled();
+    expect(mount).toHaveBeenCalledTimes(1);
+  });
+
+  it('선택 순서만 다르면 같은 대상으로 본다', () => {
+    const mount = vi.fn();
+    const unmount = vi.fn();
+    useGridSelectionStore.setState({
+      selectedElements: [keyElement(0), keyElement(1)],
+    });
+    renderProbe(mount, unmount);
+
+    select(keyElement(1), keyElement(0));
+
+    expect(unmount).not.toHaveBeenCalled();
+  });
+
+  it('배치 선택이 줄어들면 새로 마운트한다', () => {
+    const mount = vi.fn();
+    const unmount = vi.fn();
+    useGridSelectionStore.setState({
+      selectedElements: [keyElement(0), keyElement(1), keyElement(2)],
+    });
+    renderProbe(mount, unmount);
+
+    select(keyElement(0), keyElement(1));
+
+    expect(unmount).toHaveBeenCalledTimes(1);
+    expect(mount).toHaveBeenCalledTimes(2);
+  });
+
+  it('선택이 같아도 모드가 바뀌면 새로 마운트한다', () => {
+    const mount = vi.fn();
+    const unmount = vi.fn();
+    renderProbe(mount, unmount);
+
+    act(() => {
+      useKeyStore.setState({ selectedKeyType: '8key' });
+    });
+
+    expect(unmount).toHaveBeenCalledTimes(1);
+    expect(mount).toHaveBeenCalledTimes(2);
+  });
+
+  // 실앱 재현의 마지막 단계를 그대로 재현한다.
+  // TextInput은 포커스 중 새 prop을 받지 않고, finalize는 타이핑 여부와 무관하게
+  // onBlur를 부른다. 대상이 갈린 뒤 blur하면 옛 문자열이 새 대상에 저장된다
+  it('포커스된 입력은 대상이 갈리면 확정 없이 사라진다', () => {
+    const commit = vi.fn();
+    const Field = () => {
+      // 콜백이 매 렌더 최신 대상을 가리키는 실제 구조를 그대로 흉내낸다
+      const target = useGridSelectionStore(
+        (state) => state.selectedElements[0]?.id ?? '',
+      );
+      return (
+        <TextInput
+          value="LShift"
+          onChange={() => {}}
+          onBlur={(next) => commit(target, next)}
+        />
+      );
+    };
+
+    act(() => {
+      root.render(
+        <EditSessionBoundary>
+          <Field />
+        </EditSessionBoundary>,
+      );
+    });
+    const input = container.querySelector('input')!;
+    act(() => input.focus());
+
+    select(keyElement(1));
+
+    expect(container.querySelector('input')).not.toBe(input);
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('같은 대상이면 blur가 평소대로 확정한다', () => {
+    const commit = vi.fn();
+    act(() => {
+      root.render(
+        <EditSessionBoundary>
+          <TextInput value="LShift" onChange={() => {}} onBlur={commit} />
+        </EditSessionBoundary>,
+      );
+    });
+    const input = container.querySelector('input')!;
+    act(() => input.focus());
+    act(() => input.blur());
+
+    expect(commit).toHaveBeenCalledWith('LShift');
+  });
+
+  // 편집 트리만 사라지고 스크롤 뷰포트는 남아야 한다.
+  // 뷰포트가 함께 사라지면 대상을 바꿀 때마다 패널 스크롤이 맨 위로 튄다
+  it('스크롤 뷰포트를 리마운트에 끌고 들어가지 않는다', () => {
+    const Viewport = () => (
+      <div data-testid="viewport">
+        <EditSessionBoundary>
+          <span />
+        </EditSessionBoundary>
+      </div>
+    );
+    act(() => root.render(<Viewport />));
+    const viewport = container.querySelector('[data-testid="viewport"]');
+
+    select(keyElement(1));
+
+    expect(container.querySelector('[data-testid="viewport"]')).toBe(viewport);
+  });
+});

--- a/src/renderer/components/main/Grid/PropertiesPanel/EditSessionBoundary.test.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/EditSessionBoundary.test.tsx
@@ -17,6 +17,11 @@ const keyElement = (index: number): SelectedElement => ({
   index,
 });
 
+const pluginElement = (id: string): SelectedElement => ({
+  type: 'plugin',
+  id,
+});
+
 const select = (...elements: SelectedElement[]) => {
   act(() => {
     useGridSelectionStore.setState({ selectedElements: elements });
@@ -91,6 +96,43 @@ describe('EditSessionBoundary', () => {
     select(keyElement(1), keyElement(0));
 
     expect(unmount).not.toHaveBeenCalled();
+  });
+
+  it('구분자가 든 플러그인 ID 조합이 같아 보여도 다른 대상으로 본다', () => {
+    const mount = vi.fn();
+    const unmount = vi.fn();
+    useGridSelectionStore.setState({
+      selectedElements: [
+        pluginElement('plugin::a,b'),
+        pluginElement('plugin::c'),
+      ],
+    });
+    renderProbe(mount, unmount);
+
+    select(pluginElement('plugin::a'), pluginElement('plugin::b,c'));
+
+    expect(unmount).toHaveBeenCalledTimes(1);
+    expect(mount).toHaveBeenCalledTimes(2);
+  });
+
+  it('모드와 ID의 구분자 경계가 달라지면 다른 대상으로 본다', () => {
+    const mount = vi.fn();
+    const unmount = vi.fn();
+    useKeyStore.setState({ selectedKeyType: 'custom:a' });
+    useGridSelectionStore.setState({
+      selectedElements: [pluginElement('plugin::b')],
+    });
+    renderProbe(mount, unmount);
+
+    act(() => {
+      useKeyStore.setState({ selectedKeyType: 'custom' });
+      useGridSelectionStore.setState({
+        selectedElements: [pluginElement('a:plugin::b')],
+      });
+    });
+
+    expect(unmount).toHaveBeenCalledTimes(1);
+    expect(mount).toHaveBeenCalledTimes(2);
   });
 
   it('배치 선택이 줄어들면 새로 마운트한다', () => {

--- a/src/renderer/components/main/Grid/PropertiesPanel/EditSessionBoundary.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/EditSessionBoundary.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+
+import { formatEditSessionTarget } from '@src/renderer/editor/runtime/editSessionTarget';
+import { useGridSelectionStore } from '@stores/grid/useGridSelectionStore';
+import { useKeyStore } from '@stores/data/useKeyStore';
+
+interface EditSessionBoundaryProps {
+  children: ReactNode;
+}
+
+// 편집 대상이 갈리면 편집 트리를 통째로 새로 마운트한다.
+//
+// 입력과 피커는 포커스나 열림이 유지되는 동안 새 prop을 반영하지 않는다
+// (PropertyInputs의 !isFocused 동기화, StyleTabContent의 피커 열림 게이트).
+// 그래서 대상만 갈리면 옛 draft가 살아남고, 다음 blur나 pointerup이 그 값을
+// 새 대상에 저장한다. 언마운트는 blur도 pointerup도 만들지 않으므로
+// 쓰기 자체가 사라진다 - 상태를 패널 상위가 들고 있어도 마찬가지다.
+//
+// 반드시 스크롤 뷰포트 **안쪽**에 둔다. 바깥에 두면 뷰포트 DOM이 함께 사라져
+// 스크롤이 맨 위로 튀고 Lenis 인스턴스가 매번 재생성된다.
+//
+// 지문은 zustand 파생값이어야 한다. useState나 transition으로 만들면 갱신이
+// sync lane을 벗어나 언마운트 정리가 예약 작업보다 늦어질 수 있다.
+//
+// 뷰포트 안의 내용 열을 겸한다. 별도 래퍼를 얹으면 중첩만 한 겹 늘고,
+// 열 자체가 경계라는 사실이 코드에서 안 보인다
+const EditSessionBoundary = ({ children }: EditSessionBoundaryProps) => {
+  const mode = useKeyStore((state) => state.selectedKeyType);
+  const selectedElements = useGridSelectionStore(
+    (state) => state.selectedElements,
+  );
+
+  return (
+    <div
+      key={formatEditSessionTarget(mode, selectedElements)}
+      className="px-[12px] pb-[12px] flex flex-col gap-[12px]"
+    >
+      {children}
+    </div>
+  );
+};
+
+export default EditSessionBoundary;

--- a/src/renderer/components/main/Grid/PropertiesPanel/PropertyInputs.test.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/PropertyInputs.test.tsx
@@ -1389,7 +1389,7 @@ describe('숫자 입력 방향키 스텝', () => {
     act(() => input.focus());
     act(() => pressKey(input, 'ArrowUp', { shiftKey: true, repeat: true }));
 
-    // 프레임이 오기 전에 대상이 바뀐다
+    // 프레임이 오기 전에 clamp 규칙과 콜백이 바뀐다
     render(6, secondCommit);
     await nextFrame();
 

--- a/src/renderer/components/main/Grid/PropertiesPanel/PropertyInputs.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/PropertyInputs.tsx
@@ -489,7 +489,8 @@ export const NumberInput: React.FC<NumberInputProps> = ({
 
     if (repeat) {
       // 예약해 둔 함수가 아니라 최신 렌더의 것을 실행해야 한다.
-      // 예약과 실행 사이에 선택이나 min/max가 바뀌면 낡은 규칙으로 확정된다
+      // 예약과 실행 사이에 min/max가 바뀌면 낡은 규칙으로 확정된다.
+      // 대상 전환은 이 경로로 막지 않는다 - 최신 콜백은 새 대상을 가리킨다
       stepFrame.schedule(() => flushStepRef.current());
       return true;
     }
@@ -995,7 +996,8 @@ export const OptionalNumberInput: React.FC<OptionalNumberInputProps> = ({
 
     if (repeat) {
       // 예약해 둔 함수가 아니라 최신 렌더의 것을 실행해야 한다.
-      // 예약과 실행 사이에 선택이나 min/max가 바뀌면 낡은 규칙으로 확정된다
+      // 예약과 실행 사이에 min/max가 바뀌면 낡은 규칙으로 확정된다.
+      // 대상 전환은 이 경로로 막지 않는다 - 최신 콜백은 새 대상을 가리킨다
       stepFrame.schedule(() => flushStepRef.current());
       return true;
     }

--- a/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchSelectionPanel.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchSelectionPanel.tsx
@@ -34,6 +34,7 @@ import Dropdown from '@components/main/common/Dropdown';
 import ColorPicker from '@components/main/Modal/content/pickers/ColorPicker';
 import PopupExit from '@components/main/Modal/PopupExit';
 import ImagePicker from '@components/main/Modal/content/pickers/ImagePicker';
+import EditSessionBoundary from '../EditSessionBoundary';
 
 const RenameIcon: React.FC = () => (
   <svg
@@ -657,7 +658,7 @@ export const BatchKeyLikePanel: React.FC<BatchKeyLikePanelProps> = ({
               activeTab === TABS.STYLE ? '' : 'hidden'
             }`}
           >
-            <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+            <EditSessionBoundary>
               <BatchStyleTabContent
                 selectedCount={selectedBatchStyleElements.length}
                 showSoundControls={selectedKeyElements.length > 0}
@@ -815,7 +816,7 @@ export const BatchKeyLikePanel: React.FC<BatchKeyLikePanelProps> = ({
                 useCustomCSS={useCustomCSS}
                 t={t}
               />
-            </div>
+            </EditSessionBoundary>
           </div>
 
           {/* NOTE 탭 viewport */}
@@ -826,7 +827,7 @@ export const BatchKeyLikePanel: React.FC<BatchKeyLikePanelProps> = ({
                 activeTab === TABS.NOTE ? '' : 'hidden'
               }`}
             >
-              <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+              <EditSessionBoundary>
                 <BatchNoteTabContent
                   getMixedValue={getMixedValueKeysOnly}
                   handleBatchStyleChangeComplete={
@@ -852,7 +853,7 @@ export const BatchKeyLikePanel: React.FC<BatchKeyLikePanelProps> = ({
                   batchBorderColorButtonRef={batchBorderColorButtonRef}
                   t={t}
                 />
-              </div>
+              </EditSessionBoundary>
             </div>
           )}
 
@@ -863,7 +864,7 @@ export const BatchKeyLikePanel: React.FC<BatchKeyLikePanelProps> = ({
               activeTab === TABS.COUNTER ? '' : 'hidden'
             }`}
           >
-            <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+            <EditSessionBoundary>
               <BatchCounterTabContent
                 batchCounterSettings={batchCounterSettings}
                 keyVisual={batchKeyVisual}
@@ -878,7 +879,7 @@ export const BatchKeyLikePanel: React.FC<BatchKeyLikePanelProps> = ({
                 isStrokePickerOpen={batchPickerFor === 'stroke'}
                 t={t}
               />
-            </div>
+            </EditSessionBoundary>
           </div>
         </div>
 
@@ -1212,7 +1213,7 @@ export const BatchGraphOnlyPanel: React.FC<BatchGraphOnlyPanelProps> = ({
           ref={batchScrollRefFor(TABS.STYLE)}
           className="properties-panel-overlay-viewport"
         >
-          <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+          <EditSessionBoundary>
             <BatchStyleTabContent
               selectedCount={selectedGraphElements.length}
               hideDisplayText
@@ -1348,7 +1349,7 @@ export const BatchGraphOnlyPanel: React.FC<BatchGraphOnlyPanelProps> = ({
               useCustomCSS={useCustomCSS}
               t={t}
             />
-          </div>
+          </EditSessionBoundary>
         </div>
       </div>
 
@@ -1570,7 +1571,7 @@ export const BatchKnobOnlyPanel: React.FC<BatchKnobOnlyPanelProps> = ({
           ref={batchScrollRefFor(TABS.STYLE)}
           className="properties-panel-overlay-viewport"
         >
-          <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+          <EditSessionBoundary>
             <BatchStyleTabContent
               selectedCount={selectedKnobElements.length}
               hideDisplayText
@@ -1649,7 +1650,7 @@ export const BatchKnobOnlyPanel: React.FC<BatchKnobOnlyPanelProps> = ({
               useCustomCSS={useCustomCSS}
               t={t}
             />
-          </div>
+          </EditSessionBoundary>
         </div>
       </div>
 

--- a/src/renderer/components/main/Grid/PropertiesPanel/single/SingleKnobPanel.test.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/single/SingleKnobPanel.test.tsx
@@ -1,0 +1,91 @@
+import React, { act, createRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SingleKnobPanel } from './SingleSelectionPanel';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@hooks/useLenis', () => ({
+  useLenis: () => ({ scrollContainerRef: vi.fn() }),
+}));
+
+const knobPosition = {
+  dx: 0,
+  dy: 0,
+  width: 60,
+  height: 60,
+  axisId: 'HIDA:test',
+  sensitivity: 1,
+  reverse: false,
+};
+
+// 이 패널은 피커와 축 캡처 세션을 편집 트리 경계 위에서 소유한다.
+// 경계 리마운트로는 안 걷히므로 대상 전환에 직접 반응해야 한다
+describe('SingleKnobPanel 대상 전환 세션 정리', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const render = (singleKnobIndex: number) => {
+    act(() => {
+      root.render(
+        <SingleKnobPanel
+          setPanelElement={vi.fn()}
+          singleKnobPosition={knobPosition as never}
+          singleKnobIndex={singleKnobIndex}
+          selectedKeyType="4key"
+          isRenaming={false}
+          renameInputRef={createRef<HTMLInputElement>() as never}
+          renameValue=""
+          setRenameValue={vi.fn()}
+          renameCancelledRef={{ current: false }}
+          handleRenameCommit={vi.fn()}
+          handleRenameCancel={vi.fn()}
+          handleRenameStart={vi.fn()}
+          handleKnobUpdate={vi.fn()}
+          singleScrollRefFor={() => vi.fn()}
+          panelElement={null}
+          useCustomCSS={false}
+          t={((key: string) => key) as never}
+        />,
+      );
+    });
+  };
+
+  // 축 캡처 토글은 title에 축 ID를 달고 있다
+  const captureButton = () =>
+    container.querySelector<HTMLButtonElement>(
+      `button[title="${knobPosition.axisId}"]`,
+    )!;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    render(0);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('대상이 바뀌면 축 캡처 대기를 끊는다', () => {
+    act(() => captureButton().click());
+    expect(captureButton().textContent).toBe('propertiesPanel.knobCapturing');
+
+    render(1);
+
+    expect(captureButton().textContent).not.toBe(
+      'propertiesPanel.knobCapturing',
+    );
+  });
+
+  it('같은 대상이면 캡처 대기를 유지한다', () => {
+    act(() => captureButton().click());
+
+    render(0);
+
+    expect(captureButton().textContent).toBe('propertiesPanel.knobCapturing');
+  });
+});

--- a/src/renderer/components/main/Grid/PropertiesPanel/single/SingleSelectionPanel.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/single/SingleSelectionPanel.tsx
@@ -66,6 +66,7 @@ import ImagePicker from '@components/main/Modal/content/pickers/ImagePicker';
 import { ColorSwatchButton } from '@components/main/Modal/content/pickers/ColorSwatch';
 import ShadowControls from '../ShadowControls';
 import { AXIS_FIELD_WIDTH } from '@utils/cardRecipes';
+import EditSessionBoundary from '../EditSessionBoundary';
 
 const getStatTypeLabel = (statType?: StatItemType | null): string => {
   switch (statType) {
@@ -216,7 +217,7 @@ export const PluginSelectionPanel: React.FC<PluginSelectionPanelProps> = ({
           ref={setPluginScrollRef}
           className="properties-panel-overlay-viewport"
         >
-          <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+          <EditSessionBoundary>
             {isPluginResizable && (
               <PropertySection>
                 <PropertyRow label={t('propertiesPanel.position') || '위치'}>
@@ -286,7 +287,7 @@ export const PluginSelectionPanel: React.FC<PluginSelectionPanelProps> = ({
                 `plugin-element-${selectedPluginElement?.fullId ?? 'unknown'}`,
                 handlePluginSettingChange,
               )}
-          </div>
+          </EditSessionBoundary>
         </div>
       </div>
     </div>
@@ -408,7 +409,7 @@ export const SingleGraphPanel: React.FC<SingleGraphPanelProps> = ({
           ref={singleScrollRefFor(TABS.STYLE)}
           className="properties-panel-overlay-viewport"
         >
-          <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+          <EditSessionBoundary>
             <PropertySection>
               <PropertyRow label={t('propertiesPanel.position') || 'Position'}>
                 <NumberInput
@@ -708,7 +709,7 @@ export const SingleGraphPanel: React.FC<SingleGraphPanelProps> = ({
                 </PropertyRow>
               </PropertySection>
             )}
-          </div>
+          </EditSessionBoundary>
         </div>
       </div>
 
@@ -1155,7 +1156,7 @@ export const SingleKnobPanel: React.FC<SingleKnobPanelProps> = ({
           ref={singleScrollRefFor(TABS.STYLE)}
           className="properties-panel-overlay-viewport"
         >
-          <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+          <EditSessionBoundary>
             {/* 노브 매핑 (키 매핑과 동일한 라벨/버튼 구조) */}
             <PropertySection>
               <PropertyRow label={t('propertiesPanel.knobAxis') || '노브 매핑'}>
@@ -1420,7 +1421,7 @@ export const SingleKnobPanel: React.FC<SingleKnobPanelProps> = ({
               panelElement={panelElement}
               t={t}
             />
-          </div>
+          </EditSessionBoundary>
         </div>
       </div>
 
@@ -1767,7 +1768,7 @@ export const SingleKeyStatPanel: React.FC<SingleKeyStatPanelProps> = ({
             activeTab === TABS.STYLE ? '' : 'hidden'
           }`}
         >
-          <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+          <EditSessionBoundary>
             <StyleTabContent
               keyIndex={keyLikeIndex}
               keyPosition={keyLikePosition}
@@ -1814,7 +1815,7 @@ export const SingleKeyStatPanel: React.FC<SingleKeyStatPanelProps> = ({
               }
               onSizeBlur={handleSizeBlur}
             />
-          </div>
+          </EditSessionBoundary>
         </div>
 
         {/* NOTE 탭 viewport */}
@@ -1825,7 +1826,7 @@ export const SingleKeyStatPanel: React.FC<SingleKeyStatPanelProps> = ({
               activeTab === TABS.NOTE ? '' : 'hidden'
             }`}
           >
-            <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+            <EditSessionBoundary>
               <NoteTabContent
                 keyIndex={singleKeyIndex!}
                 keyPosition={singleKeyPosition!}
@@ -1834,7 +1835,7 @@ export const SingleKeyStatPanel: React.FC<SingleKeyStatPanelProps> = ({
                 panelElement={panelElement}
                 t={t}
               />
-            </div>
+            </EditSessionBoundary>
           </div>
         )}
 
@@ -1845,7 +1846,7 @@ export const SingleKeyStatPanel: React.FC<SingleKeyStatPanelProps> = ({
             activeTab === TABS.COUNTER ? '' : 'hidden'
           }`}
         >
-          <div className="px-[12px] pb-[12px] flex flex-col gap-[12px]">
+          <EditSessionBoundary>
             <CounterTabContent
               keyIndex={keyLikeIndex}
               keyPosition={keyLikePosition}
@@ -1855,7 +1856,7 @@ export const SingleKeyStatPanel: React.FC<SingleKeyStatPanelProps> = ({
               panelElement={panelElement}
               t={t}
             />
-          </div>
+          </EditSessionBoundary>
         </div>
       </div>
     </div>

--- a/src/renderer/components/main/Grid/PropertiesPanel/single/SingleSelectionPanel.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/single/SingleSelectionPanel.tsx
@@ -913,6 +913,16 @@ export const SingleKnobPanel: React.FC<SingleKnobPanelProps> = ({
       DEFAULT_KNOB_ACTIVE_BORDER_COLOR,
   });
 
+  // 이 패널은 편집 트리 경계 위에서 피커와 캡처 세션을 소유한다.
+  // 대상이 갈려도 살아남으면 열린 피커가 옛 노브에서 떠 온 색을 그대로 쥐고
+  // 있고, 축 캡처 대기는 다음 회전을 새 노브에 바인딩한다.
+  // 피커를 닫으면 아래 동기화가 새 노브 색을 다시 떠 온다
+  useEffect(() => {
+    setPickerFor(null);
+    setShowImagePicker(false);
+    setCapturing(false);
+  }, [singleKnobIndex, selectedKeyType]);
+
   // 피커가 닫혀있을 때만 외부 prop과 동기화
   useEffect(() => {
     if (!pickerFor) {

--- a/src/renderer/components/main/Modal/content/pickers/CounterAnimationPicker.editSession.test.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/CounterAnimationPicker.editSession.test.tsx
@@ -1,0 +1,131 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+
+import { EditSessionScope } from '@src/renderer/contexts/EditSessionScope';
+import { useKeyStore } from '@stores/data/useKeyStore';
+import type { KeyCounterAnimationSettings } from '@src/types/key/keys';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  savePreset: null as null | ((payload: unknown) => void),
+}));
+
+vi.mock('./CommonListPickerPage', () => ({ default: () => null }));
+vi.mock('@components/main/Modal/ListPopup', () => ({ default: () => null }));
+vi.mock('@hooks/usePickerItemMenu', () => ({
+  usePickerItemMenu: () => ({
+    menuKey: null,
+    renderKey: null,
+    renderPosition: null,
+    open: vi.fn(),
+    openFromButton: vi.fn(),
+    close: vi.fn(),
+  }),
+}));
+// 편집 모달의 저장 콜백을 밖으로 꺼낸다
+vi.mock('../editors/CounterAnimationEditorModal', () => ({
+  default: ({ onSaved }: { onSaved: (payload: unknown) => void }) => {
+    mocks.savePreset = onSaved;
+    return null;
+  },
+}));
+
+import CounterAnimationPicker from './CounterAnimationPicker';
+
+const PRESET = {
+  id: 'preset-new',
+  name: 'pop',
+  source: 'user',
+  bezier: [0.4, 0, 0.2, 1],
+  scale: 1.2,
+  duration: 300,
+} as never;
+
+const ANIMATION = { enabled: true } as unknown as KeyCounterAnimationSettings;
+
+// preset 생성 자체는 라이브러리 작업이라 끝내야 한다.
+// 모드가 갈렸을 때 버리는 것은 그 preset을 대상에 적용하는 마지막 한 걸음뿐이다
+describe('CounterAnimationPicker 저장 완료와 모드 전환', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onAnimationChange: Mock<(next: KeyCounterAnimationSettings) => void>;
+  let list: Mock<() => Promise<unknown>>;
+
+  const settle = async () => {
+    await act(async () => {
+      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+    });
+  };
+
+  const savePreset = async () => {
+    await act(async () => {
+      mocks.savePreset?.({
+        preset: PRESET,
+        mode: 'create',
+        affectedUsageCount: 0,
+      });
+      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+    });
+  };
+
+  beforeEach(async () => {
+    onAnimationChange = vi.fn();
+    list = vi.fn(async () => ({ builtinPresets: [], userPresets: [] }));
+    mocks.savePreset = null;
+    useKeyStore.setState({ selectedKeyType: '4key' });
+    window.api = { counterAnimation: { list } } as never;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        <EditSessionScope>
+          <CounterAnimationPicker
+            open
+            animation={ANIMATION}
+            onAnimationChange={onAnimationChange}
+            t={(key: string) => key}
+            pageTitle="animation"
+            onBack={vi.fn()}
+          />
+        </EditSessionScope>,
+      );
+    });
+    await settle();
+    list.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('모드가 그대로면 저장한 모션을 대상에 적용한다', async () => {
+    await savePreset();
+
+    expect(onAnimationChange).toHaveBeenCalled();
+  });
+
+  it('저장 대기 중 모드가 바뀌면 적용하지 않는다', async () => {
+    act(() => {
+      useKeyStore.setState({ selectedKeyType: '8key' });
+    });
+
+    await savePreset();
+
+    // 라이브러리 갱신은 그대로 진행한다
+    expect(list).toHaveBeenCalled();
+    expect(onAnimationChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/main/Modal/content/pickers/CounterAnimationPicker.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/CounterAnimationPicker.tsx
@@ -23,7 +23,7 @@ import {
 } from './pickerRowClass';
 import CounterAnimationEditorModal from '../editors/CounterAnimationEditorModal';
 import type { CounterAnimationKeyVisual } from '@utils/core/counterAnimationPreview';
-import { useEditSessionGuard } from '@src/renderer/contexts/EditSessionScope';
+import { useEditSessionModeGuard } from '@src/renderer/contexts/EditSessionScope';
 
 interface CounterAnimationPickerProps {
   open: boolean;
@@ -80,7 +80,7 @@ const CounterAnimationPicker = ({
   const [isLoading, setIsLoading] = useState(false);
   const [errorText, setErrorText] = useState('');
   const [editorState, setEditorState] = useState<EditorState | null>(null);
-  const isSameEditSession = useEditSessionGuard();
+  const isSameEditSessionMode = useEditSessionModeGuard();
   const loadRequestRef = useRef(0);
   const isOpenRef = useRef(open);
   const pendingPresetActionsRef = useRef(new Set<string>());
@@ -253,7 +253,7 @@ const CounterAnimationPicker = ({
   }) => {
     await loadLibrary();
     // preset은 라이브러리에 이미 저장됐다. 대상이 갈렸으면 적용만 하지 않는다
-    if (!isSameEditSession()) return;
+    if (!isSameEditSessionMode()) return;
     if (mode === 'create' || selectedPresetId === preset.id) {
       onAnimationChange(applyPresetToAnimation(animation, preset));
     }

--- a/src/renderer/components/main/Modal/content/pickers/CounterAnimationPicker.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/CounterAnimationPicker.tsx
@@ -23,6 +23,7 @@ import {
 } from './pickerRowClass';
 import CounterAnimationEditorModal from '../editors/CounterAnimationEditorModal';
 import type { CounterAnimationKeyVisual } from '@utils/core/counterAnimationPreview';
+import { useEditSessionGuard } from '@src/renderer/contexts/EditSessionScope';
 
 interface CounterAnimationPickerProps {
   open: boolean;
@@ -79,6 +80,7 @@ const CounterAnimationPicker = ({
   const [isLoading, setIsLoading] = useState(false);
   const [errorText, setErrorText] = useState('');
   const [editorState, setEditorState] = useState<EditorState | null>(null);
+  const isSameEditSession = useEditSessionGuard();
   const loadRequestRef = useRef(0);
   const isOpenRef = useRef(open);
   const pendingPresetActionsRef = useRef(new Set<string>());
@@ -250,6 +252,8 @@ const CounterAnimationPicker = ({
     affectedUsageCount: number;
   }) => {
     await loadLibrary();
+    // preset은 라이브러리에 이미 저장됐다. 대상이 갈렸으면 적용만 하지 않는다
+    if (!isSameEditSession()) return;
     if (mode === 'create' || selectedPresetId === preset.id) {
       onAnimationChange(applyPresetToAnimation(animation, preset));
     }

--- a/src/renderer/components/main/Modal/content/pickers/ImagePicker.editSession.test.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/ImagePicker.editSession.test.tsx
@@ -1,0 +1,128 @@
+import React, { act, createRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+
+import { EditSessionScope } from '@src/renderer/contexts/EditSessionScope';
+import { useKeyStore } from '@stores/data/useKeyStore';
+
+import ImagePicker from './ImagePicker';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@contexts/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@components/main/Grid/PropertiesPanel/PickerSurface', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+vi.mock('@components/main/common/Checkbox', () => ({ default: () => null }));
+vi.mock('@components/main/common/Dropdown', () => ({ default: () => null }));
+vi.mock('@components/main/common/TabSwitch', () => ({ default: () => null }));
+
+// 네이티브 파일 대화상자가 떠 있는 동안 편집 대상이 갈릴 수 있다.
+// 이미 시작된 Promise는 언마운트로 취소되지 않으므로, 연결 직전에 확인해야 한다.
+// 파일 복사는 이미 끝났으니 자산은 남기고 연결만 버린다
+describe('ImagePicker 비동기 완료와 대상 전환', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onIdleImageChange: Mock<(path: string) => void>;
+  let resolveLoad: (value: unknown) => void;
+
+  const mount = (scoped: boolean) => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const picker = (
+      <ImagePicker
+        open
+        referenceRef={createRef<HTMLElement>() as never}
+        onIdleImageChange={onIdleImageChange}
+        onClose={vi.fn()}
+        showActiveState={false}
+      />
+    );
+    act(() => {
+      root.render(
+        scoped ? <EditSessionScope>{picker}</EditSessionScope> : picker,
+      );
+    });
+  };
+
+  // 미리보기 위 호버 오버레이가 파일 선택을 연다
+  const clickPreview = () => {
+    const overlay = container.querySelector<HTMLDivElement>(
+      'div.absolute.inset-0.bg-black',
+    )!;
+    act(() => overlay.click());
+  };
+
+  const finishLoad = async () => {
+    await act(async () => {
+      resolveLoad({ success: true, imagePath: '/tmp/picked.png' });
+      await Promise.resolve();
+    });
+  };
+
+  beforeEach(() => {
+    onIdleImageChange = vi.fn();
+    useKeyStore.setState({ selectedKeyType: '4key' });
+    window.api = {
+      image: {
+        load: vi.fn(
+          () =>
+            new Promise((resolve) => {
+              resolveLoad = resolve;
+            }),
+        ),
+      },
+    } as never;
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('대상이 그대로면 고른 이미지를 연결한다', async () => {
+    mount(true);
+    clickPreview();
+
+    await finishLoad();
+
+    expect(onIdleImageChange).toHaveBeenCalledWith('/tmp/picked.png');
+  });
+
+  it('대기 중 모드가 바뀌면 연결하지 않는다', async () => {
+    mount(true);
+    clickPreview();
+
+    act(() => {
+      useKeyStore.setState({ selectedKeyType: '8key' });
+    });
+    await finishLoad();
+
+    expect(onIdleImageChange).not.toHaveBeenCalled();
+  });
+
+  it('캔버스 대상에 묶이지 않은 피커는 모드가 바뀌어도 연결한다', async () => {
+    mount(false);
+    clickPreview();
+
+    act(() => {
+      useKeyStore.setState({ selectedKeyType: '8key' });
+    });
+    await finishLoad();
+
+    expect(onIdleImageChange).toHaveBeenCalledWith('/tmp/picked.png');
+  });
+});

--- a/src/renderer/components/main/Modal/content/pickers/ImagePicker.editSession.test.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/ImagePicker.editSession.test.tsx
@@ -12,6 +12,7 @@ import {
 
 import { EditSessionScope } from '@src/renderer/contexts/EditSessionScope';
 import { useKeyStore } from '@stores/data/useKeyStore';
+import { useGridSelectionStore } from '@stores/grid/useGridSelectionStore';
 
 import ImagePicker from './ImagePicker';
 
@@ -112,6 +113,25 @@ describe('ImagePicker 비동기 완료와 대상 전환', () => {
     await finishLoad();
 
     expect(onIdleImageChange).not.toHaveBeenCalled();
+  });
+
+  // 가드를 전체 대상 지문으로 넓히면 이게 깨진다. 옛 index는 여전히 A를
+  // 가리키므로 A에 저장하는 것이 맞다
+  it('같은 모드에서 선택만 바뀌면 편집을 시작한 대상에 연결한다', async () => {
+    useGridSelectionStore.setState({
+      selectedElements: [{ type: 'key', id: 'key-0', index: 0 }],
+    });
+    mount(true);
+    clickPreview();
+
+    act(() => {
+      useGridSelectionStore.setState({
+        selectedElements: [{ type: 'key', id: 'key-1', index: 1 }],
+      });
+    });
+    await finishLoad();
+
+    expect(onIdleImageChange).toHaveBeenCalledWith('/tmp/picked.png');
   });
 
   it('캔버스 대상에 묶이지 않은 피커는 모드가 바뀌어도 연결한다', async () => {

--- a/src/renderer/components/main/Modal/content/pickers/ImagePicker.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/ImagePicker.tsx
@@ -6,6 +6,7 @@ import Dropdown from '@components/main/common/Dropdown';
 import TabSwitch from '@components/main/common/TabSwitch';
 import { PropertySection } from '@components/main/Grid/PropertiesPanel/PropertyInputs';
 import { resolveImageSource } from '@utils/core/imageSource';
+import { useEditSessionGuard } from '@src/renderer/contexts/EditSessionScope';
 
 interface ImagePickerProps {
   open: boolean;
@@ -64,6 +65,7 @@ const ImagePicker = ({
   >(STATE_MODES.idle);
   const [isLoadingImage, setIsLoadingImage] = useState<boolean>(false);
   const loadingImageRef = useRef(false);
+  const isSameEditSession = useEditSessionGuard();
   const effectiveMode = showActiveState ? mode : STATE_MODES.idle;
 
   useEffect(() => {
@@ -79,6 +81,8 @@ const ImagePicker = ({
       if (!result?.success || !result.imagePath) {
         return;
       }
+      // 파일 복사는 이미 끝났다. 대상이 갈렸으면 연결만 하지 않는다
+      if (!isSameEditSession()) return;
       if (stateMode === STATE_MODES.idle) {
         onIdleImageChange?.(result.imagePath);
       } else {

--- a/src/renderer/components/main/Modal/content/pickers/ImagePicker.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/ImagePicker.tsx
@@ -6,7 +6,7 @@ import Dropdown from '@components/main/common/Dropdown';
 import TabSwitch from '@components/main/common/TabSwitch';
 import { PropertySection } from '@components/main/Grid/PropertiesPanel/PropertyInputs';
 import { resolveImageSource } from '@utils/core/imageSource';
-import { useEditSessionGuard } from '@src/renderer/contexts/EditSessionScope';
+import { useEditSessionModeGuard } from '@src/renderer/contexts/EditSessionScope';
 
 interface ImagePickerProps {
   open: boolean;
@@ -65,7 +65,7 @@ const ImagePicker = ({
   >(STATE_MODES.idle);
   const [isLoadingImage, setIsLoadingImage] = useState<boolean>(false);
   const loadingImageRef = useRef(false);
-  const isSameEditSession = useEditSessionGuard();
+  const isSameEditSessionMode = useEditSessionModeGuard();
   const effectiveMode = showActiveState ? mode : STATE_MODES.idle;
 
   useEffect(() => {
@@ -82,7 +82,7 @@ const ImagePicker = ({
         return;
       }
       // 파일 복사는 이미 끝났다. 대상이 갈렸으면 연결만 하지 않는다
-      if (!isSameEditSession()) return;
+      if (!isSameEditSessionMode()) return;
       if (stateMode === STATE_MODES.idle) {
         onIdleImageChange?.(result.imagePath);
       } else {

--- a/src/renderer/components/main/Modal/content/pickers/SoundPicker.editSession.test.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/SoundPicker.editSession.test.tsx
@@ -1,0 +1,181 @@
+import React, { act, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+
+import { EditSessionScope } from '@src/renderer/contexts/EditSessionScope';
+import { useKeyStore } from '@stores/data/useKeyStore';
+import type { SoundListItem } from '@src/types/plugin/api';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  saveTrim: null as null | ((soundPath: string) => void),
+  openMenu: null as null | ((key: string) => void),
+  selectMenuItem: null as null | ((id: string) => void),
+}));
+
+vi.mock('@contexts/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('./CommonListPickerPage', () => ({ default: () => null }));
+// 메뉴 열림 상태를 테스트가 조종할 수 있게 한다
+vi.mock('@hooks/usePickerItemMenu', () => ({
+  usePickerItemMenu: () => {
+    const [menuKey, setMenuKey] = useState<string | null>(null);
+    mocks.openMenu = setMenuKey;
+    return {
+      menuKey,
+      renderKey: menuKey,
+      renderPosition: null,
+      open: vi.fn(),
+      openFromButton: vi.fn(),
+      close: () => setMenuKey(null),
+    };
+  },
+}));
+vi.mock('@components/main/Modal/ListPopup', () => ({
+  default: ({ onSelect }: { onSelect: (id: string) => void }) => {
+    mocks.selectMenuItem = onSelect;
+    return null;
+  },
+}));
+// 트림 모달의 저장 콜백을 밖으로 꺼낸다
+vi.mock('../managers/SoundTrimModal', () => ({
+  default: ({ onSaved }: { onSaved: (soundPath: string) => void }) => {
+    mocks.saveTrim = onSaved;
+    return null;
+  },
+}));
+
+import SoundPicker from './SoundPicker';
+
+const SOUND: SoundListItem = {
+  soundPath: 'sounds/tick.wav',
+  fileName: 'tick.wav',
+  displayName: 'tick',
+  source: 'local',
+  hidden: false,
+  originalPath: 'orig/tick.wav',
+} as SoundListItem;
+
+// 자산 작업(백엔드 삭제, 파일 저장)은 끝내고, 옛 세션에 연결하는 마지막 콜백만
+// 버려야 한다. 가드가 API 호출 앞으로 올라가면 삭제 테스트가 깨진다
+describe('SoundPicker 비동기 완료와 모드 전환', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onSoundSelect: Mock<(soundPath: string | null) => void>;
+  let remove: Mock<(soundPath: string) => Promise<void>>;
+  let resolveConfirm: (value: boolean) => void;
+
+  const switchMode = () => {
+    act(() => {
+      useKeyStore.setState({ selectedKeyType: '8key' });
+    });
+  };
+
+  const runDelete = async () => {
+    act(() => mocks.openMenu?.(SOUND.soundPath));
+    act(() => mocks.selectMenuItem?.('delete'));
+  };
+
+  const settle = async () => {
+    await act(async () => {
+      for (let i = 0; i < 5; i += 1) await Promise.resolve();
+    });
+  };
+
+  beforeEach(async () => {
+    onSoundSelect = vi.fn();
+    remove = vi.fn(async () => {});
+    mocks.saveTrim = null;
+    mocks.openMenu = null;
+    mocks.selectMenuItem = null;
+    useKeyStore.setState({ selectedKeyType: '4key' });
+    window.api = {
+      sound: {
+        list: vi.fn(async () => [SOUND]),
+        remove,
+      },
+      ui: {
+        dialog: {
+          confirm: vi.fn(
+            () =>
+              new Promise<boolean>((resolve) => {
+                resolveConfirm = resolve;
+              }),
+          ),
+        },
+      },
+    } as never;
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        <EditSessionScope>
+          <SoundPicker
+            open
+            selectedSound={SOUND.soundPath}
+            onSoundSelect={onSoundSelect}
+            pageTitle="sound"
+            onBack={vi.fn()}
+          />
+        </EditSessionScope>,
+      );
+    });
+    await settle();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('저장 완료 뒤 모드가 그대로면 사운드를 연결한다', () => {
+    act(() => mocks.saveTrim?.('sounds/new.wav'));
+
+    expect(onSoundSelect).toHaveBeenCalledWith('sounds/new.wav');
+  });
+
+  it('저장 대기 중 모드가 바뀌면 연결하지 않는다', () => {
+    switchMode();
+
+    act(() => mocks.saveTrim?.('sounds/new.wav'));
+
+    expect(onSoundSelect).not.toHaveBeenCalled();
+  });
+
+  it('삭제 확인 대기 중 모드가 바뀌어도 백엔드 삭제는 끝낸다', async () => {
+    await runDelete();
+    switchMode();
+
+    await act(async () => {
+      resolveConfirm(true);
+      await settle();
+    });
+
+    expect(remove).toHaveBeenCalledWith(SOUND.soundPath);
+    expect(onSoundSelect).not.toHaveBeenCalled();
+  });
+
+  it('삭제 뒤 모드가 그대로면 로컬 선택도 해제한다', async () => {
+    await runDelete();
+
+    await act(async () => {
+      resolveConfirm(true);
+      await settle();
+    });
+
+    expect(remove).toHaveBeenCalledWith(SOUND.soundPath);
+    expect(onSoundSelect).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/renderer/components/main/Modal/content/pickers/SoundPicker.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/SoundPicker.tsx
@@ -12,6 +12,7 @@ import {
 import MoreVerticalIcon from './MoreVerticalIcon';
 import { usePickerItemMenu } from '@hooks/usePickerItemMenu';
 import SoundTrimModal from '../managers/SoundTrimModal';
+import { useEditSessionGuard } from '@src/renderer/contexts/EditSessionScope';
 
 interface SoundPickerProps {
   open: boolean;
@@ -47,6 +48,7 @@ const SoundPicker = ({
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState('');
   const [trimState, setTrimState] = useState<TrimState | null>(null);
+  const isSameEditSession = useEditSessionGuard();
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -209,7 +211,9 @@ const SoundPicker = ({
         return next;
       });
       await window.api.sound.remove(item.soundPath);
-      if (normalizedSelectedSound === item.soundPath) {
+      // 백엔드가 이미 모든 요소에서 이 사운드를 해제했다. 대상이 갈렸으면
+      // 여기서 한 번 더 비우는 건 새 모드의 다른 사운드를 지우는 일이 된다
+      if (normalizedSelectedSound === item.soundPath && isSameEditSession()) {
         onSoundSelect(null);
       }
       await loadSounds();
@@ -280,7 +284,8 @@ const SoundPicker = ({
   };
 
   const handleTrimSaved = (soundPath: string) => {
-    onSoundSelect(soundPath);
+    // 사운드 파일은 이미 저장됐다. 대상이 갈렸으면 연결만 하지 않는다
+    if (isSameEditSession()) onSoundSelect(soundPath);
     setTrimState(null);
     void loadSounds();
   };

--- a/src/renderer/components/main/Modal/content/pickers/SoundPicker.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/SoundPicker.tsx
@@ -12,7 +12,7 @@ import {
 import MoreVerticalIcon from './MoreVerticalIcon';
 import { usePickerItemMenu } from '@hooks/usePickerItemMenu';
 import SoundTrimModal from '../managers/SoundTrimModal';
-import { useEditSessionGuard } from '@src/renderer/contexts/EditSessionScope';
+import { useEditSessionModeGuard } from '@src/renderer/contexts/EditSessionScope';
 
 interface SoundPickerProps {
   open: boolean;
@@ -48,7 +48,7 @@ const SoundPicker = ({
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState('');
   const [trimState, setTrimState] = useState<TrimState | null>(null);
-  const isSameEditSession = useEditSessionGuard();
+  const isSameEditSessionMode = useEditSessionModeGuard();
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -213,7 +213,10 @@ const SoundPicker = ({
       await window.api.sound.remove(item.soundPath);
       // 백엔드가 이미 모든 요소에서 이 사운드를 해제했다. 대상이 갈렸으면
       // 여기서 한 번 더 비우는 건 새 모드의 다른 사운드를 지우는 일이 된다
-      if (normalizedSelectedSound === item.soundPath && isSameEditSession()) {
+      if (
+        normalizedSelectedSound === item.soundPath &&
+        isSameEditSessionMode()
+      ) {
         onSoundSelect(null);
       }
       await loadSounds();
@@ -285,7 +288,7 @@ const SoundPicker = ({
 
   const handleTrimSaved = (soundPath: string) => {
     // 사운드 파일은 이미 저장됐다. 대상이 갈렸으면 연결만 하지 않는다
-    if (isSameEditSession()) onSoundSelect(soundPath);
+    if (isSameEditSessionMode()) onSoundSelect(soundPath);
     setTrimState(null);
     void loadSounds();
   };

--- a/src/renderer/components/main/Modal/content/pickers/colorPickerPrimitives.editSession.test.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/colorPickerPrimitives.editSession.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+
+import { useGridSelectionStore } from '@stores/grid/useGridSelectionStore';
+import { useKeyStore } from '@stores/data/useKeyStore';
+import { EditSessionScope } from '@src/renderer/contexts/EditSessionScope';
+
+import { usePointerSession } from './colorPickerPrimitives';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const selectKey = (index: number) => {
+  useGridSelectionStore.setState({
+    selectedElements: [{ type: 'key', id: `key-${index}`, index }],
+  });
+};
+
+describe('usePointerSession 언마운트 커밋', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let emit: Mock<(ratioX: number, ratioY: number, final: boolean) => void>;
+
+  const Track = () => {
+    const session = usePointerSession(emit);
+    return <div data-testid="track" {...session} style={{ width: 100 }} />;
+  };
+
+  const startDrag = () => {
+    const track = container.querySelector<HTMLDivElement>(
+      '[data-testid="track"]',
+    )!;
+    vi.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      right: 100,
+      top: 0,
+      bottom: 12,
+      width: 100,
+      height: 12,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    // jsdom에는 포인터 캡처 API가 없다
+    track.setPointerCapture = vi.fn();
+    track.hasPointerCapture = vi.fn(() => false);
+    track.releasePointerCapture = vi.fn();
+
+    act(() => {
+      track.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+          buttons: 1,
+          pointerId: 1,
+          isPrimary: true,
+          clientX: 50,
+          clientY: 6,
+        }),
+      );
+    });
+  };
+
+  const mount = (scoped: boolean) => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() =>
+      root.render(
+        scoped ? (
+          <EditSessionScope>
+            <Track />
+          </EditSessionScope>
+        ) : (
+          <Track />
+        ),
+      ),
+    );
+  };
+
+  beforeEach(() => {
+    emit = vi.fn();
+    useKeyStore.setState({ selectedKeyType: '4key' });
+    selectKey(0);
+    mount(true);
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it('대상이 그대로면 언마운트에서 마지막 값을 확정한다', () => {
+    startDrag();
+    emit.mockClear();
+
+    act(() => root.unmount());
+
+    expect(emit).toHaveBeenCalledWith(0.5, 0.5, true);
+  });
+
+  it('편집 대상이 갈린 뒤 사라지면 확정하지 않는다', () => {
+    startDrag();
+    emit.mockClear();
+
+    act(() => selectKey(1));
+    act(() => root.unmount());
+
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('드래그 중이 아니면 언마운트가 아무것도 내보내지 않는다', () => {
+    act(() => root.unmount());
+
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  // 같은 피커 컴포넌트가 전역 플러그인 설정에서도 쓰인다.
+  // 거기까지 억제하면 무관한 캠버스 선택 변경이 멀쩡한 색 편집을 지운다
+  it('캠버스 대상에 묶이지 않은 피커는 선택이 바뀌어도 확정한다', () => {
+    act(() => root.unmount());
+    container.remove();
+    mount(false);
+    startDrag();
+    emit.mockClear();
+
+    act(() => selectKey(1));
+    act(() => root.unmount());
+
+    expect(emit).toHaveBeenCalledWith(0.5, 0.5, true);
+  });
+});

--- a/src/renderer/components/main/Modal/content/pickers/colorPickerPrimitives.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/colorPickerPrimitives.tsx
@@ -5,6 +5,8 @@ import {
   createRafLatestScheduler,
   type ContinuousInputStrategy,
 } from '@utils/animation/rafLatestScheduler';
+import { getEditSessionTarget } from '@src/renderer/editor/runtime/editSessionTarget';
+import { useIsEditSessionScoped } from '@src/renderer/contexts/EditSessionScope';
 
 // 디자인 조절점 — 내부 폭 148px 기준 비율 ≈1.42:1
 const SATURATION_HEIGHT = 104;
@@ -57,6 +59,8 @@ export const usePointerSession = (
   const previewSchedulerRef = useRef<ReturnType<
     typeof createRafLatestScheduler<true>
   > | null>(null);
+  const editSessionScoped = useIsEditSessionScoped();
+  const sessionTargetRef = useRef<string | null>(null);
 
   // 좌표를 0~1 비율로 갱신 — 세션 시작 시 rect 유효성이 보장됨
   const updateRatio = (clientX: number, clientY: number) => {
@@ -90,6 +94,7 @@ export const usePointerSession = (
     rectRef.current = null;
     previewSchedulerRef.current?.cancel();
     previewSchedulerRef.current = null;
+    sessionTargetRef.current = null;
     blurCleanupRef.current?.();
     blurCleanupRef.current = null;
     const target = targetRef.current;
@@ -119,6 +124,9 @@ export const usePointerSession = (
     activePointerRef.current = event.pointerId;
     targetRef.current = target;
     rectRef.current = rect;
+    sessionTargetRef.current = editSessionScoped
+      ? getEditSessionTarget()
+      : null;
     target.setPointerCapture(event.pointerId);
     const onWindowBlur = () => finish();
     window.addEventListener('blur', onWindowBlur);
@@ -149,9 +157,21 @@ export const usePointerSession = (
     finish();
   };
 
-  // 드래그 중 언마운트(Esc로 팝업 닫힘 등)돼도 마지막 값을 커밋 — 저장 계약 유지
-  const finishRef = useLatest(finish);
-  useEffect(() => () => finishRef.current(), [finishRef]);
+  // 드래그 중 언마운트(Esc로 팝업 닫힘 등)돼도 마지막 값을 커밋 — 저장 계약 유지.
+  // 단 편집 대상에 묶인 피커에서 그 대상이 갈려 사라지는 경우는 커밋하지 않는다.
+  // 콜백이 가리키는 곳이 드래그를 시작한 요소가 아니고, 배열이 줄어든 경우
+  // 옛 index는 이미 다른 요소다. 캠버스 선택과 무관한 피커는 그대로 커밋한다
+  const finishOnUnmount = () => {
+    if (activePointerRef.current === null) return;
+    const sessionTarget = sessionTargetRef.current;
+    if (sessionTarget !== null && sessionTarget !== getEditSessionTarget()) {
+      teardown();
+      return;
+    }
+    finish();
+  };
+  const finishOnUnmountRef = useLatest(finishOnUnmount);
+  useEffect(() => () => finishOnUnmountRef.current(), [finishOnUnmountRef]);
 
   return {
     onPointerDown,

--- a/src/renderer/contexts/EditSessionScope.tsx
+++ b/src/renderer/contexts/EditSessionScope.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+// 이 아래 트리는 캔버스 편집 대상에 묶여 있다는 표시.
+//
+// 대상 전환 시 예약 작업을 버려야 하는 규칙은 속성 패널 안에서만 성립한다.
+// 같은 피커 컴포넌트가 전역 플러그인 설정처럼 캔버스 선택과 무관한 곳에서도
+// 쓰이므로, 그쪽까지 억제하면 멀쩡한 편집이 사라진다.
+//
+// 값은 상수라 provider가 재렌더를 만들지 않는다. 지금 대상이 무엇인지는
+// 필요한 쪽이 getEditSessionTarget()으로 직접 읽는다
+const EditSessionScopeContext = createContext(false);
+
+interface EditSessionScopeProps {
+  children: ReactNode;
+}
+
+export const EditSessionScope = ({ children }: EditSessionScopeProps) => (
+  <EditSessionScopeContext.Provider value={true}>
+    {children}
+  </EditSessionScopeContext.Provider>
+);
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useIsEditSessionScoped = (): boolean =>
+  useContext(EditSessionScopeContext);

--- a/src/renderer/contexts/EditSessionScope.tsx
+++ b/src/renderer/contexts/EditSessionScope.tsx
@@ -34,14 +34,18 @@ export const useIsEditSessionScoped = (): boolean =>
 
 // 비동기 완료 콜백이 옛 편집 세션에 값을 연결하려 할 때 쓰는 가드.
 //
-// 네이티브 대화상자나 IPC 응답을 기다리는 동안 편집 대상이 갈릴 수 있다.
-// 이미 시작된 Promise는 언마운트로 취소되지 않으므로, 마지막 연결 단계에서
+// 네이티브 대화상자나 IPC 응답을 기다리는 동안 모드가 갈릴 수 있다.
+// 이미 시작된 Promise는 언마운트로 취소되지 않으므로 마지막 연결 단계에서
 // 직접 확인해야 한다. 자산 생성 자체는 막지 않는다 - 파일 복사와 preset 생성은
 // 그대로 끝내고 옛 세션에 연결하는 한 걸음만 버린다.
 //
+// **모드만 비교한다.** 전체 대상 지문으로 넓히지 말 것 - 같은 모드에서
+// A를 편집하다 B를 고른 경우는 옛 index가 여전히 A를 가리키므로 연결이 맞다.
+// 같은 모드 안의 배열 재정렬은 이 가드가 잡지 못한다 (의도된 한계).
+//
 // 캔버스 대상에 묶이지 않은 곳(전역 키 설정 모달 등)에서는 항상 통과시킨다
 // eslint-disable-next-line react-refresh/only-export-components
-export const useEditSessionGuard = (): (() => boolean) => {
+export const useEditSessionModeGuard = (): (() => boolean) => {
   const scoped = useIsEditSessionScoped();
   const sessionMode = useRef(getEditSessionMode());
 

--- a/src/renderer/contexts/EditSessionScope.tsx
+++ b/src/renderer/contexts/EditSessionScope.tsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, type ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  type ReactNode,
+} from 'react';
+
+import { getEditSessionMode } from '@src/renderer/editor/runtime/editSessionTarget';
 
 // 이 아래 트리는 캔버스 편집 대상에 묶여 있다는 표시.
 //
@@ -23,3 +31,22 @@ export const EditSessionScope = ({ children }: EditSessionScopeProps) => (
 // eslint-disable-next-line react-refresh/only-export-components
 export const useIsEditSessionScoped = (): boolean =>
   useContext(EditSessionScopeContext);
+
+// 비동기 완료 콜백이 옛 편집 세션에 값을 연결하려 할 때 쓰는 가드.
+//
+// 네이티브 대화상자나 IPC 응답을 기다리는 동안 편집 대상이 갈릴 수 있다.
+// 이미 시작된 Promise는 언마운트로 취소되지 않으므로, 마지막 연결 단계에서
+// 직접 확인해야 한다. 자산 생성 자체는 막지 않는다 - 파일 복사와 preset 생성은
+// 그대로 끝내고 옛 세션에 연결하는 한 걸음만 버린다.
+//
+// 캔버스 대상에 묶이지 않은 곳(전역 키 설정 모달 등)에서는 항상 통과시킨다
+// eslint-disable-next-line react-refresh/only-export-components
+export const useEditSessionGuard = (): (() => boolean) => {
+  const scoped = useIsEditSessionScoped();
+  const sessionMode = useRef(getEditSessionMode());
+
+  return useCallback(
+    () => !scoped || sessionMode.current === getEditSessionMode(),
+    [scoped],
+  );
+};

--- a/src/renderer/editor/runtime/editGestureController.ts
+++ b/src/renderer/editor/runtime/editGestureController.ts
@@ -16,6 +16,7 @@ import { PREVIEW_SCHEMA_VERSION, type PreviewDomain } from '@src/types/preview';
 import { previewOverlay } from './previewOverlay';
 import { editorCoordinator } from './editorStateCoordinator';
 import { drainEditorWrites, trackEditorWrite } from './editorWriteBarrier';
+import { getEditSessionTarget } from './editSessionTarget';
 import {
   registerGestureSession,
   releaseGestureSession,
@@ -205,6 +206,8 @@ export const editGestureController = {
     const gesture = active;
     if (!gesture) return;
     active = null;
+    // 실패 복원을 판정할 기준. 정산이 끝났을 때 대상이 그대로여야 되살릴 의미가 있다
+    const committedTarget = getEditSessionTarget();
 
     persistPromise
       .then(() => {
@@ -223,8 +226,10 @@ export const editGestureController = {
           return;
         }
         console.error('Commit failed, keeping preview session', error);
-        // 새 게스처가 이미 시작됐으면 이전 세션은 오버레이만 정리
-        if (active === null) {
+        // 세션을 살려두는 건 같은 대상에서 재시도하라는 뜻이다.
+        // 그 사이 편집 대상이 갈렸으면 되살린 patch의 index가 다른 요소를 가리키므로
+        // 다음 커밋 경계에서 남의 값을 덮는다. 새 게스처가 이미 있을 때도 마찬가지
+        if (active === null && getEditSessionTarget() === committedTarget) {
           active = gesture;
         } else {
           releaseGestureSession(gesture.lifecycle);

--- a/src/renderer/editor/runtime/editGestureController.ts
+++ b/src/renderer/editor/runtime/editGestureController.ts
@@ -341,10 +341,6 @@ export const editGestureController = {
     if (!own) return false;
     return drainEditorWrites();
   },
-
-  commitPending(): void {
-    void this.commitPendingAsync();
-  },
 };
 
 // 선택 대상 변경 시 진행 중 게스처 취소 (barrier)

--- a/src/renderer/editor/runtime/editGestureController.ts
+++ b/src/renderer/editor/runtime/editGestureController.ts
@@ -351,9 +351,4 @@ if (typeof window !== 'undefined') {
       editGestureController.cancel();
     }
   });
-
-  // 창 포커스 이탈 시 진행 중 게스처 커밋 (입력 유실 방지)
-  window.addEventListener('blur', () => {
-    editGestureController.commitPending();
-  });
 }

--- a/src/renderer/editor/runtime/editSessionTarget.ts
+++ b/src/renderer/editor/runtime/editSessionTarget.ts
@@ -25,10 +25,13 @@ export const formatEditSessionTarget = (
 
 // 비동기 완료 콜백만 쓰는 좁은 지문.
 //
-// 완료 콜백은 시작 시점 클로저의 index를 들고 돌아온다. 같은 모드 안에서는 그
-// index가 편집을 시작한 그 요소를 그대로 가리키므로 적용하는 것이 맞다.
+// 완료 콜백은 시작 시점 클로저의 index를 들고 돌아온다. 단순 선택 변경만 있었다면
+// 그 index가 편집을 시작한 그 요소를 그대로 가리키므로 적용하는 것이 맞다.
 // 모드가 갈리면 다르다 - 키 저장기가 실행 시점 모드를 다시 읽어(useKeyManager.ts:544)
-// 옛 index를 새 모드의 엉뚱한 요소에 얹는다. 배열 교체 없이도 오염된다
+// 옛 index를 새 모드의 엉뚱한 요소에 얹는다. 배열 교체 없이도 오염된다.
+//
+// 같은 모드 안에서 배열이 재정렬되면 이 지문으로는 못 잡는다. canonical 리비전을
+// 비교하면 무관한 속성 변경에도 정상 연결을 버리므로 넣지 않았다
 export const getEditSessionMode = (): string =>
   useKeyStore.getState().selectedKeyType;
 

--- a/src/renderer/editor/runtime/editSessionTarget.ts
+++ b/src/renderer/editor/runtime/editSessionTarget.ts
@@ -1,0 +1,30 @@
+import { useGridSelectionStore } from '@stores/grid/useGridSelectionStore';
+import { useKeyStore } from '@stores/data/useKeyStore';
+
+import type { SelectedElement } from '@stores/grid/useGridSelectionStore';
+
+// 편집 세션이 붙어 있는 대상의 지문.
+//
+// 입력은 포커스 시점의 되돌릴 값만 기억하고 어느 대상인지는 기억하지 않는다.
+// 포커스가 유지된 채 대상이 갈리면 옛 값이 새 대상에 실리므로, 세션을 끊을지
+// 판단하는 기준이 필요하다.
+//
+// 값이 아니라 대상 id로 판정한다. 값 비교는 호출부의 정상적인 정규화
+// (그래프 speed의 100 단위 스냅, 오프셋의 0 -> undefined)를 대상 전환으로 오인한다.
+//
+// 반드시 zustand 파생값으로만 만든다. useState나 transition으로 만들면
+// 갱신이 sync lane을 벗어나 언마운트 cleanup이 예약 작업보다 늦어질 수 있다
+export const formatEditSessionTarget = (
+  mode: string,
+  selectedElements: readonly SelectedElement[],
+): string =>
+  `${mode}:${selectedElements
+    .map((element) => element.id)
+    .sort()
+    .join(',')}`;
+
+export const getEditSessionTarget = (): string =>
+  formatEditSessionTarget(
+    useKeyStore.getState().selectedKeyType,
+    useGridSelectionStore.getState().selectedElements,
+  );

--- a/src/renderer/editor/runtime/editSessionTarget.ts
+++ b/src/renderer/editor/runtime/editSessionTarget.ts
@@ -17,11 +17,19 @@ import type { SelectedElement } from '@stores/grid/useGridSelectionStore';
 export const formatEditSessionTarget = (
   mode: string,
   selectedElements: readonly SelectedElement[],
-): string =>
-  `${mode}:${selectedElements
-    .map((element) => element.id)
-    .sort()
-    .join(',')}`;
+): string => {
+  const targets = selectedElements
+    .map((element) => [element.type, element.id] as const)
+    .sort(([leftType, leftId], [rightType, rightId]) => {
+      if (leftType !== rightType) return leftType < rightType ? -1 : 1;
+      if (leftId === rightId) return 0;
+      return leftId < rightId ? -1 : 1;
+    });
+
+  // mode·ID는 플러그인과 사용자 정의 탭에서 오므로, 구분자 문자열은
+  // 서로 다른 대상을 같은 지문으로 만들 수 있다. 구조를 직렬화해 경계를 보존한다
+  return JSON.stringify([mode, targets]);
+};
 
 // 비동기 완료 콜백만 쓰는 좁은 지문.
 //

--- a/src/renderer/editor/runtime/editSessionTarget.ts
+++ b/src/renderer/editor/runtime/editSessionTarget.ts
@@ -23,6 +23,15 @@ export const formatEditSessionTarget = (
     .sort()
     .join(',')}`;
 
+// 비동기 완료 콜백만 쓰는 좁은 지문.
+//
+// 완료 콜백은 시작 시점 클로저의 index를 들고 돌아온다. 같은 모드 안에서는 그
+// index가 편집을 시작한 그 요소를 그대로 가리키므로 적용하는 것이 맞다.
+// 모드가 갈리면 다르다 - 키 저장기가 실행 시점 모드를 다시 읽어(useKeyManager.ts:544)
+// 옛 index를 새 모드의 엉뚱한 요소에 얹는다. 배열 교체 없이도 오염된다
+export const getEditSessionMode = (): string =>
+  useKeyStore.getState().selectedKeyType;
+
 export const getEditSessionTarget = (): string =>
   formatEditSessionTarget(
     useKeyStore.getState().selectedKeyType,

--- a/src/renderer/editor/runtime/focusedEditorSettlement.ts
+++ b/src/renderer/editor/runtime/focusedEditorSettlement.ts
@@ -1,0 +1,41 @@
+import { beginEditorWriteBarrier } from './editorWriteBarrier';
+import { finalizeEditorDraftForLifecycle } from './lifecycleEditorDraft';
+
+const yieldToRender = () =>
+  new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+// 포커스된 입력을 지금 대상에 확정한다.
+//
+// 순서가 계약이다. gesture 커밋을 첫 await 뒤로 미루면, 양보하는 동안 도착한
+// 원격 선택이 선택 구독자를 깨워 아직 시작도 안 한 gesture를 취소한다.
+// commitPendingAsync는 호출 즉시 동기로 active를 잡고 현재 mode·index로 patch를
+// 만든 뒤에야 persist를 await하므로, 양보 전에 시작해야 그 구간이 닫힌다.
+//
+// gesture controller를 직접 부르지 않고 콜백으로 받는다. controller가 이 파일을
+// 참조할 수 있어야 하는데 반대 방향까지 열면 순환이 된다
+export const settleFocusedEditor = async (
+  startGestureCommit: () => Promise<boolean>,
+): Promise<boolean> => {
+  const drainBlurWrites = beginEditorWriteBarrier();
+
+  const active = document.activeElement;
+  if (
+    active instanceof HTMLElement &&
+    active.matches('input, textarea, [contenteditable="true"]')
+  ) {
+    active.blur();
+  }
+
+  const draftCommitted = finalizeEditorDraftForLifecycle();
+  const gestureCommit = startGestureCommit();
+
+  // blur가 만든 React state 갱신과 IME 정산을 한 turn 기다린다
+  await yieldToRender();
+
+  const [gestureCommitted, blurWritesCommitted] = await Promise.all([
+    gestureCommit,
+    drainBlurWrites(),
+  ]);
+
+  return draftCommitted && gestureCommitted && blurWritesCommitted;
+};

--- a/src/renderer/editor/runtime/focusedEditorSettlement.ts
+++ b/src/renderer/editor/runtime/focusedEditorSettlement.ts
@@ -27,6 +27,11 @@ export const settleFocusedEditor = async (
   }
 
   const draftCommitted = finalizeEditorDraftForLifecycle();
+
+  // blur 핸들러가 promise로 이어붙인 쓰기는 여기서 끝난다.
+  // 매크로태스크는 양보하지 않는다 - 원격 선택은 그쪽으로 오므로 커밋 전에 끼어들 수 없다
+  await Promise.resolve();
+
   const gestureCommit = startGestureCommit();
 
   // blur가 만든 React state 갱신과 IME 정산을 한 turn 기다린다

--- a/src/renderer/editor/runtime/lifecycleEditorFlush.test.ts
+++ b/src/renderer/editor/runtime/lifecycleEditorFlush.test.ts
@@ -55,6 +55,26 @@ describe('flushFocusedEditorForLifecycle', () => {
     expect(settled).toBe(true);
   });
 
+  it('blur가 promise로 이어붙인 쓰기를 커밋 전에 정산한다', async () => {
+    const order: string[] = [];
+    const input = document.createElement('input');
+    input.addEventListener('blur', () => {
+      order.push('blur');
+      queueMicrotask(() => order.push('blur-settled'));
+    });
+    document.body.append(input);
+    input.focus();
+    beginEditorWriteBarrier.mockReturnValue(vi.fn(async () => true));
+    commitPendingAsync.mockImplementation(async () => {
+      order.push('commit');
+      return true;
+    });
+
+    await flushFocusedEditorForLifecycle();
+
+    expect(order).toEqual(['blur', 'blur-settled', 'commit']);
+  });
+
   it('gesture 커밋을 양보 전에 시작한다', async () => {
     // 양보하는 동안 도착한 원격 선택이 선택 구독자를 깨워 아직 시작도 안 한
     // gesture를 취소할 수 있다. history handshake 경로가 실제로 그 순서다

--- a/src/renderer/editor/runtime/lifecycleEditorFlush.test.ts
+++ b/src/renderer/editor/runtime/lifecycleEditorFlush.test.ts
@@ -48,7 +48,22 @@ describe('flushFocusedEditorForLifecycle', () => {
       settled = true;
     }, 0);
     beginEditorWriteBarrier.mockReturnValue(vi.fn(async () => true));
-    commitPendingAsync.mockImplementation(async () => settled);
+    commitPendingAsync.mockResolvedValue(true);
+
+    await flushFocusedEditorForLifecycle();
+
+    expect(settled).toBe(true);
+  });
+
+  it('gesture 커밋을 양보 전에 시작한다', async () => {
+    // 양보하는 동안 도착한 원격 선택이 선택 구독자를 깨워 아직 시작도 안 한
+    // gesture를 취소할 수 있다. history handshake 경로가 실제로 그 순서다
+    let yielded = false;
+    setTimeout(() => {
+      yielded = true;
+    }, 0);
+    beginEditorWriteBarrier.mockReturnValue(vi.fn(async () => true));
+    commitPendingAsync.mockImplementation(async () => !yielded);
 
     await expect(flushFocusedEditorForLifecycle()).resolves.toBe(true);
   });

--- a/src/renderer/editor/runtime/lifecycleEditorFlush.test.ts
+++ b/src/renderer/editor/runtime/lifecycleEditorFlush.test.ts
@@ -10,9 +10,9 @@ vi.mock('./editGestureController', () => ({
   editGestureController: { commitPendingAsync },
 }));
 
-import { flushFocusedEditorForLifecycle } from './lifecycleEditorFlush';
+import { flushFocusedEditor } from './lifecycleEditorFlush';
 
-describe('flushFocusedEditorForLifecycle', () => {
+describe('flushFocusedEditor', () => {
   afterEach(() => {
     document.body.replaceChildren();
     beginEditorWriteBarrier.mockReset();
@@ -37,7 +37,7 @@ describe('flushFocusedEditorForLifecycle', () => {
       return true;
     });
 
-    await expect(flushFocusedEditorForLifecycle()).resolves.toBe(true);
+    await expect(flushFocusedEditor()).resolves.toBe(true);
 
     expect(order).toEqual(['barrier', 'blur', 'gesture', 'blur-write']);
   });
@@ -50,7 +50,7 @@ describe('flushFocusedEditorForLifecycle', () => {
     beginEditorWriteBarrier.mockReturnValue(vi.fn(async () => true));
     commitPendingAsync.mockResolvedValue(true);
 
-    await flushFocusedEditorForLifecycle();
+    await flushFocusedEditor();
 
     expect(settled).toBe(true);
   });
@@ -70,7 +70,7 @@ describe('flushFocusedEditorForLifecycle', () => {
       return true;
     });
 
-    await flushFocusedEditorForLifecycle();
+    await flushFocusedEditor();
 
     expect(order).toEqual(['blur', 'blur-settled', 'commit']);
   });
@@ -85,7 +85,7 @@ describe('flushFocusedEditorForLifecycle', () => {
     beginEditorWriteBarrier.mockReturnValue(vi.fn(async () => true));
     commitPendingAsync.mockImplementation(async () => !yielded);
 
-    await expect(flushFocusedEditorForLifecycle()).resolves.toBe(true);
+    await expect(flushFocusedEditor()).resolves.toBe(true);
   });
 
   it.each([
@@ -99,7 +99,7 @@ describe('flushFocusedEditorForLifecycle', () => {
       );
       commitPendingAsync.mockResolvedValue(gestureResult);
 
-      await expect(flushFocusedEditorForLifecycle()).resolves.toBe(false);
+      await expect(flushFocusedEditor()).resolves.toBe(false);
     },
   );
 });

--- a/src/renderer/editor/runtime/lifecycleEditorFlush.ts
+++ b/src/renderer/editor/runtime/lifecycleEditorFlush.ts
@@ -1,26 +1,5 @@
 import { editGestureController } from './editGestureController';
-import { finalizeEditorDraftForLifecycle } from './lifecycleEditorDraft';
-import { beginEditorWriteBarrier } from './editorWriteBarrier';
+import { settleFocusedEditor } from './focusedEditorSettlement';
 
-const yieldToRender = () =>
-  new Promise<void>((resolve) => setTimeout(resolve, 0));
-
-export const flushFocusedEditorForLifecycle = async (): Promise<boolean> => {
-  const drainBlurWrites = beginEditorWriteBarrier();
-  const active = document.activeElement;
-  if (
-    active instanceof HTMLElement &&
-    active.matches('input, textarea, [contenteditable="true"]')
-  ) {
-    active.blur();
-  }
-
-  const draftCommitted = finalizeEditorDraftForLifecycle();
-  // OS 종료가 먼저 만든 focus 변경과 React 로컬 draft를 같은 turn에서 정산
-  await yieldToRender();
-  const [gestureCommitted, blurWritesCommitted] = await Promise.all([
-    editGestureController.commitPendingAsync(),
-    drainBlurWrites(),
-  ]);
-  return draftCommitted && gestureCommitted && blurWritesCommitted;
-};
+export const flushFocusedEditorForLifecycle = (): Promise<boolean> =>
+  settleFocusedEditor(() => editGestureController.commitPendingAsync());

--- a/src/renderer/editor/runtime/lifecycleEditorFlush.ts
+++ b/src/renderer/editor/runtime/lifecycleEditorFlush.ts
@@ -1,5 +1,9 @@
 import { editGestureController } from './editGestureController';
 import { settleFocusedEditor } from './focusedEditorSettlement';
 
-export const flushFocusedEditorForLifecycle = (): Promise<boolean> =>
+// 편집 경계에서 포커스된 입력을 지금 대상에 확정한다.
+//
+// 정산 순서는 settleFocusedEditor가 소유하고, 여기서는 표준 gesture 커밋만 묶는다.
+// 호출부가 각자 조립하면 커밋 대상이 갈릴 때 순서가 어긋난다
+export const flushFocusedEditor = (): Promise<boolean> =>
   settleFocusedEditor(() => editGestureController.commitPendingAsync());

--- a/src/renderer/hooks/app/useAppBootstrap.counterDelayTimers.test.tsx
+++ b/src/renderer/hooks/app/useAppBootstrap.counterDelayTimers.test.tsx
@@ -168,7 +168,7 @@ vi.mock('@stores/data/useHistoryStatusStore', () => ({
   syncHistoryStatus: vi.fn(),
 }));
 vi.mock('@src/renderer/editor/runtime/lifecycleEditorFlush', () => ({
-  flushFocusedEditorForLifecycle: vi.fn(),
+  flushFocusedEditor: vi.fn(),
 }));
 vi.mock('@src/renderer/editor/runtime/historyEditorFlushLock', () => ({
   acquireHistoryEditorFlushLock: vi.fn(),

--- a/src/renderer/hooks/app/useAppBootstrap.modeSelectionReset.test.tsx
+++ b/src/renderer/hooks/app/useAppBootstrap.modeSelectionReset.test.tsx
@@ -162,7 +162,7 @@ vi.mock('@stores/data/useHistoryStatusStore', () => ({
   syncHistoryStatus: vi.fn(),
 }));
 vi.mock('@src/renderer/editor/runtime/lifecycleEditorFlush', () => ({
-  flushFocusedEditorForLifecycle: vi.fn(),
+  flushFocusedEditor: vi.fn(),
 }));
 vi.mock('@src/renderer/editor/runtime/historyEditorFlushLock', () => ({
   acquireHistoryEditorFlushLock: vi.fn(),

--- a/src/renderer/hooks/app/useAppBootstrap.modeSelectionReset.test.tsx
+++ b/src/renderer/hooks/app/useAppBootstrap.modeSelectionReset.test.tsx
@@ -1,0 +1,401 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSettingsStore } from '@stores/useSettingsStore';
+import type { BootstrapPayload } from '@src/types/app';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+interface MockKeyState {
+  selectedKeyType: string;
+  isBootstrapped: boolean;
+  customTabs: unknown[];
+}
+
+type MockKeyStoreListener = (
+  state: MockKeyState,
+  previousState: MockKeyState,
+) => void;
+
+const mocks = vi.hoisted(() => ({
+  counterStateListener: null as null | ((payload: unknown) => void),
+  customTabsListener: null as
+    | null
+    | ((payload: { customTabs: unknown[]; selectedKeyType: string }) => void),
+  presetSnapshotListener: null as null | ((payload: unknown) => void),
+  resyncListener: null as null | (() => void),
+  bootstrap: vi.fn(),
+  keyState: {
+    selectedKeyType: '4key',
+    isBootstrapped: true,
+    customTabs: [],
+  } as MockKeyState,
+  keyStoreListeners: new Set<MockKeyStoreListener>(),
+}));
+
+vi.mock('@contexts/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@stores/data/useKeyStore', () => ({
+  useKeyStore: {
+    getState: vi.fn(() => mocks.keyState),
+    setState: vi.fn(
+      (
+        update:
+          | Partial<MockKeyState>
+          | ((state: MockKeyState) => Partial<MockKeyState>),
+      ) => {
+        const previousState = mocks.keyState;
+        const patch =
+          typeof update === 'function' ? update(previousState) : update;
+        mocks.keyState = { ...previousState, ...patch };
+        mocks.keyStoreListeners.forEach((listener) => {
+          listener(mocks.keyState, previousState);
+        });
+      },
+    ),
+    subscribe: vi.fn((listener: MockKeyStoreListener) => {
+      mocks.keyStoreListeners.add(listener);
+      return () => mocks.keyStoreListeners.delete(listener);
+    }),
+  },
+}));
+vi.mock('@stores/data/useStatItemStore', () => ({
+  useStatItemStore: {
+    getState: vi.fn(() => ({ positions: {} })),
+    setState: vi.fn(),
+  },
+}));
+vi.mock('@stores/data/useGraphItemStore', () => ({
+  useGraphItemStore: {
+    getState: vi.fn(() => ({ positions: {} })),
+    setState: vi.fn(),
+  },
+}));
+vi.mock('@stores/data/useKnobItemStore', () => ({
+  useKnobItemStore: {
+    getState: vi.fn(() => ({ positions: {} })),
+    setState: vi.fn(),
+  },
+}));
+vi.mock('@stores/data/useLayerGroupStore', () => ({
+  useLayerGroupStore: {
+    getState: vi.fn(() => ({
+      layerGroups: {},
+      setLayerGroups: vi.fn(),
+    })),
+  },
+}));
+vi.mock('@stores/useFontStore', () => ({
+  useFontStore: { getState: vi.fn(() => ({})), setState: vi.fn() },
+  syncFontCSS: vi.fn(),
+}));
+vi.mock('@api/pluginDisplayElements', () => ({
+  getUndoRedoInProgress: vi.fn(() => false),
+}));
+vi.mock('@api/modules/obsApi', () => ({
+  obsApi: {
+    onResync: vi.fn((listener: () => void) => {
+      mocks.resyncListener = listener;
+      return vi.fn();
+    }),
+  },
+}));
+vi.mock('@api/modules/shared', () => ({
+  notifyLocaleChanged: vi.fn(),
+  subscribe: vi.fn((event: string, listener: (payload: unknown) => void) => {
+    if (event === 'keys:counters-state') {
+      mocks.counterStateListener = listener;
+    }
+    return vi.fn();
+  }),
+}));
+vi.mock('@api/modules/appApi', () => ({
+  acknowledgeLifecycleAfterEditorFlush: vi.fn(),
+  cancelLifecycleEditorFlush: vi.fn(),
+}));
+vi.mock('@src/renderer/editor/runtime/editorStateCoordinator', () => ({
+  editorCoordinator: {
+    subscribe: vi.fn(() => vi.fn()),
+    getState: vi.fn(() => ({
+      conflict: null,
+      failureKind: null,
+      error: null,
+    })),
+    resolveConflict: vi.fn(),
+    start: vi.fn(),
+    sync: vi.fn(),
+  },
+}));
+vi.mock('@api/modules/selectionSessionApi', () => ({
+  panelWindowApi: {
+    onVisibility: vi.fn(() => vi.fn()),
+    isOpen: vi.fn(),
+    takeViewState: vi.fn(),
+  },
+}));
+vi.mock('@src/renderer/editor/runtime/selectionSync', () => ({
+  initSelectionSync: vi.fn(),
+  resetSelectionForModeChange: vi.fn(),
+}));
+vi.mock('@stores/grid/usePanelWindowStore', () => ({
+  usePanelWindowStore: { getState: vi.fn(() => ({ setDetached: vi.fn() })) },
+}));
+vi.mock('@stores/grid/panelViewHandoff', () => ({
+  applyPanelViewState: vi.fn(),
+}));
+vi.mock('@plugins/rpc/pluginRpcHandler', () => ({
+  initPluginRpcHandler: vi.fn(),
+}));
+vi.mock('@plugins/rpc/pluginSettingsSession', () => ({
+  initPluginSettingsSessionHost: vi.fn(),
+  notePanelVisibilityForSettingsSession: vi.fn(),
+}));
+vi.mock('@plugins/runtime/displayElement/instancesUndoSync', () => ({
+  initPluginInstancesUndoSync: vi.fn(),
+}));
+vi.mock('@api/modules/historyApi', () => ({
+  historyApi: { onStatus: vi.fn(() => vi.fn()) },
+}));
+vi.mock('@stores/data/useHistoryStatusStore', () => ({
+  useHistoryStatusStore: { getState: vi.fn(() => ({ applyStatus: vi.fn() })) },
+  syncHistoryStatus: vi.fn(),
+}));
+vi.mock('@src/renderer/editor/runtime/lifecycleEditorFlush', () => ({
+  flushFocusedEditorForLifecycle: vi.fn(),
+}));
+vi.mock('@src/renderer/editor/runtime/historyEditorFlushLock', () => ({
+  acquireHistoryEditorFlushLock: vi.fn(),
+  releaseHistoryEditorFlushLock: vi.fn(),
+  resetHistoryEditorFlushLock: vi.fn(),
+}));
+vi.mock('@src/renderer/defaults', () => ({
+  initDefaults: vi.fn(),
+  getDefaultNoteSettings: vi.fn(() => ({
+    frameLimit: 0,
+    speed: 400,
+    trackHeight: 300,
+    reverse: false,
+    fadePosition: 'auto',
+    fadeTopPx: 50,
+    fadeBottomPx: 0,
+    reverseFadeTopPx: 0,
+    reverseFadeBottomPx: 50,
+    delayedNoteEnabled: false,
+    shortNoteThresholdMs: 50,
+    shortNoteMinLengthPx: 30,
+    keyDisplayDelayMs: 0,
+  })),
+  getDefaultFontSettings: vi.fn(() => ({ customFonts: [] })),
+  getDefaultGridSettings: vi.fn(() => ({})),
+  getDefaultShortcuts: vi.fn(() => ({})),
+}));
+vi.mock('@utils/grid/cursorUtils', () => ({
+  initializeCursorSystem: vi.fn(() => Promise.resolve()),
+  refreshCursorSettings: vi.fn(() => Promise.resolve()),
+}));
+
+import { resetSelectionForModeChange } from '@src/renderer/editor/runtime/selectionSync';
+
+import { useAppBootstrap } from './useAppBootstrap';
+
+const Harness = () => {
+  useAppBootstrap();
+  return null;
+};
+
+const makeBootstrap = () => {
+  const state = useSettingsStore.getState();
+  const settings = {
+    hardwareAcceleration: state.hardwareAcceleration,
+    alwaysOnTop: state.alwaysOnTop,
+    overlayLocked: state.overlayLocked,
+    angleMode: state.angleMode,
+    noteEffect: state.noteEffect,
+    noteSettings: state.noteSettings,
+    fontSettings: state.fontSettings,
+    useCustomCSS: state.useCustomCSS,
+    customCSS: { content: state.customCSSContent, path: state.customCSSPath },
+    useCustomJS: state.useCustomJS,
+    customJS: { path: null, content: '', plugins: state.jsPlugins },
+    backgroundColor: state.backgroundColor,
+    language: state.language,
+    laboratoryEnabled: state.laboratoryEnabled,
+    developerModeEnabled: state.developerModeEnabled,
+    trayEnabled: state.trayEnabled,
+    autoUpdateEnabled: state.autoUpdateEnabled,
+    overlayResizeAnchor: state.overlayResizeAnchor,
+    keyCounterEnabled: state.keyCounterEnabled,
+    gridSettings: state.gridSettings,
+    shortcuts: state.shortcuts,
+    obsModeEnabled: state.obsModeEnabled,
+  };
+
+  return {
+    settings,
+    defaults: { settings, counterSettings: {} },
+    keys: {},
+    positions: {},
+    statPositions: {},
+    graphPositions: {},
+    knobPositions: {},
+    customTabs: [],
+    selectedKeyType: '4key',
+    currentMode: '4key',
+    activeKeys: [],
+    overlay: { visible: true, locked: false, anchor: 'top-left' },
+    keyCounters: {},
+    keyCountersSessionId: 'session-a',
+    keyCountersRevision: 0,
+    layerGroups: {},
+    tabNoteOverrides: {},
+    tabCssOverrides: {},
+    editorRevision: 0,
+  } as unknown as BootstrapPayload;
+};
+
+const makeApiMock = () =>
+  ({
+    app: { bootstrap: mocks.bootstrap },
+    settings: { onChanged: vi.fn(() => vi.fn()) },
+    keys: {
+      onModeChanged: vi.fn(() => vi.fn()),
+      onCountersChanged: vi.fn(() => vi.fn()),
+      onCounterChanged: vi.fn(() => vi.fn()),
+      customTabs: {
+        onChanged: vi.fn(
+          (
+            listener: (payload: {
+              customTabs: unknown[];
+              selectedKeyType: string;
+            }) => void,
+          ) => {
+            mocks.customTabsListener = listener;
+            return vi.fn();
+          },
+        ),
+      },
+    },
+    noteTab: {
+      getAll: vi.fn().mockResolvedValue({}),
+      onChanged: vi.fn(() => vi.fn()),
+      onChangedAll: vi.fn(() => vi.fn()),
+    },
+    presets: {
+      onSnapshot: vi.fn((listener: (payload: unknown) => void) => {
+        mocks.presetSnapshotListener = listener;
+        return vi.fn();
+      }),
+    },
+    overlay: { onLock: vi.fn(() => vi.fn()), onAnchor: vi.fn(() => vi.fn()) },
+    css: { onUse: vi.fn(() => vi.fn()), onContent: vi.fn(() => vi.fn()) },
+    js: { onUse: vi.fn(() => vi.fn()), onState: vi.fn(() => vi.fn()) },
+  } as unknown as Window['api']);
+
+// 백엔드는 customTabs:changed와 preset:snapshot을 keys:mode-changed보다 먼저 보낸다.
+// 그 사이 store가 "새 모드 + 옛 index"가 되면 옛 선택이 새 모드 요소로 재해석된다
+describe('모드 전환 선택 리셋', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let originalApi: Window['api'];
+  let originalWindowType: typeof window.__dmn_window_type;
+
+  const snapshotPayload = (selectedKeyType: string) => ({
+    customTabs: [],
+    selectedKeyType,
+    tabNoteOverrides: {},
+  });
+
+  const mount = async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<Harness />);
+    });
+  };
+
+  beforeEach(async () => {
+    originalApi = window.api;
+    originalWindowType = window.__dmn_window_type;
+    window.__dmn_window_type = 'main';
+    window.api = makeApiMock();
+    mocks.bootstrap.mockReset();
+    mocks.customTabsListener = null;
+    mocks.presetSnapshotListener = null;
+    mocks.keyState = {
+      selectedKeyType: '4key',
+      isBootstrapped: false,
+      customTabs: [],
+    };
+    mocks.keyStoreListeners.clear();
+    mocks.bootstrap.mockResolvedValue(makeBootstrap());
+    vi.mocked(resetSelectionForModeChange).mockClear();
+
+    await mount();
+    expect(mocks.bootstrap).toHaveBeenCalledTimes(1);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    window.api = originalApi;
+    window.__dmn_window_type = originalWindowType;
+    vi.restoreAllMocks();
+  });
+
+  it('customTabs 변경이 모드를 바꾸면 선택을 리셋한다', () => {
+    act(() => {
+      mocks.customTabsListener?.({ customTabs: [], selectedKeyType: '8key' });
+    });
+
+    expect(resetSelectionForModeChange).toHaveBeenCalledTimes(1);
+    expect(mocks.keyState.selectedKeyType).toBe('8key');
+  });
+
+  it('customTabs만 바뀌고 모드가 같으면 선택을 건드리지 않는다', () => {
+    act(() => {
+      mocks.customTabsListener?.({
+        customTabs: [{ id: 'tab-a' }],
+        selectedKeyType: '4key',
+      });
+    });
+
+    expect(resetSelectionForModeChange).not.toHaveBeenCalled();
+    expect(mocks.keyState.customTabs).toEqual([{ id: 'tab-a' }]);
+  });
+
+  it('프리셋 스냅샷이 모드를 바꾸면 선택을 리셋한다', () => {
+    act(() => {
+      mocks.presetSnapshotListener?.(snapshotPayload('8key'));
+    });
+
+    expect(resetSelectionForModeChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('프리셋 스냅샷의 모드가 같으면 선택을 건드리지 않는다', () => {
+    act(() => {
+      mocks.presetSnapshotListener?.(snapshotPayload('4key'));
+    });
+
+    expect(resetSelectionForModeChange).not.toHaveBeenCalled();
+  });
+
+  it('오버레이 창에서는 리셋하지 않는다', async () => {
+    act(() => root.unmount());
+    container.remove();
+    window.__dmn_window_type = 'overlay';
+    mocks.keyState = {
+      selectedKeyType: '4key',
+      isBootstrapped: false,
+      customTabs: [],
+    };
+    await mount();
+
+    act(() => {
+      mocks.customTabsListener?.({ customTabs: [], selectedKeyType: '8key' });
+    });
+
+    expect(resetSelectionForModeChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/hooks/app/useAppBootstrap.ts
+++ b/src/renderer/hooks/app/useAppBootstrap.ts
@@ -972,11 +972,17 @@ export function useAppBootstrap() {
       }),
       window.api.keys.customTabs.onChanged(
         ({ customTabs, selectedKeyType }) => {
+          const modeChanged =
+            useKeyStore.getState().selectedKeyType !== selectedKeyType;
           useKeyStore.setState((state) => ({
             ...state,
             customTabs,
             selectedKeyType,
           }));
+          // 백엔드가 customTabs를 keys:mode-changed보다 먼저 보낸다.
+          // 여기서 리셋하지 않으면 그 사이 store가 "새 모드 + 옛 index"가 된다
+          if (modeChanged && !isOverlayWindow && window.__dmn_runtime !== 'obs')
+            resetSelectionForModeChange();
         },
       ),
       window.api.noteTab.onChanged(({ tabId, settings }) => {
@@ -1000,11 +1006,15 @@ export function useAppBootstrap() {
       }),
       window.api.presets.onSnapshot((snapshot) => {
         if (disposed) return;
+        const modeChanged =
+          useKeyStore.getState().selectedKeyType !== snapshot.selectedKeyType;
         useKeyStore.setState((state) => ({
           ...state,
           customTabs: snapshot.customTabs,
           selectedKeyType: snapshot.selectedKeyType,
         }));
+        if (modeChanged && !isOverlayWindow && window.__dmn_runtime !== 'obs')
+          resetSelectionForModeChange();
         useSettingsStore.setState({
           tabNoteOverrides: snapshot.tabNoteOverrides,
         });

--- a/src/renderer/hooks/app/useAppBootstrap.ts
+++ b/src/renderer/hooks/app/useAppBootstrap.ts
@@ -45,7 +45,7 @@ import {
   useHistoryStatusStore,
   syncHistoryStatus,
 } from '@stores/data/useHistoryStatusStore';
-import { flushFocusedEditorForLifecycle } from '@src/renderer/editor/runtime/lifecycleEditorFlush';
+import { flushFocusedEditor } from '@src/renderer/editor/runtime/lifecycleEditorFlush';
 import {
   acquireHistoryEditorFlushLock,
   releaseHistoryEditorFlushLock,
@@ -147,6 +147,28 @@ export function useAppBootstrap() {
     let editorCoordinatorRetryTimer: ReturnType<typeof setTimeout> | null =
       null;
     const isOverlayWindow = window.__dmn_window_type === 'overlay';
+
+    // 모드가 실제로 갈릴 때만 선택을 리셋한다.
+    //
+    // 백엔드는 customTabs와 프리셋 스냅샷을 keys:mode-changed보다 먼저 보낸다.
+    // 여기서 리셋하지 않으면 그 사이 store가 "새 모드 + 옛 index"가 되고,
+    // 그 창에서 확정된 편집이 새 모드의 엉뚱한 요소에 실린다
+    const adoptSelectedKeyType = (
+      customTabs: CustomTab[],
+      selectedKeyType: string,
+    ) => {
+      const modeChanged =
+        useKeyStore.getState().selectedKeyType !== selectedKeyType;
+      useKeyStore.setState((state) => ({
+        ...state,
+        customTabs,
+        selectedKeyType,
+      }));
+      if (modeChanged && !isOverlayWindow && window.__dmn_runtime !== 'obs') {
+        resetSelectionForModeChange();
+      }
+    };
+
     let conflictDialogOpen = false;
     let lastShownPermanentEditorError: unknown = null;
     // 키 표시 딜레이와 동기화를 위한 카운터 업데이트 지연
@@ -874,7 +896,7 @@ export function useAppBootstrap() {
           acquireHistoryEditorFlushLock(handshakeId);
         }
         void (async () => {
-          const committed = await flushFocusedEditorForLifecycle();
+          const committed = await flushFocusedEditor();
           if (!committed) {
             throw new Error('pending focused editor failed to commit');
           }
@@ -972,17 +994,7 @@ export function useAppBootstrap() {
       }),
       window.api.keys.customTabs.onChanged(
         ({ customTabs, selectedKeyType }) => {
-          const modeChanged =
-            useKeyStore.getState().selectedKeyType !== selectedKeyType;
-          useKeyStore.setState((state) => ({
-            ...state,
-            customTabs,
-            selectedKeyType,
-          }));
-          // 백엔드가 customTabs를 keys:mode-changed보다 먼저 보낸다.
-          // 여기서 리셋하지 않으면 그 사이 store가 "새 모드 + 옛 index"가 된다
-          if (modeChanged && !isOverlayWindow && window.__dmn_runtime !== 'obs')
-            resetSelectionForModeChange();
+          adoptSelectedKeyType(customTabs, selectedKeyType);
         },
       ),
       window.api.noteTab.onChanged(({ tabId, settings }) => {
@@ -1006,15 +1018,7 @@ export function useAppBootstrap() {
       }),
       window.api.presets.onSnapshot((snapshot) => {
         if (disposed) return;
-        const modeChanged =
-          useKeyStore.getState().selectedKeyType !== snapshot.selectedKeyType;
-        useKeyStore.setState((state) => ({
-          ...state,
-          customTabs: snapshot.customTabs,
-          selectedKeyType: snapshot.selectedKeyType,
-        }));
-        if (modeChanged && !isOverlayWindow && window.__dmn_runtime !== 'obs')
-          resetSelectionForModeChange();
+        adoptSelectedKeyType(snapshot.customTabs, snapshot.selectedKeyType);
         useSettingsStore.setState({
           tabNoteOverrides: snapshot.tabNoteOverrides,
         });

--- a/src/renderer/stores/grid/usePanelWindowStore.ts
+++ b/src/renderer/stores/grid/usePanelWindowStore.ts
@@ -1,8 +1,7 @@
 import { create } from 'zustand';
 
 import { panelWindowApi } from '@api/modules/selectionSessionApi';
-import { editGestureController } from '@src/renderer/editor/runtime/editGestureController';
-import { settleFocusedEditor } from '@src/renderer/editor/runtime/focusedEditorSettlement';
+import { flushFocusedEditor } from '@src/renderer/editor/runtime/lifecycleEditorFlush';
 import { flushSelectionSync } from '@src/renderer/editor/runtime/selectionSync';
 import { capturePanelViewState } from '@stores/grid/panelViewHandoff';
 import { usePropertiesPanelStore } from '@stores/grid/usePropertiesPanelStore';
@@ -49,7 +48,7 @@ const yieldToRender = () =>
 const flushPanelTransition = async (): Promise<boolean> => {
   const [editorCommitted, pluginElementsCommitted, pluginSettingsCommitted] =
     await Promise.all([
-      settleFocusedEditor(() => editGestureController.commitPendingAsync()),
+      flushFocusedEditor(),
       drainPendingPluginElementWrites(),
       drainPendingPluginSettingsWrites(),
     ]);

--- a/src/renderer/stores/grid/usePanelWindowStore.ts
+++ b/src/renderer/stores/grid/usePanelWindowStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 
 import { panelWindowApi } from '@api/modules/selectionSessionApi';
 import { editGestureController } from '@src/renderer/editor/runtime/editGestureController';
-import { beginEditorWriteBarrier } from '@src/renderer/editor/runtime/editorWriteBarrier';
+import { settleFocusedEditor } from '@src/renderer/editor/runtime/focusedEditorSettlement';
 import { flushSelectionSync } from '@src/renderer/editor/runtime/selectionSync';
 import { capturePanelViewState } from '@stores/grid/panelViewHandoff';
 import { usePropertiesPanelStore } from '@stores/grid/usePropertiesPanelStore';
@@ -43,39 +43,23 @@ export const usePanelWindowStore = create<PanelWindowState>((set) => ({
 const yieldToRender = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 0));
 
-// 단축키·토글 OFF·네이티브 close는 click 포커스 이동이 없으므로
-// blur 전용 편집값을 먼저 확정하고 React·IME 정산 turn을 기다림
-const flushFocusedEditor = async (): Promise<void> => {
-  const active = document.activeElement;
-  if (
-    active instanceof HTMLElement &&
-    active.matches('input, textarea, [contenteditable="true"]')
-  ) {
-    active.blur();
-    await yieldToRender();
-  }
-};
-
+// 단축키·토글 OFF·네이티브 close는 click 포커스 이동이 없으므로 blur 전용 편집값을 먼저 확정한다.
+// 정산 순서는 공용 함수가 소유한다 - 여기서 따로 양보하면 그 사이 도착한 선택 변경이
+// 아직 시작도 안 한 gesture를 취소한다
 const flushPanelTransition = async (): Promise<boolean> => {
-  const drainBlurWrites = beginEditorWriteBarrier();
-  await flushFocusedEditor();
-  const [
-    committed,
-    blurWritesCommitted,
-    pluginElementsCommitted,
-    pluginSettingsCommitted,
-  ] = await Promise.all([
-    editGestureController.commitPendingAsync(),
-    drainBlurWrites(),
-    drainPendingPluginElementWrites(),
-    drainPendingPluginSettingsWrites(),
-  ]);
-  const editorAndPluginsCommitted =
-    committed &&
-    blurWritesCommitted &&
-    pluginElementsCommitted &&
-    pluginSettingsCommitted;
-  if (!editorAndPluginsCommitted) return false;
+  const [editorCommitted, pluginElementsCommitted, pluginSettingsCommitted] =
+    await Promise.all([
+      settleFocusedEditor(() => editGestureController.commitPendingAsync()),
+      drainPendingPluginElementWrites(),
+      drainPendingPluginSettingsWrites(),
+    ]);
+  if (
+    !editorCommitted ||
+    !pluginElementsCommitted ||
+    !pluginSettingsCommitted
+  ) {
+    return false;
+  }
 
   return flushSelectionSync();
 };

--- a/src/renderer/windows/panel/App.tsx
+++ b/src/renderer/windows/panel/App.tsx
@@ -14,6 +14,8 @@ import { reattachPropertiesPanel } from '@stores/grid/usePanelWindowStore';
 import { initPluginSettingsMirror } from '@plugins/rpc/pluginSettingsMirror';
 import { startPluginRpcClient } from '@plugins/rpc/pluginRpcClient';
 import { onSelectionSyncReady } from '@src/renderer/editor/runtime/selectionSync';
+import { editGestureController } from '@src/renderer/editor/runtime/editGestureController';
+import { settleFocusedEditor } from '@src/renderer/editor/runtime/focusedEditorSettlement';
 import { applyPanelViewState } from '@stores/grid/panelViewHandoff';
 import { usePropertiesPanelStore } from '@stores/grid/usePropertiesPanelStore';
 import { isHistoryEditorFlushLocked } from '@src/renderer/editor/runtime/historyEditorFlushLock';
@@ -42,6 +44,23 @@ const App = ({ initialViewState }: AppProps) => {
   useEffect(() => startPluginRpcClient(), []);
   // main 소유 설정 세션의 descriptor 미러 - 입력은 RPC로 왕복
   useEffect(() => initPluginSettingsMirror(), []);
+
+  // 이 창이 포커스를 잃으면 편집을 지금 대상에 확정한다.
+  //
+  // 메인 창을 클릭해도 이 창의 입력은 커서를 놓지 않는다. 그 뒤 선택만 메인에서
+  // 넘어오면 콜백은 새 대상을 가리키는데 draft는 옛 대상 것이라, 다음 blur가
+  // 옛 값을 새 대상에 저장한다.
+  // 창 blur는 로컬 이벤트고 선택 반영은 백엔드 왕복이라 정산이 항상 먼저 도착한다.
+  // 메인 창에는 걸지 않는다 - alt-tab만 해도 편집 중인 입력이 풀린다
+  useEffect(() => {
+    const settle = () => {
+      void settleFocusedEditor(() =>
+        editGestureController.commitPendingAsync(),
+      );
+    };
+    window.addEventListener('blur', settle);
+    return () => window.removeEventListener('blur', settle);
+  }, []);
   useEffect(
     () =>
       panelWindowApi.onPropertyModeRequested(() => {

--- a/src/renderer/windows/panel/App.tsx
+++ b/src/renderer/windows/panel/App.tsx
@@ -14,8 +14,7 @@ import { reattachPropertiesPanel } from '@stores/grid/usePanelWindowStore';
 import { initPluginSettingsMirror } from '@plugins/rpc/pluginSettingsMirror';
 import { startPluginRpcClient } from '@plugins/rpc/pluginRpcClient';
 import { onSelectionSyncReady } from '@src/renderer/editor/runtime/selectionSync';
-import { editGestureController } from '@src/renderer/editor/runtime/editGestureController';
-import { settleFocusedEditor } from '@src/renderer/editor/runtime/focusedEditorSettlement';
+import { flushFocusedEditor } from '@src/renderer/editor/runtime/lifecycleEditorFlush';
 import { applyPanelViewState } from '@stores/grid/panelViewHandoff';
 import { usePropertiesPanelStore } from '@stores/grid/usePropertiesPanelStore';
 import { isHistoryEditorFlushLocked } from '@src/renderer/editor/runtime/historyEditorFlushLock';
@@ -54,9 +53,7 @@ const App = ({ initialViewState }: AppProps) => {
   // 메인 창에는 걸지 않는다 - alt-tab만 해도 편집 중인 입력이 풀린다
   useEffect(() => {
     const settle = () => {
-      void settleFocusedEditor(() =>
-        editGestureController.commitPendingAsync(),
-      );
+      void flushFocusedEditor();
     };
     window.addEventListener('blur', settle);
     return () => window.removeEventListener('blur', settle);


### PR DESCRIPTION
## 개요

속성 패널에서 편집을 시작한 뒤 선택이나 모드가 바뀌면 옛 대상 기준으로 계산된 값이 새 대상에 저장되던 문제들을 고쳤습니다. 편집 트리에 대상 지문을 key로 걸어 대상이 갈리면 통째로 새로 마운트하고, 비동기 완료 콜백은 마지막 연결 단계에서 모드 전환 여부를 확인합니다.

## 변경 내용

- 편집 대상 지문을 도입하고 속성 패널 편집 트리를 지문 기준으로 재마운트, 옛 draft가 살아남지 않음
- 편집 정산 순서를 공용 함수로 이관해 gesture 커밋이 양보보다 먼저 시작하도록 고정
- 분리 패널이 포커스를 잃을 때 편집을 지금 대상에 확정
- 커밋 실패 세션 복원이 대상 전환 뒤에도 되살아나던 문제 수정
- 커스텀 탭과 프리셋 스냅샷이 모드를 바꿔도 선택을 리셋하지 않던 문제 수정
- 배치 색상 피커가 열린 채 선택이 바뀌면 옛 대상 색을 새 선택에 쓰던 문제, 드래그 중 언마운트가 옛 index에 색을 확정하던 문제 수정
- 단일 노브 패널의 피커와 축 캡처가 대상 전환 뒤에도 남던 문제 수정
- 비동기 완료 콜백에 모드 가드 추가, 캔버스 선택과 무관한 전역 설정 화면은 가드에서 제외
- 편집 정산 결합을 공용 함수 한 곳으로 모으고 호출부가 사라진 gesture 커밋 래퍼 제거

## 알려진 한계

같은 모드 안에서 배열이 재정렬되면 이 경계가 잡지 못합니다. 대상 지문이 모드와 선택 요소 id로 만들어지는데, 요소에는 배열 index 말고 안정적인 신원이 없기 때문입니다. 근본 해결은 요소에 안정적 id를 도입하는 것이라 별도로 진행합니다.

---
스택 2/2 · base `feature/ui-motion`

PR 1 머지 후 base가 `master`로 자동 전환됩니다.
