### PR TITLE
fix: 편집 취소와 대상 전환에서 값이 잘못 적용되던 문제

### DIFF
--- a/src/renderer/__tests__/batchStyleEditCancel.test.tsx
+++ b/src/renderer/__tests__/batchStyleEditCancel.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+import type { KeyPosition } from '@src/types/key/keys';
+import BatchStyleTabContent from '@components/main/Grid/PropertiesPanel/batch/BatchStyleTabContent';
+import { PanelNavProvider } from '@components/main/Grid/PropertiesPanel/PanelNavContext';
+import { editGestureController } from '@src/renderer/editor/runtime/editGestureController';
+
+interface CapturedNumberInput {
+  min?: number;
+  max?: number;
+  onChange?: (value: number) => void;
+  onCancel?: () => void;
+}
+
+const captured = vi.hoisted(() => ({
+  numberInputs: [] as CapturedNumberInput[],
+}));
+
+vi.mock(
+  '@components/main/Grid/PropertiesPanel/PropertyInputs',
+  async (importOriginal) => {
+    const mod = await importOriginal<
+      typeof import('@components/main/Grid/PropertiesPanel/PropertyInputs')
+    >();
+    return {
+      ...mod,
+      NumberInput: (props: CapturedNumberInput) => {
+        captured.numberInputs.push(props);
+        return <div data-testid="number-input" />;
+      },
+      ColorInput: () => <div data-testid="color-input" />,
+      TextInput: () => <div data-testid="text-input" />,
+    };
+  },
+);
+
+vi.mock('@components/main/Grid/PropertiesPanel/ShadowControls', () => ({
+  default: () => <div data-testid="shadow-controls" />,
+}));
+
+const flatPosition = () =>
+  ({
+    dx: 0,
+    dy: 0,
+    width: 60,
+    height: 60,
+    count: 0,
+  } as KeyPosition);
+
+const mixedGetter = (positions: KeyPosition[]) =>
+  function getMixedValue<T>(
+    getter: (pos: KeyPosition) => T | undefined,
+    defaultValue: T,
+  ): { isMixed: boolean; value: T } {
+    const values = positions.map((item) => getter(item) ?? defaultValue);
+    const value = values[0] ?? defaultValue;
+    return {
+      value,
+      isMixed: values.some(
+        (candidate) => JSON.stringify(candidate) !== JSON.stringify(value),
+      ),
+    };
+  };
+
+// max로 필드를 가른다. 간격 500, 테두리 두께 20, 모서리 100, 글자 크기 72
+const fieldByMax = (max: number) =>
+  captured.numberInputs.find((props) => props.max === max);
+
+type BatchSpacingHandler = (
+  spacing: number,
+  options?: { gestureId?: string },
+) => void;
+
+describe('배치 스타일 숫자 필드 취소', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let handleBatchSpacing: Mock<BatchSpacingHandler>;
+
+  const renderPanel = () => {
+    const positions = [flatPosition(), flatPosition()];
+    act(() => {
+      root.render(
+        <PanelNavProvider
+          value={{
+            activePageKey: null,
+            renderPageKey: null,
+            openPage: vi.fn(),
+            closePage: vi.fn(),
+            pageHost: null,
+          }}
+        >
+          <BatchStyleTabContent
+            selectedCount={2}
+            shadowActiveState
+            getMixedValue={mixedGetter(positions)}
+            getKeyOnlyMixedValue={mixedGetter(positions)}
+            getSelectedKeysData={() => []}
+            handleBatchAlign={vi.fn()}
+            handleBatchDistribute={vi.fn()}
+            handleBatchSpacing={handleBatchSpacing}
+            batchSpacing={{ isMixed: false, value: 10 }}
+            handleBatchResize={vi.fn()}
+            handleBatchStyleChange={vi.fn()}
+            handleBatchStyleChangeComplete={vi.fn()}
+            handleBatchShadowChangeComplete={vi.fn()}
+            handleBatchShadowEnabledChange={vi.fn()}
+            showBatchImagePicker={false}
+            onToggleBatchImagePicker={vi.fn()}
+            batchImageButtonRef={React.createRef<HTMLButtonElement>()}
+            panelElement={null}
+            useCustomCSS={false}
+            t={(key) => key}
+          />
+        </PanelNavProvider>,
+      );
+    });
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    captured.numberInputs = [];
+    handleBatchSpacing = vi.fn<BatchSpacingHandler>();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('간격 취소는 예약만 되고 아직 안 나간 커밋을 걷는다', () => {
+    renderPanel();
+    const spacing = fieldByMax(500);
+    expect(spacing).toBeDefined();
+
+    act(() => spacing!.onChange?.(40));
+    act(() => spacing!.onCancel?.());
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(handleBatchSpacing).not.toHaveBeenCalled();
+  });
+
+  it('취소가 없으면 예약된 간격이 그대로 나간다', () => {
+    renderPanel();
+    const spacing = fieldByMax(500);
+
+    act(() => spacing!.onChange?.(40));
+    act(() => vi.advanceTimersByTime(1000));
+
+    expect(handleBatchSpacing).toHaveBeenCalled();
+  });
+
+  it('스타일 숫자 필드 취소는 진행 중 gesture를 취소한다', () => {
+    const cancel = vi
+      .spyOn(editGestureController, 'cancel')
+      .mockImplementation(() => undefined);
+    renderPanel();
+
+    // 테두리 두께
+    act(() => fieldByMax(20)?.onCancel?.());
+    expect(cancel).toHaveBeenCalledTimes(1);
+
+    // 모서리 반경
+    act(() => fieldByMax(100)?.onCancel?.());
+    expect(cancel).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/renderer/__tests__/batchStyleEditCancel.test.tsx
+++ b/src/renderer/__tests__/batchStyleEditCancel.test.tsx
@@ -18,6 +18,7 @@ import { editGestureController } from '@src/renderer/editor/runtime/editGestureC
 interface CapturedNumberInput {
   min?: number;
   max?: number;
+  prefix?: string;
   onChange?: (value: number) => void;
   onCancel?: () => void;
 }
@@ -176,6 +177,21 @@ describe('배치 스타일 숫자 필드 취소', () => {
 
     // 모서리 반경
     act(() => fieldByMax(100)?.onCancel?.());
+    expect(cancel).toHaveBeenCalledTimes(2);
+  });
+
+  it('배치 크기 필드 취소는 진행 중 gesture를 취소한다', () => {
+    const cancel = vi
+      .spyOn(editGestureController, 'cancel')
+      .mockImplementation(() => undefined);
+    renderPanel();
+
+    const width = captured.numberInputs.find((props) => props.prefix === 'W');
+    const height = captured.numberInputs.find((props) => props.prefix === 'H');
+
+    act(() => width?.onCancel?.());
+    act(() => height?.onCancel?.());
+
     expect(cancel).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/renderer/components/main/Grid/PropertiesPanel.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel.tsx
@@ -2116,7 +2116,11 @@ const PropertiesPanel: React.FC<PropertiesPanelProps> = ({
     };
 
     return (
-      <div className="flex flex-col gap-[12px]">
+      // 대상이 바뀌면 폼을 통째로 새로 만든다. 설정 key만으로 묶으면 같은 스키마를 가진
+      // 다른 요소로 선택이 옮겨가도 입력 인스턴스가 살아남아, 편집 중이던 값이
+      // 새 대상에 확정되거나 취소가 옛 값을 새 대상에 쓴다.
+      // 포커스를 유지한 채 선택만 바뀌는 경로가 분리 패널 selection sync에 있다
+      <div key={colorIdPrefix} className="flex flex-col gap-[12px]">
         {sections.map((section) => {
           if (!section.renderVisible) return null;
           const sectionLabel = translate(section.label, section.label);

--- a/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchStyleTabContent.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchStyleTabContent.tsx
@@ -371,6 +371,19 @@ const BatchStyleTabContent: React.FC<BatchStyleTabContentProps> = ({
     spacingGestureIdRef.current = null;
   };
 
+  // Escape는 onBlur를 타지 않는다. 예약만 되고 아직 안 나간 커밋을 걷지 않으면
+  // 취소한 값이 80ms 뒤에 그대로 적용된다. 이미 나간 커밋은 되돌리지 않는다 -
+  // 항목별 원래 간격은 이 컴포넌트가 갖고 있지 않다
+  const onSpacingCancel = () => {
+    if (spacingDebounceTimerRef.current) {
+      clearTimeout(spacingDebounceTimerRef.current);
+      spacingDebounceTimerRef.current = null;
+    }
+    lastSpacingRef.current = null;
+    lastCommittedSpacingRef.current = null;
+    spacingGestureIdRef.current = null;
+  };
+
   useEffect(() => {
     return () => {
       if (spacingDebounceTimerRef.current) {
@@ -687,6 +700,7 @@ const BatchStyleTabContent: React.FC<BatchStyleTabContentProps> = ({
             value={batchSpacing.value}
             onChange={onSpacingChange}
             onBlur={onSpacingBlur}
+            onCancel={onSpacingCancel}
             suffix="px"
             min={0}
             max={500}

--- a/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchStyleTabContent.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchStyleTabContent.tsx
@@ -882,6 +882,7 @@ const BatchStyleTabContent: React.FC<BatchStyleTabContentProps> = ({
               handleBatchStyleChangeComplete('borderWidth', value)
             }
             onPreview={(value) => handleBatchStyleChange('borderWidth', value)}
+            onCancel={() => editGestureController.cancel()}
             suffix="px"
             min={0}
             max={20}
@@ -905,6 +906,7 @@ const BatchStyleTabContent: React.FC<BatchStyleTabContentProps> = ({
               handleBatchStyleChangeComplete('borderRadius', value)
             }
             onPreview={(value) => handleBatchStyleChange('borderRadius', value)}
+            onCancel={() => editGestureController.cancel()}
             suffix="px"
             min={0}
             max={100}
@@ -1013,6 +1015,7 @@ const BatchStyleTabContent: React.FC<BatchStyleTabContentProps> = ({
                   onPreview={(value) =>
                     handleBatchStyleChange('fontSize', value)
                   }
+                  onCancel={() => editGestureController.cancel()}
                   suffix="px"
                   min={8}
                   max={72}

--- a/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchStyleTabContent.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/batch/BatchStyleTabContent.tsx
@@ -716,6 +716,7 @@ const BatchStyleTabContent: React.FC<BatchStyleTabContentProps> = ({
             value={getMixedValue((pos) => pos.width, 60).value}
             onChange={(value) => handleBatchResize('width', value)}
             onPreview={(value) => handleBatchStyleChange('width', value)}
+            onCancel={() => editGestureController.cancel()}
             prefix="W"
             min={10}
             max={500}
@@ -727,6 +728,7 @@ const BatchStyleTabContent: React.FC<BatchStyleTabContentProps> = ({
             value={getMixedValue((pos) => pos.height, 60).value}
             onChange={(value) => handleBatchResize('height', value)}
             onPreview={(value) => handleBatchStyleChange('height', value)}
+            onCancel={() => editGestureController.cancel()}
             prefix="H"
             min={10}
             max={500}

--- a/src/renderer/components/main/Modal/content/editors/CounterAnimationEditorModal.test.tsx
+++ b/src/renderer/components/main/Modal/content/editors/CounterAnimationEditorModal.test.tsx
@@ -130,4 +130,20 @@ describe('CounterAnimationEditorModal 베지어 드래그', () => {
 
     expect(Number(p1().getAttribute('cx'))).toBeCloseTo(75);
   });
+
+  // 드래그의 preventDefault가 포커스를 남긴다. 편집 세션을 안 끊으면
+  // 뒤이은 Escape가 드래그 결과까지 함께 되돌린다
+  it('드래그를 시작하면 포커스된 입력의 편집 세션을 끊는다', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    act(() => p1().dispatchEvent(pointerEvent('pointerdown', 47.5, 79.4)));
+
+    expect(document.activeElement).not.toBe(input);
+
+    act(() => window.dispatchEvent(pointerEvent('pointerup', 47.5, 79.4)));
+    input.remove();
+  });
 });

--- a/src/renderer/components/main/Modal/content/editors/CounterAnimationEditorModal.tsx
+++ b/src/renderer/components/main/Modal/content/editors/CounterAnimationEditorModal.tsx
@@ -697,6 +697,13 @@ const CounterAnimationEditorModal = ({
     target: DragTarget,
   ) => {
     if (event.button !== 0 || spaceHeldRef.current) return;
+    // 드래그가 시작되면 텍스트 편집은 끝난 것으로 본다.
+    // 아래 preventDefault가 포커스를 남기는데, 드래그는 베지어 입력값도 같이 바꾼다.
+    // 편집 세션을 안 끊으면 뒤이은 Escape가 드래그 결과까지 함께 되돌린다
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && active.matches('input, textarea')) {
+      active.blur();
+    }
     event.preventDefault();
     event.stopPropagation();
     cancelAutoFit();


### PR DESCRIPTION
## 개요

편집 취소와 편집 대상 전환에서 값이 엉뚱한 대상에 실리던 문제 정리

## 변경 내용

- 배치 스타일 숫자 필드 Escape에 취소 배선, 대표값이 선택 전체에 실리지 않고 진행 중 gesture는 취소
- 간격 입력 Escape가 예약된 커밋을 걷도록 정정, debounce 뒤에 되살아나던 값 차단
- 플러그인 설정 폼을 대상 기준으로 재마운트, 같은 스키마의 다른 요소로 옮겨가도 입력 인스턴스 재사용 없음
- 베지어 컨트롤 드래그 시작 시 포커스된 텍스트 편집 종료, 뒤이은 Escape가 드래그 결과까지 되돌리던 동작 제거

## 검증

- 배치 스타일 취소, 베지어 드래그 편집 종료 회귀 테스트 추가. 수정을 되돌리면 실패
- 플러그인 설정 폼 재마운트는 자동 검증 없음, 속성 패널 전체 렌더 하네스가 필요해 범위에서 제외
- `npx tsc --noEmit`
- `npm run lint` 오류 0, 경고는 base와 동일
- `npm run format:check`
- `npm test` 117 files, 854 tests 통과
