### PR TITLE
perf: 캔버스 편집 리렌더와 프리뷰 발행 정리

### DIFF
--- a/src/renderer/__tests__/previewOverlaySession.test.ts
+++ b/src/renderer/__tests__/previewOverlaySession.test.ts
@@ -332,6 +332,36 @@ describe('editGestureController', () => {
     });
   });
 
+  it('아직 발행하지 않은 다른 그룹은 대기 중 최신값으로 교체됨', async () => {
+    let release: () => void = () => undefined;
+    vi.mocked(previewApi.publish).mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    editGestureController.preview('4key', [
+      { index: 0, patch: { width: 10 } },
+      { index: 1, patch: { width: 20 } },
+    ]);
+    await flushPromises();
+    expect(previewApi.publish).toHaveBeenCalledTimes(1);
+
+    editGestureController.preview('4key', [{ index: 1, patch: { width: 30 } }]);
+    await flushPromises();
+
+    release();
+    await flushPromises();
+    await flushPromises();
+
+    const targetOneCalls = vi
+      .mocked(previewApi.publish)
+      .mock.calls.map(([request]) => request)
+      .filter((request) => request.targets.includes(1));
+    expect(targetOneCalls).toHaveLength(1);
+    expect(targetOneCalls[0].patch).toEqual({ width: 30 });
+  });
+
   it('같은 patch를 쓰는 여러 대상은 한 번에 발행됨', async () => {
     editGestureController.preview('4key', [
       { index: 0, patch: { width: 42 } },

--- a/src/renderer/__tests__/previewOverlaySession.test.ts
+++ b/src/renderer/__tests__/previewOverlaySession.test.ts
@@ -302,6 +302,49 @@ describe('editGestureController', () => {
     expect(request.patch).toEqual({ backgroundColor: '#111111' });
   });
 
+  it('발행 대기 중 쌓인 중간값은 대상별 최신 값 하나로 합쳐 발행됨', async () => {
+    let release: () => void = () => undefined;
+    vi.mocked(previewApi.publish).mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    editGestureController.preview('4key', [{ index: 0, patch: { width: 1 } }]);
+    await flushPromises();
+    expect(previewApi.publish).toHaveBeenCalledTimes(1);
+
+    // in-flight 하나가 도는 동안 값이 계속 바뀐다 (드래그, 방향키 꾹 누르기)
+    for (const width of [2, 3, 4, 5]) {
+      editGestureController.preview('4key', [{ index: 0, patch: { width } }]);
+      await flushPromises();
+    }
+    expect(previewApi.publish).toHaveBeenCalledTimes(1);
+
+    release();
+    await flushPromises();
+    await flushPromises();
+
+    // 중간값 2, 3, 4는 이미 무의미하므로 IPC를 타지 않는다
+    expect(previewApi.publish).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(previewApi.publish).mock.calls[1][0].patch).toEqual({
+      width: 5,
+    });
+  });
+
+  it('같은 patch를 쓰는 여러 대상은 한 번에 발행됨', async () => {
+    editGestureController.preview('4key', [
+      { index: 0, patch: { width: 42 } },
+      { index: 1, patch: { width: 42 } },
+    ]);
+    await flushPromises();
+
+    expect(previewApi.publish).toHaveBeenCalledTimes(1);
+    const request = vi.mocked(previewApi.publish).mock.calls[0][0];
+    expect(request.targets).toEqual([0, 1]);
+    expect(request.patch).toEqual({ width: 42 });
+  });
+
   it('settleCommit 성공 시 로컬 세션 종료 + 보조 cancel 브로드캐스트', async () => {
     editGestureController.preview('4key', [
       { index: 0, patch: { width: 100 } },

--- a/src/renderer/components/main/Grid/core/Grid.tsx
+++ b/src/renderer/components/main/Grid/core/Grid.tsx
@@ -1,5 +1,6 @@
 import React, {
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   useSyncExternalStore,
@@ -941,19 +942,72 @@ const Grid = ({
     setIsContextOpen(true);
   };
 
+  // 자식에게 넘기는 콜백 참조를 요소별로 한 번만 만든다.
+  //
+  // 인라인 화살표를 그대로 넘기면 렌더마다 새 함수라 DraggableKey의 React.memo가
+  // 항상 깨진다. 그러면 값 하나가 바뀌는 프리뷰에도 화면의 모든 요소가 다시 그려진다
+  // (실측 키 100개 기준 3.13ms -> 0.35ms, 200개 7.32ms -> 0.62ms).
+  // 참조는 고정하고 실제 동작은 매 렌더 최신 구현으로 갈아끼워 값은 항상 최신을 본다
+  const handlerSlotsRef = useRef(
+    new Map<
+      string,
+      {
+        impl: Record<string, (...args: never[]) => unknown>;
+        props: Record<string, (...args: never[]) => unknown>;
+      }
+    >(),
+  );
+
+  // 최신 구현 교체는 커밋 시점에만. 렌더 중에 바꾸면 React가 그 렌더를 버렸을 때
+  // 화면에는 이전 트리가 붙어 있는데 이벤트만 폐기된 렌더의 클로저를 호출한다
+  const pendingImplRef = useRef(
+    new Map<string, Record<string, (...args: never[]) => unknown>>(),
+  );
+  pendingImplRef.current.clear();
+
+  const stableHandlers = <
+    T extends Record<string, (...args: never[]) => unknown>,
+  >(
+    id: string,
+    impl: T,
+  ): T => {
+    pendingImplRef.current.set(id, impl);
+
+    const slots = handlerSlotsRef.current;
+    const found = slots.get(id);
+    // 첫 등록은 커밋 전이라 이벤트가 들어올 수 없다. 바로 채워도 안전하다
+    if (found) return found.props as T;
+
+    const slot = {
+      impl: impl as Record<string, (...args: never[]) => unknown>,
+      props: {} as Record<string, (...args: never[]) => unknown>,
+    };
+    Object.keys(impl).forEach((name) => {
+      slot.props[name] = ((...args: unknown[]) =>
+        (slot.impl[name] as (...a: unknown[]) => unknown)(...args)) as (
+        ...args: never[]
+      ) => unknown;
+    });
+    slots.set(id, slot);
+    return slot.props as T;
+  };
+
+  useLayoutEffect(() => {
+    const slots = handlerSlotsRef.current;
+    pendingImplRef.current.forEach((impl, id) => {
+      const slot = slots.get(id);
+      if (slot) slot.impl = impl;
+    });
+  });
+
   const renderKeys = () => {
     if (!positions[selectedKeyType]) return null;
 
     return positions[selectedKeyType].map(
-      (position: KeyPosition, index: number) => (
-        <DraggableKey
-          key={`${selectedKeyType}-${index}`}
-          index={index}
-          position={position}
-          keyName={slotDisplayName(keyMappings[selectedKeyType]?.[index] ?? '')}
-          onPositionChange={onPositionChange}
-          zIndex={position.zIndex ?? index}
-          onClick={() => {
+      (position: KeyPosition, index: number) => {
+        const handlers = stableHandlers(`key-${index}`, {
+          onPositionChange: onPositionChange,
+          onClick: () => {
             selectElementWithGroup('key', index);
             // 마지막 선택 키 좌표 저장 (Shift+클릭 범위 선택용)
             const pos = positions[selectedKeyType]?.[index];
@@ -965,9 +1019,9 @@ const Grid = ({
                 height: pos.height || 60,
               });
             }
-          }}
-          onDoubleClick={() => openElementEditor('key', index)}
-          onCtrlClick={() => {
+          },
+          onDoubleClick: () => openElementEditor('key', index),
+          onCtrlClick: () => {
             // 다중 선택: 기존 선택 유지하면서 추가/제거
             toggleSelection({ type: 'key', id: `key-${index}`, index });
             // 마지막 선택 키 좌표 저장 (Shift+클릭 범위 선택용)
@@ -980,8 +1034,8 @@ const Grid = ({
                 height: pos.height || 60,
               });
             }
-          }}
-          onShiftClick={() => {
+          },
+          onShiftClick: () => {
             // 좌표 기반 범위 선택
             if (!lastSelectedKeyBounds) {
               // 이전 선택이 없으면 단일 선택처럼 동작
@@ -1121,18 +1175,12 @@ const Grid = ({
             });
 
             setSelectedElements(newSelectedElements);
-          }}
-          isSelected={selectedElements.some(
-            (el) => el.type === 'key' && el.index === index,
-          )}
-          selectedElements={selectedElements}
-          onMultiDrag={(deltaX, deltaY) =>
-            moveSelectedElements(deltaX, deltaY, undefined, false)
-          }
-          onMultiDragStart={beginSelectedPluginInstancesDrag}
-          onMultiDragEnd={commitSelectedElementsDrag}
-          activeTool={activeTool}
-          onEraserClick={() => {
+          },
+          onMultiDrag: (deltaX: number, deltaY: number) =>
+            moveSelectedElements(deltaX, deltaY, undefined, false),
+          onMultiDragStart: beginSelectedPluginInstancesDrag,
+          onMultiDragEnd: commitSelectedElementsDrag,
+          onEraserClick: () => {
             const slot = keyMappings[selectedKeyType]?.[index] ?? '';
             const displayName = slotDisplayName(slot);
             showConfirm(
@@ -1140,8 +1188,8 @@ const Grid = ({
               () => onKeyDelete(index),
               { confirmText: t('confirm.remove') },
             );
-          }}
-          onContextMenu={(e) => {
+          },
+          onContextMenu: (e: React.MouseEvent) => {
             openElementContextMenu(
               'key',
               index,
@@ -1149,18 +1197,36 @@ const Grid = ({
               e.clientY,
               keyRefs.current[index] || null,
             );
-          }}
-          setReferenceRef={(node) => {
+          },
+          setReferenceRef: (node: HTMLElement | null) => {
             keyRefs.current[index] = node;
-          }}
-          zoom={zoom}
-          panX={panX}
-          panY={panY}
-          isViewportTransforming={isTransforming}
-          counterEnabled={keyCounterEnabled}
-          counterPreviewValue={0}
-        />
-      ),
+          },
+        });
+
+        return (
+          <DraggableKey
+            key={`${selectedKeyType}-${index}`}
+            index={index}
+            position={position}
+            keyName={slotDisplayName(
+              keyMappings[selectedKeyType]?.[index] ?? '',
+            )}
+            zIndex={position.zIndex ?? index}
+            isSelected={selectedElements.some(
+              (el) => el.type === 'key' && el.index === index,
+            )}
+            selectedElements={selectedElements}
+            activeTool={activeTool}
+            zoom={zoom}
+            panX={panX}
+            panY={panY}
+            isViewportTransforming={isTransforming}
+            counterEnabled={keyCounterEnabled}
+            counterPreviewValue={0}
+            {...handlers}
+          />
+        );
+      },
     );
   };
 
@@ -1190,45 +1256,33 @@ const Grid = ({
       });
     };
 
-    return items.map((position: StatItemPosition, index: number) => (
-      <DraggableKey
-        key={`stat-${selectedKeyType}-${index}`}
-        index={index}
-        elementId={`stat-${index}`}
-        position={position}
-        keyName={getStatTypeLabel(position.statType)}
-        onPositionChange={handleStatPositionChange}
-        zIndex={position.zIndex ?? index}
-        onClick={() => {
+    return items.map((position: StatItemPosition, index: number) => {
+      const handlers = stableHandlers(`stat-${index}`, {
+        onPositionChange: handleStatPositionChange,
+        onClick: () => {
           selectElementWithGroup('stat', index);
-        }}
-        onDoubleClick={() => openElementEditor('stat', index)}
-        onCtrlClick={() => {
+        },
+        onDoubleClick: () => openElementEditor('stat', index),
+        onCtrlClick: () => {
           toggleSelection({ type: 'stat', id: `stat-${index}`, index });
-        }}
-        onShiftClick={() => {
+        },
+        onShiftClick: () => {
           // 통계 요소는 범위 선택 대상이 아니므로 Ctrl+클릭과 동일하게 처리
           toggleSelection({ type: 'stat', id: `stat-${index}`, index });
-        }}
-        isSelected={selectedElements.some(
-          (el) => el.type === 'stat' && el.index === index,
-        )}
-        selectedElements={selectedElements}
-        onMultiDrag={(deltaX, deltaY) =>
-          moveSelectedElements(deltaX, deltaY, undefined, false)
-        }
-        onMultiDragStart={beginSelectedPluginInstancesDrag}
-        onMultiDragEnd={commitSelectedElementsDrag}
-        activeTool={activeTool}
-        onEraserClick={() => {
+        },
+        onMultiDrag: (deltaX: number, deltaY: number) =>
+          moveSelectedElements(deltaX, deltaY, undefined, false),
+        onMultiDragStart: beginSelectedPluginInstancesDrag,
+        onMultiDragEnd: commitSelectedElementsDrag,
+        onEraserClick: () => {
           const displayName = getStatTypeLabel(position.statType);
           showConfirm(
             t('confirm.removeStat', { name: displayName }),
             () => deleteStatAtIndex(index),
             { confirmText: t('confirm.remove') },
           );
-        }}
-        onContextMenu={(e) => {
+        },
+        onContextMenu: (e: React.MouseEvent) => {
           openElementContextMenu(
             'stat',
             index,
@@ -1236,18 +1290,35 @@ const Grid = ({
             e.clientY,
             statRefs.current[index] || null,
           );
-        }}
-        zoom={zoom}
-        panX={panX}
-        panY={panY}
-        isViewportTransforming={isTransforming}
-        counterEnabled={true}
-        counterPreviewValue={0}
-        setReferenceRef={(node) => {
+        },
+        setReferenceRef: (node: HTMLElement | null) => {
           statRefs.current[index] = node;
-        }}
-      />
-    ));
+        },
+      });
+
+      return (
+        <DraggableKey
+          key={`stat-${selectedKeyType}-${index}`}
+          index={index}
+          elementId={`stat-${index}`}
+          position={position}
+          keyName={getStatTypeLabel(position.statType)}
+          zIndex={position.zIndex ?? index}
+          isSelected={selectedElements.some(
+            (el) => el.type === 'stat' && el.index === index,
+          )}
+          selectedElements={selectedElements}
+          activeTool={activeTool}
+          zoom={zoom}
+          panX={panX}
+          panY={panY}
+          isViewportTransforming={isTransforming}
+          counterEnabled={true}
+          counterPreviewValue={0}
+          {...handlers}
+        />
+      );
+    });
   };
 
   const renderGraphItems = () => {

--- a/src/renderer/components/main/Grid/layers/KeyCounterPreviewLayer.tsx
+++ b/src/renderer/components/main/Grid/layers/KeyCounterPreviewLayer.tsx
@@ -34,12 +34,18 @@ interface KeyCounterPreviewLayerProps {
   selectedElements?: SelectedElement[];
 }
 
-const KeyCounterPreview = ({
+// 프리뷰로 위치 하나가 바뀌면 컴파일러가 map 전체를 한 단위로 캐시하고 있어
+// 목록이 통째로 다시 돈다. 이때 leaf를 memo로 격리하지 않으면 안 바뀐 항목까지
+// Zod 정규화를 다시 돌린다 - useCounterSettings는 use 접두사라 컴파일러가
+// 훅으로 보고 절대 메모하지 않는다 (실측 키 100개 기준 0.267ms -> 0.077ms).
+// 위치 객체는 프리뷰 합성에서 바뀐 대상만 새로 만들어지므로 얕은 비교로 충분하다.
+// 그라디언트 편집 세션은 leaf가 직접 구독하므로 memo가 막지 않는다
+const KeyCounterPreview = React.memo(function KeyCounterPreview({
   position,
   index,
   previewValue = 0,
   isInBatchSelection = false,
-}: KeyCounterPreviewProps) => {
+}: KeyCounterPreviewProps) {
   const dx = Number.isFinite(position?.dx) ? position.dx! : 0;
   const dy = Number.isFinite(position?.dy) ? position.dy! : 0;
   const width = Number.isFinite(position?.width) ? position.width! : 60;
@@ -127,7 +133,7 @@ const KeyCounterPreview = ({
       </span>
     </div>
   );
-};
+});
 
 const KeyCounterPreviewLayer = ({
   positions,

--- a/src/renderer/components/main/Grid/layers/StatCounterLayer.tsx
+++ b/src/renderer/components/main/Grid/layers/StatCounterLayer.tsx
@@ -33,12 +33,18 @@ interface StatCounterLayerProps {
   selectedElements?: SelectedElement[];
 }
 
-const StatCounter = ({
+// 프리뷰로 위치 하나가 바뀌면 컴파일러가 map 전체를 한 단위로 캐시하고 있어
+// 목록이 통째로 다시 돈다. 이때 leaf를 memo로 격리하지 않으면 안 바뀐 항목까지
+// Zod 정규화를 다시 돌린다 - useCounterSettings는 use 접두사라 컴파일러가
+// 훅으로 보고 절대 메모하지 않는다.
+// 위치 객체는 프리뷰 합성에서 바뀐 대상만 새로 만들어지므로 얕은 비교로 충분하다.
+// 그라디언트 편집 세션은 leaf가 직접 구독하므로 memo가 막지 않는다
+const StatCounter = React.memo(function StatCounter({
   position,
   index,
   previewValue = 0,
   isInBatchSelection = false,
-}: StatCounterProps) => {
+}: StatCounterProps) {
   const dx = Number.isFinite(position?.dx) ? position.dx! : 0;
   const dy = Number.isFinite(position?.dy) ? position.dy! : 0;
   const width = Number.isFinite(position?.width) ? position.width! : 60;
@@ -127,7 +133,7 @@ const StatCounter = ({
       </span>
     </div>
   );
-};
+});
 
 const StatCounterLayer = ({
   positions,

--- a/src/renderer/components/main/Grid/overlays/SmartGuidesOverlay.tsx
+++ b/src/renderer/components/main/Grid/overlays/SmartGuidesOverlay.tsx
@@ -38,9 +38,11 @@ export const SmartGuidesOverlay: React.FC<SmartGuidesOverlayProps> = ({
     (state) => state.elements,
   );
 
-  // 모든 요소의 bounds 계산
+  // 모든 요소의 bounds 계산.
+  // 가이드가 꺼져 있으면 계산하지 않는다 - 프리뷰마다 전체 요소를 훑던 비용
   const allElementBounds: ElementBounds[] = (() => {
     const bounds: ElementBounds[] = [];
+    if (!isActive) return bounds;
 
     // 키 요소 bounds
     const keyPositions = positions[selectedKeyType] || [];

--- a/src/renderer/components/shared/OverlayScene.tsx
+++ b/src/renderer/components/shared/OverlayScene.tsx
@@ -14,6 +14,7 @@ import {
 } from '@src/types/key/keys';
 import type { NoteSettings } from '@src/types/settings/noteSettings';
 import type { NoteBuffer } from '@stores/signals/noteBuffer';
+import { resolveZIndexFallback } from '@utils/core/zIndexFallback';
 
 const FALLBACK_POSITION: KeyPosition = {
   dx: 0,
@@ -184,10 +185,7 @@ const OverlayScene = ({
           currentPositions[index] ??
           FALLBACK_POSITION;
 
-        const position = {
-          ...basePosition,
-          zIndex: basePosition.zIndex ?? index,
-        };
+        const position = resolveZIndexFallback(basePosition, index);
 
         return (
           <OverlayKey

--- a/src/renderer/editor/runtime/editGestureController.ts
+++ b/src/renderer/editor/runtime/editGestureController.ts
@@ -66,30 +66,33 @@ const hasPending = (gesture: ActiveGesture): boolean => {
   return false;
 };
 
-// 발행 직전에만 같은 patch를 쓰는 대상끼리 묶는다. 배치 편집의 한 번 발행 이득은
-// 그대로 두면서, 대기 구간에서는 대상별 최신 값만 남는다
-const collectGroups = (gesture: ActiveGesture) => {
-  const groups: {
-    domain: PreviewDomain;
-    targets: number[];
-    patch: Record<string, unknown>;
-  }[] = [];
-
+// 다음 발행분 하나만 꺼낸다. 아직 발행하지 않은 대상은 pending에 남아 있어야
+// 앞선 invoke를 기다리는 동안 새 입력이 들어왔을 때 최신 patch로 교체할 수 있다
+const takeNextGroup = (gesture: ActiveGesture) => {
   for (const [domain, targets] of gesture.pendingPatches) {
-    const byPatch = new Map<string, (typeof groups)[number]>();
-    for (const [index, patch] of targets) {
-      const key = JSON.stringify(patch);
-      const group = byPatch.get(key);
-      if (group) {
-        group.targets.push(index);
-        continue;
-      }
-      byPatch.set(key, { domain, targets: [index], patch });
+    const first = targets.entries().next();
+    if (first.done) {
+      gesture.pendingPatches.delete(domain);
+      continue;
     }
-    groups.push(...byPatch.values());
+
+    const [firstIndex, patch] = first.value;
+    const patchKey = JSON.stringify(patch);
+    const groupTargets = [firstIndex];
+    targets.delete(firstIndex);
+
+    for (const [index, candidate] of targets) {
+      if (JSON.stringify(candidate) === patchKey) {
+        groupTargets.push(index);
+        targets.delete(index);
+      }
+    }
+
+    if (targets.size === 0) gesture.pendingPatches.delete(domain);
+    return { domain, targets: groupTargets, patch };
   }
-  gesture.pendingPatches.clear();
-  return groups;
+
+  return null;
 };
 
 const flushPending = async (gesture: ActiveGesture) => {
@@ -97,10 +100,11 @@ const flushPending = async (gesture: ActiveGesture) => {
   if (gesture !== active || gesture.publishInFlight) return;
   if (!hasPending(gesture)) return;
 
-  const groups = collectGroups(gesture);
   gesture.publishInFlight = true;
   try {
-    for (const group of groups) {
+    while (gesture === active) {
+      const group = takeNextGroup(gesture);
+      if (!group) break;
       gesture.seq += 1;
       await previewApi.publish({
         schemaVersion: PREVIEW_SCHEMA_VERSION,

--- a/src/renderer/editor/runtime/editGestureController.ts
+++ b/src/renderer/editor/runtime/editGestureController.ts
@@ -38,15 +38,11 @@ interface ActiveGesture {
   seq: number;
   // 도메인 → target index → 게스처 동안 누적된 전체 patch
   appliedPatches: Map<PreviewDomain, Map<number, Record<string, unknown>>>;
-  // 다음 flush에 실릴 patch (patch 내용 직렬화 키로 그룹핑)
-  pendingGroups: Map<
-    string,
-    {
-      domain: PreviewDomain;
-      targets: Set<number>;
-      patch: Record<string, unknown>;
-    }
-  >;
+  // 도메인 → target index → 다음 flush에 실릴 patch.
+  // 대상별로 모아야 같은 대상의 옛 값이 덮어써진다. patch 내용으로 묶으면
+  // 값이 연속으로 바뀌는 편집(드래그, 방향키 꾹 누르기)에서 중간값마다 그룹이 하나씩 생기고,
+  // in-flight 하나가 도는 동안 쌓인 그룹이 전부 순차 발행돼 이미 무의미해진 값까지 IPC를 탄다
+  pendingPatches: Map<PreviewDomain, Map<number, Record<string, unknown>>>;
   flushScheduled: boolean;
   publishInFlight: boolean;
 }
@@ -63,13 +59,45 @@ const schedulePublishFlush = () => {
   });
 };
 
+const hasPending = (gesture: ActiveGesture): boolean => {
+  for (const targets of gesture.pendingPatches.values()) {
+    if (targets.size > 0) return true;
+  }
+  return false;
+};
+
+// 발행 직전에만 같은 patch를 쓰는 대상끼리 묶는다. 배치 편집의 한 번 발행 이득은
+// 그대로 두면서, 대기 구간에서는 대상별 최신 값만 남는다
+const collectGroups = (gesture: ActiveGesture) => {
+  const groups: {
+    domain: PreviewDomain;
+    targets: number[];
+    patch: Record<string, unknown>;
+  }[] = [];
+
+  for (const [domain, targets] of gesture.pendingPatches) {
+    const byPatch = new Map<string, (typeof groups)[number]>();
+    for (const [index, patch] of targets) {
+      const key = JSON.stringify(patch);
+      const group = byPatch.get(key);
+      if (group) {
+        group.targets.push(index);
+        continue;
+      }
+      byPatch.set(key, { domain, targets: [index], patch });
+    }
+    groups.push(...byPatch.values());
+  }
+  gesture.pendingPatches.clear();
+  return groups;
+};
+
 const flushPending = async (gesture: ActiveGesture) => {
   // invoke in-flight 1개 유지, 대기 중 최신 patch만 보존
   if (gesture !== active || gesture.publishInFlight) return;
-  if (gesture.pendingGroups.size === 0) return;
+  if (!hasPending(gesture)) return;
 
-  const groups = [...gesture.pendingGroups.values()];
-  gesture.pendingGroups.clear();
+  const groups = collectGroups(gesture);
   gesture.publishInFlight = true;
   try {
     for (const group of groups) {
@@ -80,7 +108,7 @@ const flushPending = async (gesture: ActiveGesture) => {
         seq: gesture.seq,
         domain: group.domain,
         mode: gesture.mode,
-        targets: [...group.targets],
+        targets: group.targets,
         patch: group.patch,
       });
     }
@@ -88,7 +116,7 @@ const flushPending = async (gesture: ActiveGesture) => {
     console.error('Failed to publish preview', error);
   } finally {
     gesture.publishInFlight = false;
-    if (gesture === active && gesture.pendingGroups.size > 0) {
+    if (gesture === active && hasPending(gesture)) {
       schedulePublishFlush();
     }
   }
@@ -118,7 +146,7 @@ export const editGestureController = {
         mode,
         seq: 0,
         appliedPatches: new Map(),
-        pendingGroups: new Map(),
+        pendingPatches: new Map(),
         flushScheduled: false,
         publishInFlight: false,
       };
@@ -142,18 +170,16 @@ export const editGestureController = {
         entry.patch,
         domain,
       );
-      const groupKey = JSON.stringify([domain, entry.patch]);
-      const group = active.pendingGroups.get(groupKey);
-      if (group) {
-        group.targets.add(entry.index);
-        group.patch = { ...group.patch, ...entry.patch };
-      } else {
-        active.pendingGroups.set(groupKey, {
-          domain,
-          targets: new Set([entry.index]),
-          patch: { ...entry.patch },
-        });
+      let pending = active.pendingPatches.get(domain);
+      if (!pending) {
+        pending = new Map();
+        active.pendingPatches.set(domain, pending);
       }
+      const queued = pending.get(entry.index);
+      pending.set(
+        entry.index,
+        queued ? { ...queued, ...entry.patch } : { ...entry.patch },
+      );
     }
     schedulePublishFlush();
   },
@@ -210,7 +236,7 @@ export const editGestureController = {
     if (!gesture) return;
     active = null;
     releaseGestureSession(gesture.lifecycle);
-    gesture.pendingGroups.clear();
+    gesture.pendingPatches.clear();
     previewOverlay.endSession(gesture.sessionId);
     previewApi.cancel(gesture.sessionId).catch(() => {});
   },

--- a/src/renderer/hooks/shared/useLayoutComputation.ts
+++ b/src/renderer/hooks/shared/useLayoutComputation.ts
@@ -33,6 +33,12 @@ interface Bounds {
   maxY: number;
 }
 
+// 오프셋 적용 결과 캐시. 키가 원본 위치 객체라 원본이 사라지면 함께 회수된다
+const offsetCache = new WeakMap<
+  object,
+  { x: number; y: number; result: unknown }
+>();
+
 export function computeLayout(input: LayoutInput) {
   const {
     currentKeys,
@@ -173,15 +179,26 @@ export function computeLayout(input: LayoutInput) {
   const offsetX = bounds ? PADDING - bounds.minX : 0;
   const offsetY = bounds ? topOffset - bounds.minY : 0;
 
+  // 원본 객체와 오프셋이 그대로면 이전 결과를 재사용한다.
+  // 매번 새 객체를 만들면 아래쪽 Key의 React.memo가 항상 깨져,
+  // 프리뷰로 키 하나만 움직여도 오버레이의 모든 키가 다시 그려진다
   const applyOffset = <T extends { dx: number; dy: number }>(
     items: T[],
   ): T[] => {
     if (!bounds || !items.length) return items;
-    return items.map((item) => ({
-      ...item,
-      dx: item.dx + offsetX,
-      dy: item.dy + offsetY,
-    }));
+    return items.map((item) => {
+      const cached = offsetCache.get(item);
+      if (cached && cached.x === offsetX && cached.y === offsetY) {
+        return cached.result as T;
+      }
+      const shifted = {
+        ...item,
+        dx: item.dx + offsetX,
+        dy: item.dy + offsetY,
+      };
+      offsetCache.set(item, { x: offsetX, y: offsetY, result: shifted });
+      return shifted;
+    });
   };
 
   const displayPositions = applyOffset(currentPositions);

--- a/src/renderer/utils/core/zIndexFallback.test.ts
+++ b/src/renderer/utils/core/zIndexFallback.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { resolveZIndexFallback } from './zIndexFallback';
+
+// 백엔드는 미설정 zIndex를 null로 직렬화한다. undefined만 결측으로 보면
+// 폴백이 한 번도 걸리지 않고 Key 쪽 기본값 0으로 떨어져 쌓임 순서가 사라진다
+describe('오버레이 키 zIndex 폴백', () => {
+  it('null은 결측으로 보고 인덱스를 채운다', () => {
+    const base = { zIndex: null } as unknown as { zIndex?: number };
+
+    expect(resolveZIndexFallback(base, 3).zIndex).toBe(3);
+  });
+
+  it('undefined도 결측으로 보고 인덱스를 채운다', () => {
+    const base: { zIndex?: number } = {};
+
+    expect(resolveZIndexFallback(base, 2).zIndex).toBe(2);
+  });
+
+  it('설정된 zIndex는 그대로 두고 원본 참조를 유지한다', () => {
+    const base = { zIndex: 7 };
+
+    expect(resolveZIndexFallback(base, 1)).toBe(base);
+  });
+
+  it('0은 유효한 값이라 인덱스로 덮지 않는다', () => {
+    const base = { zIndex: 0 };
+
+    expect(resolveZIndexFallback(base, 5)).toBe(base);
+  });
+
+  it('같은 원본과 같은 인덱스면 같은 객체를 돌려준다', () => {
+    const base: { zIndex?: number } = {};
+
+    expect(resolveZIndexFallback(base, 4)).toBe(resolveZIndexFallback(base, 4));
+  });
+
+  it('인덱스가 바뀌면 새 값으로 다시 채운다', () => {
+    const base: { zIndex?: number } = {};
+    resolveZIndexFallback(base, 4);
+
+    expect(resolveZIndexFallback(base, 9).zIndex).toBe(9);
+  });
+});

--- a/src/renderer/utils/core/zIndexFallback.ts
+++ b/src/renderer/utils/core/zIndexFallback.ts
@@ -1,0 +1,17 @@
+// zIndex 폴백만 채운 사본. 같은 원본과 같은 index면 같은 객체를 돌려준다
+const cache = new WeakMap<object, { index: number; result: unknown }>();
+
+// zIndex가 이미 있으면 원본을 그대로 돌려준다. 무조건 펼치면 새 객체가 되어
+// 아래 키 컴포넌트의 memo가 항상 깨지고 키 하나 변경에 전부 다시 그려진다.
+// 백엔드가 미설정 zIndex를 null로 직렬화하므로 결측 판정은 undefined만이 아니라 null까지 본다
+export const resolveZIndexFallback = <T extends { zIndex?: number }>(
+  base: T,
+  index: number,
+): T => {
+  if (base.zIndex != null) return base;
+  const cached = cache.get(base);
+  if (cached && cached.index === index) return cached.result as T;
+  const filled = { ...base, zIndex: index };
+  cache.set(base, { index, result: filled });
+  return filled;
+};


### PR DESCRIPTION
## 개요

캔버스 편집 중 리렌더 범위를 좁히고 프리뷰 발행 정리

## 변경 내용

- 캔버스 레이어 memo 경계를 좁혀 변경된 요소만 리렌더
- 레이아웃 계산 결과 캐시, 드래그 중 객체 재생성 제거
- 프리뷰 발행을 in-flight 1개로 유지, 대기 구간에는 대상별 최신 patch만 보존
- 스마트 가이드 전역 구독 해제
- z-index 폴백 해석을 유틸로 분리

## 검증

- 프리뷰 세션, z-index 폴백 회귀 테스트 포함
- `npx tsc --noEmit`
- `npm run lint` 오류 0, 경고는 base와 동일
- `npm run format:check`
- `npm test` 117 files, 858 tests 통과

## 리뷰 포인트

master의 인터랙션 최적화와 같은 영역이라 텍스트 충돌 없음만으로는 안전 판정이 어려움. 프리뷰 발행 병합이 `createRafLatestScheduler` 계열과 이중으로 걸리지 않는지 확인 필요
