### PR TITLE
perf: 고배율 윈도우에서 노트 그리는 비용 줄이기

### DIFF
--- a/src/renderer/components/overlay/WebGLTracksOGL.tsx
+++ b/src/renderer/components/overlay/WebGLTracksOGL.tsx
@@ -10,7 +10,6 @@ import {
   resolvedGlowSize,
   type TrackLayoutInput,
 } from '@stores/signals/noteBuffer';
-import { isMac } from '@utils/core/platform';
 
 const vertexShader = `
   attribute vec3 position;
@@ -355,11 +354,13 @@ const normalizeFrameLimit = (value: unknown): number => {
 
 const FRAME_PACING_EPSILON_MS = 0.3;
 const MAX_DRIFT_FRAMES = 8;
-const MACOS_DPR_CAP = 1;
+// 노트 캔버스 backing 배율 상한 - 좌표계가 CSS px라 위치·크기는 그대로, 픽셀 밀도만 줄어듦
+// GPU 드로우는 fill 비례라 고배율 화면에서 절반~1/3로 감소
+const NOTE_DPR_CAP = 1;
 
 const resolveDpr = (): number => {
   const rawDpr = window.devicePixelRatio || 1;
-  return isMac() ? Math.min(rawDpr, MACOS_DPR_CAP) : rawDpr;
+  return Math.min(rawDpr, NOTE_DPR_CAP);
 };
 
 // 캔버스 crop: 노트가 실제로 그려질 수 있는 트랙 union 영역 (DOM 좌표)


### PR DESCRIPTION
## 개요

맥에서만 걸려 있던 노트 캔버스 배율 캡(1.0)을 윈도우에도 적용해 배율 125-200%에서 노트 GPU 드로우 비용을 절반에서 1/3로 축소

## 변경 내용

- `WebGLTracksOGL`의 `resolveDpr`에서 macOS 조건을 빼고 항상 `min(devicePixelRatio, 1)` 적용, 상수 이름은 `MACOS_DPR_CAP` → `NOTE_DPR_CAP`
- 좌표가 전부 CSS px라 오버레이 크기·키 위치·노트 위치와 굵기는 그대로, 캔버스 픽셀 밀도만 내려감
- 맥은 2월부터 같은 규칙으로 동작 중이라 변화 없음, 윈도우 100% 배율도 그대로

## 검증

- `npx tsc --noEmit` / `npm run lint` 오류 0 / `npm run format`
- 오버레이 쪽 vitest 59개 통과, Rust 변경 없음
- 벤치(M5 Pro, Chrome 151, 120Hz, 시나리오 8종 × 3회, GPU 타이머 쿼리): 배율 2.0 → 1.0에서 GPU 드로우 p50 rain 0.064 → 0.047ms, 글로우 최대 0.211 → 0.097ms, 12트랙 90KPS 연타 2.077 → 0.589ms. 프레임 p95와 drain은 차이 없음
- 같은 장면 캡처 비교: 색·글로우·그라데이션 동일. 기술적으로는 테두리 안티앨리어싱 폭이 물리 2px → 1px로 줄지만 6-8배 확대해도 구분이 어렵고, 맥은 같은 상태로 6개월째 화질 신고 없음

## 참고

- 7월에 윈도우 배율 토글을 검토하다 "crop 이후엔 남는 이득이 적다"고 미뤘던 건. 다시 재보니 가벼운 설정에선 그 판단이 맞고(+20-40%) 글로우·긴 트랙·연타에선 픽셀 수에 비례해 커짐(+118-253%)
- 설정으로 노출하지 않고 자동 적용. 선명도를 되돌려 달라는 요청이 오면 그때 옵션 검토
- 같은 벤치에서 antialias:true가 GPU를 14-60% 더 쓰는 것도 확인, 지금처럼 꺼둔 상태 유지

## 리뷰 포인트

- 윈도우 실기는 미확인. 125-200% 배율에서 노트 가장자리 체감, 접근성 텍스트 배율 보정 줌과 겹칠 때 이상 없는지 확인 필요
- 이 맥에선 어떤 조건에서도 프레임이 안 떨어져서 렉 해소 여부는 하위 GPU에서 따로 봐야 함
