### PR TITLE
fix: 토글이 클릭 중 흔들림에 안 켜지던 문제와 패널 훅의 창 기준 정리

### DIFF
--- a/src/renderer/components/main/Grid/PropertiesPanel/PanelToggleButton.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/PanelToggleButton.tsx
@@ -33,13 +33,19 @@ const PanelToggleButton = ({
   commitStrategy = 'after-paint',
 }: PanelToggleButtonProps) => {
   const { t } = useTranslation();
+  // 버튼 ref는 두 훅이 나눠 쓴다. 커밋 프레임과 표식 프레임 모두 버튼이 사는 창 기준
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const { value: visualOpen, toggle } = useOptimisticBooleanCommit({
     canonicalValue: open,
     onCommit: onClick,
     strategy: commitStrategy,
+    frameHostRef: buttonRef,
   });
   // 버튼에 data-instant 부여 — 외부 개폐 시 divider/lines transition도 차단
-  const { ref, isInstant } = usePressGatedSwap<HTMLButtonElement>(visualOpen);
+  const { isInstant } = usePressGatedSwap<HTMLButtonElement>(
+    visualOpen,
+    buttonRef,
+  );
   const chipRef = useRef<HTMLSpanElement>(null);
   const mountedRef = useRef(false);
   const animRef = useRef<Animation | null>(null);
@@ -90,7 +96,7 @@ const PanelToggleButton = ({
   return (
     <div className="absolute top-0 right-0 z-30 w-[48px] h-[48px] flex items-center justify-center pointer-events-none">
       <button
-        ref={ref}
+        ref={buttonRef}
         {...togglePress}
         className="dmn-panel-toggle pointer-events-auto relative w-[32px] h-[32px] flex items-center justify-center text-fg-faint hover:text-fg transition-colors"
         data-open={visualOpen ? 'true' : 'false'}

--- a/src/renderer/components/main/Grid/PropertiesPanel/PropertyInputs.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/PropertyInputs.tsx
@@ -1285,6 +1285,7 @@ export const TextInput: React.FC<TextInputProps> = ({
     useAfterPaintValueCommit<string>({
       onCommit: liveCommit,
       strategy: commitStrategy,
+      frameHostRef: inputRef,
     });
 
   useEffect(() => {
@@ -1823,9 +1824,11 @@ const FontStyleButton = ({
   onChange,
   children,
 }: FontStyleButtonProps) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const { value: visualActive, toggle } = useOptimisticBooleanCommit({
     canonicalValue: active,
     onCommit: onChange,
+    frameHostRef: buttonRef,
   });
   const buttonClass = visualActive
     ? 'bg-fill-hover text-fg'
@@ -1833,6 +1836,7 @@ const FontStyleButton = ({
 
   return (
     <button
+      ref={buttonRef}
       type="button"
       aria-pressed={visualActive}
       onClick={toggle}

--- a/src/renderer/components/main/Grid/PropertiesPanel/ShadowControls.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/ShadowControls.tsx
@@ -56,6 +56,9 @@ const ShadowControls = ({
       canonicalValue: canonicalEnabled,
       onCommit: onEnabledChange,
       strategy: enabledCommitStrategy,
+      // 토글 자체는 Checkbox라 자기 trackRef를 따로 물고 있다. 여기 버튼 ref는
+      // 이 훅이 쓸 창을 정할 뿐이고, 창 판정은 같은 섹션 안 요소면 충분하다
+      frameHostRef: configButtonRef,
     });
 
   // 설정하기 행이 항상 남으므로 열어둔 피커를 끊지 않는다.

--- a/src/renderer/components/main/Grid/PropertiesPanel/layer/LayerTabContent.tsx
+++ b/src/renderer/components/main/Grid/PropertiesPanel/layer/LayerTabContent.tsx
@@ -55,14 +55,17 @@ const LayerGroupDisclosure = ({
   collapsed,
   onToggle,
 }: LayerGroupDisclosureProps) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const { value: visualCollapsed, toggle } = useOptimisticBooleanCommit({
     canonicalValue: collapsed,
     onCommit: onToggle,
+    frameHostRef: buttonRef,
   });
 
   return (
     <>
       <button
+        ref={buttonRef}
         type="button"
         aria-expanded={!visualCollapsed}
         className="absolute left-0 top-0 bottom-0 w-[34px] flex items-center pl-[1px] cursor-pointer z-[1]"

--- a/src/renderer/components/main/Modal/content/pickers/colorPickerPrimitives.childWindow.test.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/colorPickerPrimitives.childWindow.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePointerSession } from './colorPickerPrimitives';
+
+// 분리 패널은 opener 자식 창이라 메인 트리가 자식 문서로 DOM을 포털한다.
+// 거기 그려진 색 트랙은 취소 사유가 되는 blur도, 프리뷰 프레임도 자기 창에서 봐야 한다.
+// iframe으로 같은 힙에 문서와 창이 하나 더 있는 상황을 만든다
+const TRACK = { left: 10, top: 20, width: 100, height: 50 };
+
+interface HarnessProps {
+  emit: (x: number, y: number, final: boolean) => void;
+}
+
+const Harness = ({ emit }: HarnessProps) => {
+  const session = usePointerSession(emit);
+  return <div data-track="true" {...session} />;
+};
+
+describe('색상 트랙 pointer session 자식 창', () => {
+  let frame: HTMLIFrameElement;
+  let childDoc: Document;
+  let childWin: Window & typeof globalThis;
+  let container: HTMLDivElement;
+  let root: Root;
+  let mounted: boolean;
+  let emit: ReturnType<
+    typeof vi.fn<(x: number, y: number, final: boolean) => void>
+  >;
+  let mainRaf: ReturnType<typeof vi.fn>;
+  let childRaf: ReturnType<typeof vi.fn>;
+  let childRafCallbacks: Map<number, FrameRequestCallback>;
+  let nextChildRafId: number;
+
+  const track = () => container.querySelector<HTMLElement>('[data-track]')!;
+
+  const flushChildRaf = () => {
+    const pending = [...childRafCallbacks.values()];
+    childRafCallbacks.clear();
+    act(() => pending.forEach((callback) => callback(performance.now())));
+  };
+
+  // 이벤트를 만든 창이 곧 입력이 뜬 창이다
+  const childEvent = (type: string, clientX: number, clientY: number) => {
+    const event = new childWin.MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      buttons: type === 'pointerup' ? 0 : 1,
+      clientX,
+      clientY,
+    });
+    Object.defineProperties(event, {
+      pointerId: { value: 1 },
+      isPrimary: { value: true },
+    });
+    return event;
+  };
+
+  const send = (type: string, clientX: number, clientY: number) =>
+    act(() => {
+      track().dispatchEvent(childEvent(type, clientX, clientY));
+    });
+
+  const unmount = () => {
+    if (!mounted) return;
+    mounted = false;
+    act(() => root.unmount());
+  };
+
+  beforeEach(() => {
+    mainRaf = vi.fn(() => 1);
+    vi.stubGlobal('requestAnimationFrame', mainRaf);
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+    frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    childDoc = frame.contentDocument!;
+    childWin = frame.contentWindow as Window & typeof globalThis;
+    childRafCallbacks = new Map();
+    nextChildRafId = 1;
+    childRaf = vi.fn((callback: FrameRequestCallback) => {
+      const id = nextChildRafId;
+      nextChildRafId += 1;
+      childRafCallbacks.set(id, callback);
+      return id;
+    });
+    childWin.requestAnimationFrame = childRaf as typeof requestAnimationFrame;
+    childWin.cancelAnimationFrame = (id: number) => {
+      childRafCallbacks.delete(id);
+    };
+
+    container = childDoc.createElement('div');
+    childDoc.body.appendChild(container);
+    root = createRoot(container);
+    mounted = true;
+
+    emit = vi.fn<(x: number, y: number, final: boolean) => void>();
+    act(() => root.render(<Harness emit={emit} />));
+
+    const node = track();
+    vi.spyOn(node, 'getBoundingClientRect').mockReturnValue({
+      left: TRACK.left,
+      top: TRACK.top,
+      width: TRACK.width,
+      height: TRACK.height,
+      right: TRACK.left + TRACK.width,
+      bottom: TRACK.top + TRACK.height,
+      x: TRACK.left,
+      y: TRACK.top,
+      toJSON: () => ({}),
+    } as DOMRect);
+    Object.defineProperties(node, {
+      setPointerCapture: { value: vi.fn(), configurable: true },
+      hasPointerCapture: { value: vi.fn(() => true), configurable: true },
+      releasePointerCapture: { value: vi.fn(), configurable: true },
+    });
+  });
+
+  afterEach(() => {
+    unmount();
+    container.remove();
+    frame.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('메인 창 blur는 세션을 끝내지 않는다', () => {
+    send('pointerdown', TRACK.left, TRACK.top);
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenLastCalledWith(0, 0, false);
+
+    // 자식 창이 포커스를 가져가면 메인 창에 blur가 뜬다. 여기서 커밋하면 안 된다
+    act(() => {
+      window.dispatchEvent(new Event('blur'));
+    });
+
+    expect(emit).toHaveBeenCalledTimes(1);
+
+    // 세션이 살아 있어야 이어지는 이동이 계속 실린다
+    send('pointermove', TRACK.left + 50, TRACK.top + 25);
+    flushChildRaf();
+    expect(emit).toHaveBeenLastCalledWith(0.5, 0.5, false);
+  });
+
+  it('자식 창 blur는 세션을 한 번만 끝낸다', () => {
+    send('pointerdown', TRACK.left + 25, TRACK.top + 10);
+    emit.mockClear();
+
+    act(() => {
+      childWin.dispatchEvent(new Event('blur'));
+    });
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenLastCalledWith(0.25, 0.2, true);
+
+    // 뒤늦게 온 메인 창 blur는 아무것도 만들지 않는다
+    act(() => {
+      window.dispatchEvent(new Event('blur'));
+    });
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('프리뷰는 자식 창 프레임에 실린다', () => {
+    send('pointerdown', TRACK.left, TRACK.top);
+    emit.mockClear();
+
+    send('pointermove', TRACK.left + 50, TRACK.top + 25);
+    // 프레임 전에는 아직 반영되지 않는다
+    expect(emit).not.toHaveBeenCalled();
+    expect(childRaf).toHaveBeenCalled();
+    expect(mainRaf).not.toHaveBeenCalled();
+
+    flushChildRaf();
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenLastCalledWith(0.5, 0.5, false);
+  });
+
+  it('blur 리스너는 자식 창에 걸고 종료 때 같은 창에서 걷는다', () => {
+    const addSpy = vi.spyOn(childWin, 'addEventListener');
+    const removeSpy = vi.spyOn(childWin, 'removeEventListener');
+    const blurOf = (spy: typeof addSpy) =>
+      spy.mock.calls.filter(([type]) => type === 'blur');
+
+    send('pointerdown', TRACK.left, TRACK.top);
+    expect(blurOf(addSpy)).toHaveLength(1);
+    expect(blurOf(removeSpy)).toHaveLength(0);
+
+    send('pointerup', TRACK.left + 100, TRACK.top + 50);
+    expect(emit).toHaveBeenLastCalledWith(1, 1, true);
+    // 건 핸들러를 그대로 같은 창에서 걷는다
+    expect(blurOf(removeSpy)).toHaveLength(1);
+    expect(blurOf(removeSpy)[0][1]).toBe(blurOf(addSpy)[0][1]);
+  });
+});

--- a/src/renderer/components/main/Modal/content/pickers/colorPickerPrimitives.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/colorPickerPrimitives.tsx
@@ -78,12 +78,9 @@ export const usePointerSession = (
     emitRef.current(x, y, final);
   };
 
+  // 스케줄러는 세션 시작 때 트랙이 사는 창으로 만들어 둔다
   const schedulePreview = () => {
-    previewSchedulerRef.current ??= createRafLatestScheduler(
-      () => emitLast(false),
-      continuousInputStrategy,
-    );
-    previewSchedulerRef.current.push(true);
+    previewSchedulerRef.current?.push(true);
   };
 
   // 세션 해제 — 어떤 종료 경로로 와도 1회만 동작
@@ -128,10 +125,17 @@ export const usePointerSession = (
       ? getEditSessionTarget()
       : null;
     target.setPointerCapture(event.pointerId);
+    // 트랙이 분리 패널 자식 창에 있으면 그 창의 blur·프레임을 쓴다
+    const ownerWindow = target.ownerDocument.defaultView ?? window;
     const onWindowBlur = () => finish();
-    window.addEventListener('blur', onWindowBlur);
+    ownerWindow.addEventListener('blur', onWindowBlur);
     blurCleanupRef.current = () =>
-      window.removeEventListener('blur', onWindowBlur);
+      ownerWindow.removeEventListener('blur', onWindowBlur);
+    previewSchedulerRef.current = createRafLatestScheduler<true>(
+      () => emitLast(false),
+      continuousInputStrategy,
+      ownerWindow,
+    );
     updateRatio(event.clientX, event.clientY);
     emitLast(false);
   };

--- a/src/renderer/components/main/common/Checkbox.childWindow.test.tsx
+++ b/src/renderer/components/main/common/Checkbox.childWindow.test.tsx
@@ -1,0 +1,361 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Checkbox from './Checkbox';
+
+// 분리 패널은 opener 자식 창이라 메인 트리가 자식 문서로 DOM을 포털한다.
+// 여기 그려진 토글은 리스너·rAF·선택 잠금·스타일 계산을 전부 자식 창에 걸어야 한다.
+// iframe으로 같은 힙에 문서와 창이 하나 더 있는 상황을 만든다
+const TRACK = { x: 100, y: 0, width: 28, height: 16 };
+const THUMB = { width: 12, height: 12 };
+const TRAVEL = TRACK.width - THUMB.width - (TRACK.height - THUMB.height);
+
+const rect = (width: number, height: number, left = 0): DOMRect =>
+  ({
+    x: left,
+    y: 0,
+    width,
+    height,
+    left,
+    right: left + width,
+    top: 0,
+    bottom: height,
+    toJSON: () => ({}),
+  } as DOMRect);
+
+describe('Checkbox 자식 창 노브 드래그', () => {
+  let frame: HTMLIFrameElement;
+  let childDoc: Document;
+  let childWin: Window & typeof globalThis;
+  let container: HTMLDivElement;
+  let root: Root;
+  let mounted: boolean;
+  let mainRaf: ReturnType<typeof vi.fn>;
+  let mainRafCallbacks: Map<number, FrameRequestCallback>;
+  let nextMainRafId: number;
+  let childRaf: ReturnType<typeof vi.fn>;
+  let childRafCallbacks: Map<number, FrameRequestCallback>;
+  let nextChildRafId: number;
+  let mainButton: HTMLButtonElement;
+  let mainClick: ReturnType<typeof vi.fn<(event: Event) => void>>;
+
+  const track = () => container.querySelector<HTMLElement>('[role="switch"]')!;
+  const thumb = () =>
+    container.querySelector<HTMLElement>('.dmn-toggle-thumb')!;
+
+  const flush = (callbacks: Map<number, FrameRequestCallback>) => {
+    const pending = [...callbacks.values()];
+    callbacks.clear();
+    act(() => pending.forEach((callback) => callback(performance.now())));
+  };
+
+  const flushChildRaf = () => flush(childRafCallbacks);
+  const flushMainRaf = () => flush(mainRafCallbacks);
+
+  // 이벤트를 만든 창이 곧 입력이 뜬 창이다
+  const pointerEvent = (
+    view: Window & typeof globalThis,
+    type: string,
+    init: Record<string, unknown> = {},
+  ) => {
+    const event = new view.MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      ...init,
+    });
+    Object.defineProperties(event, {
+      pointerId: { value: 1 },
+      isPrimary: { value: true },
+    });
+    return event;
+  };
+
+  const childEvent = (type: string, init: Record<string, unknown> = {}) =>
+    pointerEvent(childWin, type, init);
+
+  const send = (type: string, init: Record<string, unknown> = {}) =>
+    act(() => {
+      track().dispatchEvent(childEvent(type, init));
+    });
+
+  const clickChild = () =>
+    act(() => {
+      track().dispatchEvent(childEvent('click'));
+    });
+
+  const render = (checked: boolean, onChange: () => void) => {
+    act(() => root.render(<Checkbox checked={checked} onChange={onChange} />));
+    vi.spyOn(track(), 'getBoundingClientRect').mockReturnValue(
+      rect(TRACK.width, TRACK.height, TRACK.x),
+    );
+    vi.spyOn(thumb(), 'getBoundingClientRect').mockReturnValue(
+      rect(THUMB.width, THUMB.height),
+    );
+  };
+
+  const unmount = () => {
+    if (!mounted) return;
+    mounted = false;
+    act(() => root.unmount());
+  };
+
+  beforeEach(() => {
+    mainRafCallbacks = new Map();
+    nextMainRafId = 1;
+    mainRaf = vi.fn((callback: FrameRequestCallback) => {
+      const id = nextMainRafId;
+      nextMainRafId += 1;
+      mainRafCallbacks.set(id, callback);
+      return id;
+    });
+    vi.stubGlobal('requestAnimationFrame', mainRaf);
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      mainRafCallbacks.delete(id);
+    });
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+    frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    childDoc = frame.contentDocument!;
+    childWin = frame.contentWindow as Window & typeof globalThis;
+    childRafCallbacks = new Map();
+    nextChildRafId = 1;
+    childRaf = vi.fn((callback: FrameRequestCallback) => {
+      const id = nextChildRafId;
+      nextChildRafId += 1;
+      childRafCallbacks.set(id, callback);
+      return id;
+    });
+    childWin.requestAnimationFrame = childRaf as typeof requestAnimationFrame;
+    childWin.cancelAnimationFrame = (id: number) => {
+      childRafCallbacks.delete(id);
+    };
+
+    container = childDoc.createElement('div');
+    childDoc.body.appendChild(container);
+    root = createRoot(container);
+    mounted = true;
+
+    // 메인 문서 버튼. 억제가 메인 창에 걸리면 이 버튼의 클릭까지 먹힌다
+    mainButton = document.createElement('button');
+    mainClick = vi.fn<(event: Event) => void>();
+    mainButton.addEventListener('click', mainClick);
+    document.body.appendChild(mainButton);
+  });
+
+  afterEach(() => {
+    unmount();
+    mainButton.remove();
+    // 도킹을 흉내 낸 테스트는 컨테이너를 메인 문서로 옮긴다
+    container.remove();
+    frame.remove();
+    document.body.style.userSelect = '';
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('반대편까지 끌고 놓은 뒤 자식 창에 click이 와도 한 번만 뒤집는다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 4 + TRAVEL });
+    send('pointerup', { clientX: TRACK.x + 4 + TRAVEL });
+    act(() => {
+      mainButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    clickChild();
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(mainClick).toHaveBeenCalledOnce();
+  });
+
+  it('이동 폭 미만 흔들림은 탭으로 한 번 뒤집는다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+
+    // 노브가 이미 왼쪽 끝이라 clamp돼 제자리. 슬롭은 넘지만 이동 폭에는 못 미친다
+    send('pointerdown', { clientX: TRACK.x + 20 });
+    send('pointermove', { clientX: TRACK.x + 20 - 5 });
+    send('pointerup', { clientX: TRACK.x + 20 - 5 });
+    clickChild();
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(track().hasAttribute('data-dmn-dragging')).toBe(false);
+  });
+
+  it('드래그 중 메인 창 blur는 세션을 취소하지 않는다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 4 + 6 });
+    // 자식 창이 포커스를 가져가면 메인 창에 blur가 뜬다. 여기서 끊기면 안 된다
+    act(() => {
+      window.dispatchEvent(new Event('blur'));
+    });
+    // 취소로 걸렸다면 메인 프레임에서 표식이 걷혔을 것이다
+    flushMainRaf();
+    expect(track().hasAttribute('data-dmn-dragging')).toBe(true);
+
+    send('pointermove', { clientX: TRACK.x + 4 + TRAVEL });
+    flushChildRaf();
+    // 세션이 살아 있어야 이어지는 이동이 노브에 계속 실린다
+    expect(thumb().style.translate).toBe(`${TRAVEL}px 0`);
+
+    send('pointerup', { clientX: TRACK.x + 4 + TRAVEL });
+    clickChild();
+
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it('드래그 중 자식 창 blur는 세션을 취소한다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 4 + TRAVEL });
+    act(() => {
+      childWin.dispatchEvent(new Event('blur'));
+    });
+    send('pointerup', { clientX: TRACK.x + 4 + TRAVEL });
+    flushChildRaf();
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(track().hasAttribute('data-dmn-dragging')).toBe(false);
+  });
+
+  it('드래그 중 선택 잠금은 자식 문서 body에 걸린다', () => {
+    render(false, vi.fn());
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 4 + TRAVEL });
+
+    expect(childDoc.body.style.userSelect).toBe('none');
+    expect(document.body.style.userSelect).toBe('');
+
+    send('pointerup', { clientX: TRACK.x + 4 + TRAVEL });
+
+    expect(childDoc.body.style.userSelect).toBe('');
+  });
+
+  it('정산 프레임과 노브 스케줄러는 자식 창의 rAF를 쓴다', () => {
+    render(false, vi.fn());
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 10 });
+    // 노브 위치는 자식 창 프레임에서 반영된다
+    expect(thumb().style.translate).toBe('');
+    flushChildRaf();
+    expect(thumb().style.translate).toBe('6px 0');
+
+    send('pointermove', { clientX: TRACK.x + 4 + TRAVEL });
+    send('pointerup', { clientX: TRACK.x + 4 + TRAVEL });
+    expect(track().hasAttribute('data-dmn-dragging')).toBe(true);
+    flushChildRaf();
+    expect(track().hasAttribute('data-dmn-dragging')).toBe(false);
+
+    expect(childRaf).toHaveBeenCalled();
+    expect(mainRaf).not.toHaveBeenCalled();
+  });
+
+  // 해제 조건인 다음 입력도 무장한 창에서만 본다. 메인 창 입력으로 풀리면
+  // 드래그 직후 자식 창 click이 살아 두 번 뒤집는다
+  it('억제 해제는 무장한 창의 입력으로만 걸린다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+    const dragAcross = () => {
+      send('pointerdown', { clientX: TRACK.x + 4 });
+      send('pointermove', { clientX: TRACK.x + 4 + TRAVEL });
+      send('pointerup', { clientX: TRACK.x + 4 + TRAVEL });
+      flushChildRaf();
+    };
+
+    dragAcross();
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    });
+    clickChild();
+    expect(onChange).toHaveBeenCalledOnce();
+
+    dragAcross();
+    act(() => {
+      childWin.dispatchEvent(
+        new childWin.KeyboardEvent('keydown', { key: 'Tab' }),
+      );
+    });
+    clickChild();
+    expect(onChange).toHaveBeenCalledTimes(3);
+  });
+
+  // 토글을 쥔 채로 패널이 도킹되면 호스트가 서브트리를 메인 문서로 옮긴다.
+  // 떠나온 창은 숨겨져 프레임이 멈추므로 정산은 지금 사는 창에서 돌아야 한다
+  it('세션 도중 노브가 옮겨지면 정산 프레임도 옮겨간 창에 건다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 4 + TRAVEL });
+    flushChildRaf();
+    expect(childDoc.body.style.userSelect).toBe('none');
+    expect(thumb().style.translate).toBe(`${TRAVEL}px 0`);
+
+    act(() => {
+      document.body.appendChild(document.adoptNode(container));
+    });
+    act(() => {
+      track().dispatchEvent(
+        pointerEvent(window, 'pointerup', { clientX: TRACK.x + 4 + TRAVEL }),
+      );
+    });
+
+    // 떠나온 자식 창 프레임은 정산을 들고 있지 않다
+    flushChildRaf();
+    expect(track().hasAttribute('data-dmn-dragging')).toBe(true);
+
+    flushMainRaf();
+    expect(track().hasAttribute('data-dmn-dragging')).toBe(false);
+    expect(thumb().style.translate).toBe('');
+    // 잠금은 걸었던 문서에서 풀린다
+    expect(childDoc.body.style.userSelect).toBe('');
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it('자식 문서 요소의 토큰 이동 폭이 실측을 이긴다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+    // 토큰 24 > 실측 12. 실측 기준(6px)으로는 넘지만 토큰 기준(12px)으로는 못 넘는 지점
+    track().style.setProperty('--ui-toggle-travel', '24');
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 4 + 8 });
+    expect(track().className).not.toContain('bg-accent');
+    send('pointermove', { clientX: TRACK.x + 4 + 14 });
+    expect(track().className).toContain('bg-accent');
+  });
+
+  it('언마운트 정리가 자식 창 리스너와 선택 잠금을 걷는다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 4 + TRAVEL });
+    expect(childDoc.body.style.userSelect).toBe('none');
+
+    const node = track();
+    unmount();
+
+    expect(childDoc.body.style.userSelect).toBe('');
+    expect(node.hasAttribute('data-dmn-dragging')).toBe(false);
+    // 걷힌 뒤 자식 창에 남은 입력은 아무 일도 만들지 않는다
+    act(() => {
+      node.dispatchEvent(childEvent('click'));
+      childWin.dispatchEvent(new Event('blur'));
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/main/common/Checkbox.commitChildWindow.test.tsx
+++ b/src/renderer/components/main/common/Checkbox.commitChildWindow.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Checkbox from './Checkbox';
+
+// 분리 패널은 opener 자식 창이라 메인 트리가 자식 문서로 DOM을 포털한다.
+// after-paint 커밋이 메인 프레임에 걸리면 메인이 가려진 동안 토글이 저장되지 않는다.
+// iframe으로 같은 힙에 문서와 창이 하나 더 있는 상황을 만든다
+describe('Checkbox 자식 창 after-paint 커밋', () => {
+  let frame: HTMLIFrameElement;
+  let childDoc: Document;
+  let childWin: Window & typeof globalThis;
+  let container: HTMLDivElement;
+  let root: Root;
+  let mounted: boolean;
+  let mainRaf: ReturnType<typeof vi.fn>;
+  let childRaf: ReturnType<typeof vi.fn>;
+  let childRafCallbacks: Map<number, FrameRequestCallback>;
+  let nextChildRafId: number;
+  let childTimers: Map<number, () => void>;
+  let nextChildTimerId: number;
+
+  const track = () => container.querySelector<HTMLElement>('[role="switch"]')!;
+
+  const flushChildRaf = () => {
+    const pending = [...childRafCallbacks.values()];
+    childRafCallbacks.clear();
+    act(() => pending.forEach((callback) => callback(performance.now())));
+  };
+
+  const flushChildTimers = () => {
+    const pending = [...childTimers.values()];
+    childTimers.clear();
+    act(() => pending.forEach((callback) => callback()));
+  };
+
+  const clickChild = () =>
+    act(() => {
+      track().dispatchEvent(
+        new childWin.MouseEvent('click', { bubbles: true, cancelable: true }),
+      );
+    });
+
+  const unmount = () => {
+    if (!mounted) return;
+    mounted = false;
+    act(() => root.unmount());
+  };
+
+  beforeEach(() => {
+    mainRaf = vi.fn(() => 1);
+    vi.stubGlobal('requestAnimationFrame', mainRaf);
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+    frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    childDoc = frame.contentDocument!;
+    childWin = frame.contentWindow as Window & typeof globalThis;
+
+    childRafCallbacks = new Map();
+    nextChildRafId = 1;
+    childRaf = vi.fn((callback: FrameRequestCallback) => {
+      const id = nextChildRafId;
+      nextChildRafId += 1;
+      childRafCallbacks.set(id, callback);
+      return id;
+    });
+    childWin.requestAnimationFrame = childRaf as typeof requestAnimationFrame;
+    childWin.cancelAnimationFrame = (id: number) => {
+      childRafCallbacks.delete(id);
+    };
+
+    childTimers = new Map();
+    nextChildTimerId = 1;
+    childWin.setTimeout = ((callback: () => void) => {
+      const id = nextChildTimerId;
+      nextChildTimerId += 1;
+      childTimers.set(id, callback);
+      return id;
+    }) as unknown as typeof setTimeout;
+    childWin.clearTimeout = ((id: number) => {
+      childTimers.delete(id);
+    }) as typeof clearTimeout;
+
+    container = childDoc.createElement('div');
+    childDoc.body.appendChild(container);
+    root = createRoot(container);
+    mounted = true;
+  });
+
+  afterEach(() => {
+    unmount();
+    container.remove();
+    frame.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const render = (onChange: () => void) =>
+    act(() =>
+      root.render(
+        <Checkbox
+          checked={false}
+          onChange={onChange}
+          commitStrategy="after-paint"
+        />,
+      ),
+    );
+
+  it('클릭 커밋은 자식 창 프레임을 타고 한 번만 발화한다', () => {
+    const onChange = vi.fn();
+    render(onChange);
+
+    clickChild();
+    // 표시값은 즉시 뒤집히고 커밋만 미뤄진다
+    expect(track().getAttribute('aria-checked')).toBe('true');
+    expect(onChange).not.toHaveBeenCalled();
+
+    flushChildRaf();
+    flushChildTimers();
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(mainRaf).not.toHaveBeenCalled();
+  });
+
+  it('커밋 프레임 전에 언마운트돼도 한 번은 커밋된다', () => {
+    const onChange = vi.fn();
+    render(onChange);
+
+    clickChild();
+    expect(() => unmount()).not.toThrow();
+
+    expect(onChange).toHaveBeenCalledOnce();
+    flushChildRaf();
+    flushChildTimers();
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(mainRaf).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/main/common/Checkbox.drag.test.tsx
+++ b/src/renderer/components/main/common/Checkbox.drag.test.tsx
@@ -71,8 +71,7 @@ describe('Checkbox 노브 드래그', () => {
       host.dispatchEvent(pointer('click'));
     });
 
-  const render = (checked: boolean, onChange: () => void) => {
-    act(() => root.render(<Checkbox checked={checked} onChange={onChange} />));
+  const mockRects = () => {
     vi.spyOn(track(), 'getBoundingClientRect').mockReturnValue(
       rect(TRACK.width, TRACK.height, TRACK.x),
     );
@@ -80,6 +79,41 @@ describe('Checkbox 노브 드래그', () => {
       rect(THUMB.width, THUMB.height),
     );
   };
+
+  const render = (checked: boolean, onChange: () => void) => {
+    act(() => root.render(<Checkbox checked={checked} onChange={onChange} />));
+    mockRects();
+  };
+
+  const renderAfterPaint = (checked: boolean, onChange: () => void) => {
+    act(() =>
+      root.render(
+        <Checkbox
+          checked={checked}
+          onChange={onChange}
+          commitStrategy="after-paint"
+        />,
+      ),
+    );
+    mockRects();
+  };
+
+  // after-paint 커밋은 프레임을 하나 넘긴 뒤 타이머에서 실행된다.
+  // rAF 스텁을 지켜야 하니 타이머만 가짜로 바꾼다
+  const flushDeferredCommit = async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    try {
+      flushRaf();
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  };
+
+  // 손 떨림 폭. 슬롭 아래부터 이동 폭 직전까지 1px 단위로 훑는다
+  const JITTERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 
   beforeEach(() => {
     rafCallbacks = new Map();
@@ -142,9 +176,22 @@ describe('Checkbox 노브 드래그', () => {
     expect(onChange).toHaveBeenCalledOnce();
   });
 
-  // 노브가 이미 끝이라 안 움직이는 방향으로 반 폭 이상 끈 건 "켜려고 끈" 의도다.
-  // 중앙선 통과 여부만으로 탭 판정하면 여기서 click이 살아 켜려고 끌었는데 꺼진다
-  it('켜진 스위치를 켜는 방향으로 반 폭 이상 끌면 켜진 채로 남는다', () => {
+  // 노브가 이미 끝이라 안 움직이는 방향으로 이동 폭만큼 끈 건 "켜려고 끈" 의도다.
+  // 이걸 탭으로 강등하면 click이 살아 켜려고 끌었는데 꺼진다
+  it('켜진 스위치를 켜는 방향으로 이동 폭만큼 끌면 켜진 채로 남는다', () => {
+    const onChange = vi.fn();
+    render(true, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 14 });
+    send('pointermove', { clientX: TRACK.x + 14 + TRAVEL });
+    send('pointerup', { clientX: TRACK.x + 14 + TRAVEL });
+    clickAfterRelease();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // 같은 방향이라도 이동 폭에 못 미치면 끌 의도로 보기 어렵다. 흔들린 클릭으로 두고 뒤집는다
+  it('켜진 스위치를 켜는 방향으로 이동 폭보다 짧게 끌면 탭이라 click이 뒤집는다', () => {
     const onChange = vi.fn();
     render(true, onChange);
 
@@ -153,12 +200,12 @@ describe('Checkbox 노브 드래그', () => {
     send('pointerup', { clientX: TRACK.x + 14 + TRAVEL / 2 + 2 });
     clickAfterRelease();
 
-    expect(onChange).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledOnce();
   });
 
-  // 슬롭(3)과 중앙선(6) 사이는 클릭 중 손 떨림 범위와 겹친다. 여기서 값 그대로 + click 삼킴으로
+  // 슬롭(3)과 이동 폭(12) 사이는 클릭 중 손 떨림 범위와 겹친다. 여기서 값 그대로 + click 삼킴으로
   // 끝내면 눌렀는데 아무 반응이 없다 - 흔들린 클릭으로 보고 뒤따르는 click이 뒤집게 둔다
-  it('슬롭은 넘겼지만 중앙선에 못 닿은 흔들린 클릭은 탭으로 강등돼 click이 뒤집는다', () => {
+  it('슬롭은 넘겼지만 이동 폭에 못 미친 흔들린 클릭은 탭으로 강등돼 click이 뒤집는다', () => {
     const onChange = vi.fn();
     render(false, onChange);
 
@@ -185,7 +232,7 @@ describe('Checkbox 노브 드래그', () => {
     expect(onChange).toHaveBeenCalledOnce();
   });
 
-  it('중앙선을 넘었다 슬롭 안으로 되돌아와도 취소다 - 넘은 적이 있으므로 탭으로 강등하지 않는다', () => {
+  it('이동 폭만큼 끌었다 슬롭 안으로 되돌아와도 취소다 - 끝까지 간 적이 있으므로 탭으로 강등하지 않는다', () => {
     const onChange = vi.fn();
     render(false, onChange);
 
@@ -219,7 +266,7 @@ describe('Checkbox 노브 드래그', () => {
     expect(track().getAttribute('aria-checked')).toBe('false');
   });
 
-  it('중앙선을 넘겼다 되돌아오면 취소로 보고 커밋하지 않는다', () => {
+  it('이동 폭만큼 끌었다 되돌아오면 취소로 보고 커밋하지 않는다', () => {
     const onChange = vi.fn();
     render(false, onChange);
 
@@ -381,13 +428,29 @@ describe('Checkbox 노브 드래그', () => {
     expect(track().className).not.toContain('bg-accent');
     send('pointermove', { clientX: TRACK.x + 4 + 14 });
     expect(track().className).toContain('bg-accent');
-    // 되돌아와 놓으면 취소 - 토큰 기준 반 폭(12)을 넘겼으니 탭으로 강등되지 않는다
+    // 되돌아와 놓으면 취소 - 토큰 기준 이동 폭(24)을 채웠으니 탭으로 강등되지 않는다
+    send('pointermove', { clientX: TRACK.x + 4 + 24 });
     send('pointermove', { clientX: TRACK.x + 4 + 8 });
     send('pointerup', { clientX: TRACK.x + 4 + 8 });
     clickAfterRelease();
     flushRaf();
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('토큰 이동 폭이 24면 14px 흔들림은 아직 탭이라 click이 뒤집는다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+    track().style.setProperty('--ui-toggle-travel', '24');
+
+    // 실측 이동 폭(12) 기준이면 드래그로 굳지만 토큰 기준으로는 아직 흔들림이다
+    send('pointerdown', { clientX: TRACK.x + 20 });
+    send('pointermove', { clientX: TRACK.x + 20 - 14 });
+    send('pointerup', { clientX: TRACK.x + 20 - 14 });
+    clickAfterRelease();
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(track().hasAttribute('data-dmn-dragging')).toBe(false);
   });
 
   it('이전 드래그의 정산 프레임 안에 새 드래그가 시작돼도 표식과 위치를 잃지 않는다', () => {
@@ -480,5 +543,198 @@ describe('Checkbox 노브 드래그', () => {
     act(() => root.render(null));
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // 이동 폭만큼 끌었으면 노브가 clamp돼 제자리여도 의도한 드래그다. 값을 그대로 두고
+  // click까지 삼켜 "끌어봤지만 안 움직였다"는 결과를 지킨다
+  it('꺼진 스위치를 못 움직이는 쪽으로 이동 폭만큼 끌면 아무 일도 안 일어난다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 20 });
+    send('pointermove', { clientX: TRACK.x + 20 - TRAVEL });
+    send('pointerup', { clientX: TRACK.x + 20 - TRAVEL });
+    clickAfterRelease();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  // 강등은 세션 시작값으로 판정한다. 현재 값으로 보면 남이 켠 걸 뒤따르는 click이 되돌린다
+  it('드래그 중 외부에서 값이 바뀌어 목표와 같아져도 탭으로 강등하지 않는다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 11 });
+    // 노브가 중앙선을 넘긴 사이 외부에서 켜진다
+    act(() => root.render(<Checkbox checked={true} onChange={onChange} />));
+    send('pointerup', { clientX: TRACK.x + 11 });
+    clickAfterRelease();
+    flushRaf();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('중앙선을 넘긴 짧은 드래그는 트랙 밖에서 떼도 조상 click까지 삼킨다', () => {
+    const onChange = vi.fn();
+    const ancestorClick = vi.fn();
+    act(() =>
+      root.render(
+        <div onClick={ancestorClick}>
+          <Checkbox checked={false} onChange={onChange} />
+        </div>,
+      ),
+    );
+    mockRects();
+
+    // 이동 폭에는 못 미치지만 값이 바뀌는 드래그다 - 억제까지 살아 있어야 한다
+    send('pointerdown', { clientX: TRACK.x + 22 });
+    send('pointermove', { clientX: TRACK.x + 29 });
+    send('pointerup', { clientX: TRACK.x + 29 });
+    act(() => {
+      track().parentElement!.dispatchEvent(pointer('click'));
+    });
+    flushRaf();
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(ancestorClick).not.toHaveBeenCalled();
+  });
+
+  // 브라우저가 마지막 이동보다 앞선 좌표로 pointerup을 주기도 한다. 그 좌표까지 접어야
+  // 빠른 플릭이 짧은 흔들림으로 잡히지 않는다
+  it('뗄 때 좌표가 마지막 이동보다 멀면 그 거리까지 드래그로 본다', () => {
+    const onChange = vi.fn();
+    render(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 20 });
+    send('pointermove', { clientX: TRACK.x + 13 });
+    send('pointerup', { clientX: TRACK.x + 8 });
+    clickAfterRelease();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('after-paint 전략에서 이동 폭만큼 끌어 뒤집으면 한 번만 커밋한다', async () => {
+    const onChange = vi.fn();
+    renderAfterPaint(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 4 + TRAVEL });
+    send('pointerup', { clientX: TRACK.x + 4 + TRAVEL });
+    clickAfterRelease();
+    await flushDeferredCommit();
+
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it('after-paint 전략에서도 흔들린 클릭이 한 번 뒤집는다', async () => {
+    const onChange = vi.fn();
+    renderAfterPaint(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 20 });
+    send('pointermove', { clientX: TRACK.x + 14 });
+    send('pointerup', { clientX: TRACK.x + 14 });
+    clickAfterRelease();
+    await flushDeferredCommit();
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(track().hasAttribute('data-dmn-dragging')).toBe(false);
+  });
+
+  it('after-paint 전략에서 갔다 되돌아온 흔들린 클릭도 한 번 뒤집는다', async () => {
+    const onChange = vi.fn();
+    renderAfterPaint(false, onChange);
+
+    send('pointerdown', { clientX: TRACK.x + 4 });
+    send('pointermove', { clientX: TRACK.x + 11 });
+    send('pointermove', { clientX: TRACK.x + 5 });
+    send('pointerup', { clientX: TRACK.x + 5 });
+    clickAfterRelease();
+    await flushDeferredCommit();
+
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  // 이동 폭이 12px뿐이라 클릭 중 손 떨림이 판정 경계와 겹친다. 슬롭 위·이동 폭 아래는
+  // 폭도 방향도 가리지 않고 결과가 "한 번 뒤집기"로 같아야 한다
+  describe('이동 폭에 못 미친 흔들림', () => {
+    it.each(JITTERS)(
+      '꺼진 스위치를 왼쪽으로 %ipx 흔들어도 한 번 뒤집는다',
+      (drift) => {
+        const onChange = vi.fn();
+        render(false, onChange);
+
+        // 노브가 이미 왼쪽 끝이라 clamp돼 제자리
+        send('pointerdown', { clientX: TRACK.x + 20 });
+        send('pointermove', { clientX: TRACK.x + 20 - drift });
+        send('pointerup', { clientX: TRACK.x + 20 - drift });
+        clickAfterRelease();
+
+        expect(onChange).toHaveBeenCalledOnce();
+      },
+    );
+
+    // 중앙선을 넘긴 쪽은 드래그가, 못 넘긴 쪽은 뒤따르는 click이 뒤집는다
+    it.each(JITTERS)(
+      '꺼진 스위치를 오른쪽으로 %ipx 흔들어도 한 번 뒤집는다',
+      (drift) => {
+        const onChange = vi.fn();
+        render(false, onChange);
+
+        send('pointerdown', { clientX: TRACK.x + 4 });
+        send('pointermove', { clientX: TRACK.x + 4 + drift });
+        send('pointerup', { clientX: TRACK.x + 4 + drift });
+        clickAfterRelease();
+
+        expect(onChange).toHaveBeenCalledOnce();
+      },
+    );
+
+    it.each(JITTERS)(
+      '켜진 스위치를 오른쪽으로 %ipx 흔들어도 한 번 뒤집는다',
+      (drift) => {
+        const onChange = vi.fn();
+        render(true, onChange);
+
+        send('pointerdown', { clientX: TRACK.x + 8 });
+        send('pointermove', { clientX: TRACK.x + 8 + drift });
+        send('pointerup', { clientX: TRACK.x + 8 + drift });
+        clickAfterRelease();
+
+        expect(onChange).toHaveBeenCalledOnce();
+      },
+    );
+
+    it.each(JITTERS)(
+      '켜진 스위치를 왼쪽으로 %ipx 흔들어도 한 번 뒤집는다',
+      (drift) => {
+        const onChange = vi.fn();
+        render(true, onChange);
+
+        send('pointerdown', { clientX: TRACK.x + 20 });
+        send('pointermove', { clientX: TRACK.x + 20 - drift });
+        send('pointerup', { clientX: TRACK.x + 20 - drift });
+        clickAfterRelease();
+
+        expect(onChange).toHaveBeenCalledOnce();
+      },
+    );
+
+    // 넘어갔다 돌아오는 손 떨림. 이동 폭을 채운 적이 없어 취소로 안 보고 탭으로 둔다
+    it.each([0, 1, 2, 3, 4, 5])(
+      '오른쪽 7px까지 갔다 %ipx로 돌아와도 한 번 뒤집는다',
+      (back) => {
+        const onChange = vi.fn();
+        render(false, onChange);
+
+        send('pointerdown', { clientX: TRACK.x + 4 });
+        send('pointermove', { clientX: TRACK.x + 4 + 7 });
+        send('pointermove', { clientX: TRACK.x + 4 + back });
+        send('pointerup', { clientX: TRACK.x + 4 + back });
+        clickAfterRelease();
+
+        expect(onChange).toHaveBeenCalledOnce();
+      },
+    );
   });
 });

--- a/src/renderer/components/main/common/Checkbox.tsx
+++ b/src/renderer/components/main/common/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { usePressGatedSwap } from '@hooks/usePressGatedSwap';
 import { useSwitchDrag } from '@hooks/useSwitchDrag';
 import {
@@ -19,12 +19,18 @@ const Checkbox = ({
   onChange,
   commitStrategy = 'sync',
 }: CheckboxProps) => {
+  // 트랙 ref는 두 훅이 나눠 쓴다. 커밋 프레임과 표식 프레임 모두 트랙이 사는 창 기준
+  const trackRef = useRef<HTMLDivElement>(null);
   const { value: visualChecked, toggle } = useOptimisticBooleanCommit({
     canonicalValue: checked,
     onCommit: onChange,
     strategy: commitStrategy,
+    frameHostRef: trackRef,
   });
-  const { ref, markPress } = usePressGatedSwap<HTMLDivElement>(visualChecked);
+  const { markPress } = usePressGatedSwap<HTMLDivElement>(
+    visualChecked,
+    trackRef,
+  );
   const drag = useSwitchDrag({
     checked: visualChecked,
     onFlip: toggle,
@@ -44,7 +50,7 @@ const Checkbox = ({
 
   return (
     <div
-      ref={ref}
+      ref={trackRef}
       role="switch"
       aria-checked={visualChecked}
       className={`dmn-toggle-track relative w-[28px] h-[16px] rounded-full cursor-pointer transition-colors duration-base ease-out-expo ${

--- a/src/renderer/components/main/common/SearchField.tsx
+++ b/src/renderer/components/main/common/SearchField.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { useAfterPaintValueCommit } from '@hooks/useAfterPaintValueCommit';
 import type { CommitStrategy } from '@hooks/useOptimisticBooleanCommit';
@@ -24,10 +24,12 @@ const SearchField = ({
 }: SearchFieldProps) => {
   const [localValue, setLocalValue] = useState(value);
   const [isFocused, setIsFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   const { scheduleCommit, flushPendingCommit } =
     useAfterPaintValueCommit<string>({
       onCommit: onChange,
       strategy: commitStrategy,
+      frameHostRef: inputRef,
     });
 
   useEffect(() => {
@@ -53,6 +55,7 @@ const SearchField = ({
         />
       </svg>
       <input
+        ref={inputRef}
         type="text"
         value={localValue}
         onChange={(event) => {

--- a/src/renderer/components/main/common/SettingRow.tsx
+++ b/src/renderer/components/main/common/SettingRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import Checkbox from '@components/main/common/Checkbox';
 import {
   useOptimisticBooleanCommit,
@@ -85,14 +85,17 @@ export const SettingToggleRow = ({
   onMouseEnter,
   onMouseLeave,
 }: SettingToggleRowProps) => {
+  const rowRef = useRef<HTMLButtonElement>(null);
   const { value: visualChecked, toggle } = useOptimisticBooleanCommit({
     canonicalValue: checked,
     onCommit: onToggle,
     strategy: commitStrategy,
+    frameHostRef: rowRef,
   });
 
   return (
     <button
+      ref={rowRef}
       type="button"
       role="switch"
       aria-checked={visualChecked}

--- a/src/renderer/components/main/common/TabSwitch.tsx
+++ b/src/renderer/components/main/common/TabSwitch.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useOptimisticValueCommit } from '@hooks/useOptimisticValueCommit';
 import type { CommitStrategy } from '@hooks/useOptimisticBooleanCommit';
 
@@ -23,10 +23,12 @@ const TabSwitch = ({
   commitStrategy = 'sync',
   className,
 }: TabSwitchProps) => {
+  const rootRef = useRef<HTMLDivElement>(null);
   const { value: visualActiveTab, select } = useOptimisticValueCommit({
     canonicalValue: activeTab,
     onCommit: onTabChange,
     strategy: commitStrategy,
+    frameHostRef: rootRef,
   });
   const activeIndex = Math.max(
     0,
@@ -35,6 +37,7 @@ const TabSwitch = ({
 
   return (
     <div
+      ref={rootRef}
       className={`relative flex w-full h-[30px] bg-inset rounded-surface items-center p-[2px] ${
         className ?? ''
       }`}

--- a/src/renderer/hooks/useAfterPaintValueCommit.ts
+++ b/src/renderer/hooks/useAfterPaintValueCommit.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import type React from 'react';
 
 import type { CommitStrategy } from './useOptimisticBooleanCommit';
 
@@ -9,14 +10,21 @@ interface PendingValue<T> {
 interface UseAfterPaintValueCommitOptions<T> {
   onCommit: (value: T) => void;
   strategy?: CommitStrategy;
+  /**
+   * 요소가 분리 패널 자식 창에 있으면 그 창의 프레임에 커밋을 싣는다.
+   * 메인이 가려져 있어도 멈추지 않게
+   */
+  frameHostRef?: React.RefObject<Element | null>;
 }
 
 export const useAfterPaintValueCommit = <T>({
   onCommit,
   strategy = 'after-paint',
+  frameHostRef,
 }: UseAfterPaintValueCommitOptions<T>) => {
-  const commitFrameRef = useRef<number | null>(null);
-  const commitTimerRef = useRef<number | null>(null);
+  // 프레임·타이머는 예약한 창과 함께 들고 있어야 그 창에서 취소된다
+  const commitFrameRef = useRef<{ win: Window; id: number } | null>(null);
+  const commitTimerRef = useRef<{ win: Window; id: number } | null>(null);
   const pendingValueRef = useRef<PendingValue<T> | null>(null);
   const onCommitRef = useRef(onCommit);
 
@@ -25,13 +33,15 @@ export const useAfterPaintValueCommit = <T>({
   }, [onCommit]);
 
   const cancelScheduledCommit = useCallback(() => {
-    if (commitFrameRef.current !== null) {
-      cancelAnimationFrame(commitFrameRef.current);
+    const frame = commitFrameRef.current;
+    if (frame !== null) {
       commitFrameRef.current = null;
+      frame.win.cancelAnimationFrame(frame.id);
     }
-    if (commitTimerRef.current !== null) {
-      window.clearTimeout(commitTimerRef.current);
+    const timer = commitTimerRef.current;
+    if (timer !== null) {
       commitTimerRef.current = null;
+      timer.win.clearTimeout(timer.id);
     }
   }, []);
 
@@ -51,15 +61,22 @@ export const useAfterPaintValueCommit = <T>({
 
       pendingValueRef.current = { value };
       cancelScheduledCommit();
-      commitFrameRef.current = requestAnimationFrame(() => {
-        commitFrameRef.current = null;
-        commitTimerRef.current = window.setTimeout(() => {
-          commitTimerRef.current = null;
-          commitPendingValue();
-        }, 0);
-      });
+      const win = frameHostRef?.current?.ownerDocument.defaultView ?? window;
+      commitFrameRef.current = {
+        win,
+        id: win.requestAnimationFrame(() => {
+          commitFrameRef.current = null;
+          commitTimerRef.current = {
+            win,
+            id: win.setTimeout(() => {
+              commitTimerRef.current = null;
+              commitPendingValue();
+            }, 0),
+          };
+        }),
+      };
     },
-    [cancelScheduledCommit, commitPendingValue, strategy],
+    [cancelScheduledCommit, commitPendingValue, frameHostRef, strategy],
   );
 
   const cancelPendingCommit = useCallback(() => {

--- a/src/renderer/hooks/useOptimisticBooleanCommit.ts
+++ b/src/renderer/hooks/useOptimisticBooleanCommit.ts
@@ -1,4 +1,11 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import type React from 'react';
 
 export type CommitStrategy = 'sync' | 'after-paint';
 export type BooleanCommitStrategy = CommitStrategy;
@@ -7,16 +14,23 @@ interface UseOptimisticBooleanCommitOptions {
   canonicalValue: boolean;
   onCommit: (value: boolean) => void;
   strategy?: BooleanCommitStrategy;
+  /**
+   * 요소가 분리 패널 자식 창에 있으면 그 창의 프레임에 커밋을 싣는다.
+   * 메인이 가려져 있어도 멈추지 않게
+   */
+  frameHostRef?: React.RefObject<Element | null>;
 }
 
 export const useOptimisticBooleanCommit = ({
   canonicalValue,
   onCommit,
   strategy = 'after-paint',
+  frameHostRef,
 }: UseOptimisticBooleanCommitOptions) => {
   const [optimisticValue, setOptimisticValue] = useState<boolean | null>(null);
-  const commitFrameRef = useRef<number | null>(null);
-  const commitTimerRef = useRef<number | null>(null);
+  // 프레임·타이머는 예약한 창과 함께 들고 있어야 그 창에서 취소된다
+  const commitFrameRef = useRef<{ win: Window; id: number } | null>(null);
+  const commitTimerRef = useRef<{ win: Window; id: number } | null>(null);
   const pendingValueRef = useRef<boolean | null>(null);
   const canonicalValueRef = useRef(canonicalValue);
   const onCommitRef = useRef(onCommit);
@@ -26,21 +40,29 @@ export const useOptimisticBooleanCommit = ({
     onCommitRef.current = onCommit;
   }, [canonicalValue, onCommit]);
 
+  const cancelScheduledCommit = useCallback(() => {
+    const frame = commitFrameRef.current;
+    if (frame !== null) {
+      commitFrameRef.current = null;
+      frame.win.cancelAnimationFrame(frame.id);
+    }
+    const timer = commitTimerRef.current;
+    if (timer !== null) {
+      commitTimerRef.current = null;
+      timer.win.clearTimeout(timer.id);
+    }
+  }, []);
+
   useEffect(
     () => () => {
-      if (commitFrameRef.current !== null) {
-        cancelAnimationFrame(commitFrameRef.current);
-      }
-      if (commitTimerRef.current !== null) {
-        window.clearTimeout(commitTimerRef.current);
-      }
+      cancelScheduledCommit();
       const pending = pendingValueRef.current;
       pendingValueRef.current = null;
       if (pending !== null && pending !== canonicalValueRef.current) {
         onCommitRef.current(pending);
       }
     },
-    [],
+    [cancelScheduledCommit],
   );
 
   const toggle = () => {
@@ -55,28 +77,30 @@ export const useOptimisticBooleanCommit = ({
     pendingValueRef.current = next;
     setOptimisticValue(next);
 
-    if (commitFrameRef.current !== null) {
-      cancelAnimationFrame(commitFrameRef.current);
-    }
-    if (commitTimerRef.current !== null) {
-      window.clearTimeout(commitTimerRef.current);
-    }
+    cancelScheduledCommit();
 
-    commitFrameRef.current = requestAnimationFrame(() => {
-      commitFrameRef.current = null;
-      commitTimerRef.current = window.setTimeout(() => {
-        commitTimerRef.current = null;
-        const pending = pendingValueRef.current;
-        pendingValueRef.current = null;
-        if (pending === null) return;
-        if (pending !== canonicalValueRef.current) {
-          onCommitRef.current(pending);
-        }
-        setOptimisticValue((currentOptimistic) =>
-          currentOptimistic === pending ? null : currentOptimistic,
-        );
-      }, 0);
-    });
+    const win = frameHostRef?.current?.ownerDocument.defaultView ?? window;
+    commitFrameRef.current = {
+      win,
+      id: win.requestAnimationFrame(() => {
+        commitFrameRef.current = null;
+        commitTimerRef.current = {
+          win,
+          id: win.setTimeout(() => {
+            commitTimerRef.current = null;
+            const pending = pendingValueRef.current;
+            pendingValueRef.current = null;
+            if (pending === null) return;
+            if (pending !== canonicalValueRef.current) {
+              onCommitRef.current(pending);
+            }
+            setOptimisticValue((currentOptimistic) =>
+              currentOptimistic === pending ? null : currentOptimistic,
+            );
+          }, 0),
+        };
+      }),
+    };
 
     return next;
   };

--- a/src/renderer/hooks/useOptimisticCommit.childWindow.test.tsx
+++ b/src/renderer/hooks/useOptimisticCommit.childWindow.test.tsx
@@ -1,0 +1,244 @@
+// @vitest-environment jsdom
+import { act, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useOptimisticBooleanCommit } from './useOptimisticBooleanCommit';
+import { useOptimisticValueCommit } from './useOptimisticValueCommit';
+
+// 분리 패널은 opener 자식 창이라 메인 트리가 자식 문서로 DOM을 포털한다.
+// 커밋 프레임이 메인 창에 걸리면 메인이 가려진 동안 저장이 통째로 멈춘다.
+// iframe으로 같은 힙에 문서와 창이 하나 더 있는 상황을 만든다
+
+interface BooleanHarnessProps {
+  onCommit: (value: boolean) => void;
+}
+
+const BooleanHarness = ({ onCommit }: BooleanHarnessProps) => {
+  const hostRef = useRef<HTMLButtonElement>(null);
+  const { value, toggle } = useOptimisticBooleanCommit({
+    canonicalValue: false,
+    onCommit,
+    strategy: 'after-paint',
+    frameHostRef: hostRef,
+  });
+  return (
+    <button
+      ref={hostRef}
+      type="button"
+      data-host="true"
+      aria-pressed={value}
+      onClick={toggle}
+    />
+  );
+};
+
+interface ValueHarnessProps {
+  onCommit: (value: string) => void;
+}
+
+const ValueHarness = ({ onCommit }: ValueHarnessProps) => {
+  const hostRef = useRef<HTMLButtonElement>(null);
+  const { value, select } = useOptimisticValueCommit({
+    canonicalValue: 'a',
+    onCommit,
+    strategy: 'after-paint',
+    frameHostRef: hostRef,
+  });
+  return (
+    <button
+      ref={hostRef}
+      type="button"
+      data-host="true"
+      data-value={value}
+      onClick={() => select('b')}
+    />
+  );
+};
+
+describe('낙관 커밋 훅 자식 창', () => {
+  let frame: HTMLIFrameElement;
+  let childDoc: Document;
+  let childWin: Window & typeof globalThis;
+  let container: HTMLDivElement;
+  let root: Root;
+  let mounted: boolean;
+  let mainRaf: ReturnType<typeof vi.fn>;
+  let mainSetTimeout: ReturnType<typeof vi.fn>;
+  let mainTimers: Map<number, () => void>;
+  let nextMainTimerId: number;
+  let childRaf: ReturnType<typeof vi.fn>;
+  let childRafCallbacks: Map<number, FrameRequestCallback>;
+  let nextChildRafId: number;
+  let childTimers: Map<number, () => void>;
+  let childSetTimeout: ReturnType<typeof vi.fn>;
+  let nextChildTimerId: number;
+
+  const host = () => container.querySelector<HTMLElement>('[data-host]')!;
+
+  const flushChildRaf = () => {
+    const pending = [...childRafCallbacks.values()];
+    childRafCallbacks.clear();
+    act(() => pending.forEach((callback) => callback(performance.now())));
+  };
+
+  const flushChildTimers = () => {
+    const pending = [...childTimers.values()];
+    childTimers.clear();
+    act(() => pending.forEach((callback) => callback()));
+  };
+
+  // 메인 큐도 삼키지 않고 실제로 돌린다. 라이브러리가 건 타이머까지 죽이면
+  // 커밋이 메인 큐에 실렸는지 여부를 이 테스트로 가릴 수 없다
+  const flushMainTimers = () => {
+    const pending = [...mainTimers.values()];
+    mainTimers.clear();
+    act(() => pending.forEach((callback) => callback()));
+  };
+
+  const click = () =>
+    act(() => {
+      host().dispatchEvent(new childWin.MouseEvent('click', { bubbles: true }));
+    });
+
+  const unmount = () => {
+    if (!mounted) return;
+    mounted = false;
+    act(() => root.unmount());
+  };
+
+  beforeEach(() => {
+    mainRaf = vi.fn(() => 1);
+    vi.stubGlobal('requestAnimationFrame', mainRaf);
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
+    mainTimers = new Map();
+    nextMainTimerId = 1;
+    mainSetTimeout = vi.fn((callback: () => void) => {
+      const id = nextMainTimerId;
+      nextMainTimerId += 1;
+      mainTimers.set(id, callback);
+      return id;
+    });
+    vi.spyOn(window, 'setTimeout').mockImplementation(
+      mainSetTimeout as unknown as typeof window.setTimeout,
+    );
+    vi.spyOn(window, 'clearTimeout').mockImplementation(((id: number) => {
+      mainTimers.delete(id);
+    }) as typeof window.clearTimeout);
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+    frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    childDoc = frame.contentDocument!;
+    childWin = frame.contentWindow as Window & typeof globalThis;
+
+    childRafCallbacks = new Map();
+    nextChildRafId = 1;
+    childRaf = vi.fn((callback: FrameRequestCallback) => {
+      const id = nextChildRafId;
+      nextChildRafId += 1;
+      childRafCallbacks.set(id, callback);
+      return id;
+    });
+    childWin.requestAnimationFrame = childRaf as typeof requestAnimationFrame;
+    childWin.cancelAnimationFrame = (id: number) => {
+      childRafCallbacks.delete(id);
+    };
+
+    childTimers = new Map();
+    nextChildTimerId = 1;
+    childSetTimeout = vi.fn((callback: () => void) => {
+      const id = nextChildTimerId;
+      nextChildTimerId += 1;
+      childTimers.set(id, callback);
+      return id;
+    });
+    childWin.setTimeout = childSetTimeout as unknown as typeof setTimeout;
+    childWin.clearTimeout = ((id: number) => {
+      childTimers.delete(id);
+    }) as typeof clearTimeout;
+
+    container = childDoc.createElement('div');
+    childDoc.body.appendChild(container);
+    root = createRoot(container);
+    mounted = true;
+  });
+
+  afterEach(() => {
+    unmount();
+    container.remove();
+    frame.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('토글 커밋은 자식 창 프레임과 타이머를 탄다', () => {
+    const onCommit = vi.fn();
+    act(() => root.render(<BooleanHarness onCommit={onCommit} />));
+
+    click();
+    // 표시값은 즉시 뒤집히고 커밋만 미뤄진다
+    expect(host().getAttribute('aria-pressed')).toBe('true');
+    expect(childRaf).toHaveBeenCalledTimes(1);
+    expect(mainRaf).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+
+    flushChildRaf();
+    expect(childSetTimeout).toHaveBeenCalledTimes(1);
+    expect(onCommit).not.toHaveBeenCalled();
+
+    // 메인 큐를 다 돌려도 커밋은 오지 않는다
+    flushMainTimers();
+    expect(onCommit).not.toHaveBeenCalled();
+
+    flushChildTimers();
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it('선택 커밋도 자식 창 프레임과 타이머를 탄다', () => {
+    const onCommit = vi.fn();
+    act(() => root.render(<ValueHarness onCommit={onCommit} />));
+
+    click();
+    expect(host().getAttribute('data-value')).toBe('b');
+    expect(childRaf).toHaveBeenCalledTimes(1);
+    expect(mainRaf).not.toHaveBeenCalled();
+
+    flushChildRaf();
+    expect(childSetTimeout).toHaveBeenCalledTimes(1);
+
+    flushMainTimers();
+    expect(onCommit).not.toHaveBeenCalled();
+
+    flushChildTimers();
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith('b');
+  });
+
+  it('프레임 전에 언마운트돼도 토글은 한 번 커밋된다', () => {
+    const onCommit = vi.fn();
+    act(() => root.render(<BooleanHarness onCommit={onCommit} />));
+
+    click();
+    expect(() => unmount()).not.toThrow();
+
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith(true);
+    // 걷힌 프레임·타이머가 뒤늦게 돌아도 두 번 커밋되지 않는다
+    flushChildRaf();
+    flushChildTimers();
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it('프레임 전에 언마운트돼도 선택은 한 번 커밋된다', () => {
+    const onCommit = vi.fn();
+    act(() => root.render(<ValueHarness onCommit={onCommit} />));
+
+    click();
+    expect(() => unmount()).not.toThrow();
+
+    expect(onCommit).toHaveBeenCalledExactlyOnceWith('b');
+    flushChildRaf();
+    flushChildTimers();
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/hooks/useOptimisticValueCommit.ts
+++ b/src/renderer/hooks/useOptimisticValueCommit.ts
@@ -1,4 +1,11 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import type React from 'react';
 
 import type { CommitStrategy } from './useOptimisticBooleanCommit';
 
@@ -11,6 +18,11 @@ interface UseOptimisticValueCommitOptions<T> {
   onCommit: (value: T) => void;
   strategy?: CommitStrategy;
   isEqual?: (left: T, right: T) => boolean;
+  /**
+   * 요소가 분리 패널 자식 창에 있으면 그 창의 프레임에 커밋을 싣는다.
+   * 메인이 가려져 있어도 멈추지 않게
+   */
+  frameHostRef?: React.RefObject<Element | null>;
 }
 
 export const useOptimisticValueCommit = <T>({
@@ -18,11 +30,13 @@ export const useOptimisticValueCommit = <T>({
   onCommit,
   strategy = 'after-paint',
   isEqual = Object.is,
+  frameHostRef,
 }: UseOptimisticValueCommitOptions<T>) => {
   const [optimisticValue, setOptimisticValue] =
     useState<OptimisticValue<T> | null>(null);
-  const commitFrameRef = useRef<number | null>(null);
-  const commitTimerRef = useRef<number | null>(null);
+  // 프레임·타이머는 예약한 창과 함께 들고 있어야 그 창에서 취소된다
+  const commitFrameRef = useRef<{ win: Window; id: number } | null>(null);
+  const commitTimerRef = useRef<{ win: Window; id: number } | null>(null);
   const pendingValueRef = useRef<OptimisticValue<T> | null>(null);
   const canonicalValueRef = useRef(canonicalValue);
   const onCommitRef = useRef(onCommit);
@@ -34,14 +48,22 @@ export const useOptimisticValueCommit = <T>({
     isEqualRef.current = isEqual;
   }, [canonicalValue, isEqual, onCommit]);
 
+  const cancelScheduledCommit = useCallback(() => {
+    const frame = commitFrameRef.current;
+    if (frame !== null) {
+      commitFrameRef.current = null;
+      frame.win.cancelAnimationFrame(frame.id);
+    }
+    const timer = commitTimerRef.current;
+    if (timer !== null) {
+      commitTimerRef.current = null;
+      timer.win.clearTimeout(timer.id);
+    }
+  }, []);
+
   useEffect(
     () => () => {
-      if (commitFrameRef.current !== null) {
-        cancelAnimationFrame(commitFrameRef.current);
-      }
-      if (commitTimerRef.current !== null) {
-        window.clearTimeout(commitTimerRef.current);
-      }
+      cancelScheduledCommit();
       const pending = pendingValueRef.current;
       pendingValueRef.current = null;
       if (
@@ -51,7 +73,7 @@ export const useOptimisticValueCommit = <T>({
         onCommitRef.current(pending.value);
       }
     },
-    [],
+    [cancelScheduledCommit],
   );
 
   const select = (next: T) => {
@@ -67,30 +89,35 @@ export const useOptimisticValueCommit = <T>({
     pendingValueRef.current = pending;
     setOptimisticValue(pending);
 
-    if (commitFrameRef.current !== null) {
-      cancelAnimationFrame(commitFrameRef.current);
-    }
-    if (commitTimerRef.current !== null) {
-      window.clearTimeout(commitTimerRef.current);
-    }
+    cancelScheduledCommit();
 
-    commitFrameRef.current = requestAnimationFrame(() => {
-      commitFrameRef.current = null;
-      commitTimerRef.current = window.setTimeout(() => {
-        commitTimerRef.current = null;
-        const currentPending = pendingValueRef.current;
-        pendingValueRef.current = null;
-        if (currentPending === null) return;
-        if (
-          !isEqualRef.current(currentPending.value, canonicalValueRef.current)
-        ) {
-          onCommitRef.current(currentPending.value);
-        }
-        setOptimisticValue((currentOptimistic) =>
-          currentOptimistic === currentPending ? null : currentOptimistic,
-        );
-      }, 0);
-    });
+    const win = frameHostRef?.current?.ownerDocument.defaultView ?? window;
+    commitFrameRef.current = {
+      win,
+      id: win.requestAnimationFrame(() => {
+        commitFrameRef.current = null;
+        commitTimerRef.current = {
+          win,
+          id: win.setTimeout(() => {
+            commitTimerRef.current = null;
+            const currentPending = pendingValueRef.current;
+            pendingValueRef.current = null;
+            if (currentPending === null) return;
+            if (
+              !isEqualRef.current(
+                currentPending.value,
+                canonicalValueRef.current,
+              )
+            ) {
+              onCommitRef.current(currentPending.value);
+            }
+            setOptimisticValue((currentOptimistic) =>
+              currentOptimistic === currentPending ? null : currentOptimistic,
+            );
+          }, 0),
+        };
+      }),
+    };
 
     return next;
   };

--- a/src/renderer/hooks/usePressGatedSwap.childWindow.test.tsx
+++ b/src/renderer/hooks/usePressGatedSwap.childWindow.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { act, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePressGatedSwap } from './usePressGatedSwap';
+
+// 분리 패널은 opener 자식 창이라 메인 트리가 자식 문서로 DOM을 포털한다.
+// 표식을 걷는 더블 rAF가 메인 창에 걸리면 그 창이 가려졌을 때 표식이 눌러붙는다.
+// iframe으로 같은 힙에 문서와 창이 하나 더 있는 상황을 만든다
+const Harness = ({ value }: { value: boolean }) => {
+  const { ref } = usePressGatedSwap<HTMLButtonElement>(value);
+  return (
+    <button ref={ref} type="button" data-host="true">
+      {String(value)}
+    </button>
+  );
+};
+
+// 밖에서 만든 ref를 나눠 쓰는 소비자(Checkbox·PanelToggleButton) 경로
+const SharedRefHarness = ({ value }: { value: boolean }) => {
+  const hostRef = useRef<HTMLButtonElement>(null);
+  usePressGatedSwap<HTMLButtonElement>(value, hostRef);
+  return (
+    <button ref={hostRef} type="button" data-host="true">
+      {String(value)}
+    </button>
+  );
+};
+
+describe('usePressGatedSwap 자식 창', () => {
+  let frame: HTMLIFrameElement;
+  let childDoc: Document;
+  let childWin: Window & typeof globalThis;
+  let container: HTMLDivElement;
+  let root: Root;
+  let mounted: boolean;
+  let mainRaf: ReturnType<typeof vi.fn>;
+  let mainCancelRaf: ReturnType<typeof vi.fn>;
+  let childRaf: ReturnType<typeof vi.fn>;
+  let childCancelled: number[];
+  let childRafCallbacks: Map<number, FrameRequestCallback>;
+  let nextChildRafId: number;
+
+  const host = () => container.querySelector<HTMLElement>('[data-host]')!;
+
+  const flushChildRaf = () => {
+    const pending = [...childRafCallbacks.values()];
+    childRafCallbacks.clear();
+    act(() => pending.forEach((callback) => callback(performance.now())));
+  };
+
+  const render = (value: boolean) =>
+    act(() => root.render(<Harness value={value} />));
+
+  const renderShared = (value: boolean) =>
+    act(() => root.render(<SharedRefHarness value={value} />));
+
+  const unmount = () => {
+    if (!mounted) return;
+    mounted = false;
+    act(() => root.unmount());
+  };
+
+  beforeEach(() => {
+    mainRaf = vi.fn(() => 1);
+    mainCancelRaf = vi.fn();
+    vi.stubGlobal('requestAnimationFrame', mainRaf);
+    vi.stubGlobal('cancelAnimationFrame', mainCancelRaf);
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+    frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    childDoc = frame.contentDocument!;
+    childWin = frame.contentWindow as Window & typeof globalThis;
+    childRafCallbacks = new Map();
+    childCancelled = [];
+    nextChildRafId = 1;
+    childRaf = vi.fn((callback: FrameRequestCallback) => {
+      const id = nextChildRafId;
+      nextChildRafId += 1;
+      childRafCallbacks.set(id, callback);
+      return id;
+    });
+    childWin.requestAnimationFrame = childRaf as typeof requestAnimationFrame;
+    childWin.cancelAnimationFrame = (id: number) => {
+      childCancelled.push(id);
+      childRafCallbacks.delete(id);
+    };
+
+    container = childDoc.createElement('div');
+    childDoc.body.appendChild(container);
+    root = createRoot(container);
+    mounted = true;
+  });
+
+  afterEach(() => {
+    unmount();
+    container.remove();
+    frame.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('클릭 없는 변경 표식은 자식 창 더블 rAF로 걷는다', () => {
+    render(false);
+    expect(host().hasAttribute('data-dmn-instant')).toBe(false);
+
+    render(true);
+    expect(host().hasAttribute('data-dmn-instant')).toBe(true);
+    expect(mainRaf).not.toHaveBeenCalled();
+
+    // 더블 rAF - 첫 프레임에서는 아직 살아 있다
+    flushChildRaf();
+    expect(host().hasAttribute('data-dmn-instant')).toBe(true);
+
+    flushChildRaf();
+    expect(host().hasAttribute('data-dmn-instant')).toBe(false);
+    expect(mainRaf).not.toHaveBeenCalled();
+  });
+
+  it('직접 클릭에서 온 변경에는 표식을 붙이지 않는다', () => {
+    render(false);
+    act(() => {
+      host().dispatchEvent(new childWin.MouseEvent('click', { bubbles: true }));
+    });
+    render(true);
+
+    expect(host().hasAttribute('data-dmn-instant')).toBe(false);
+    expect(childRaf).not.toHaveBeenCalled();
+  });
+
+  it('연이은 변경은 앞선 프레임을 예약한 창에서 취소한다', () => {
+    render(false);
+    render(true);
+    const [firstId] = [...childRafCallbacks.keys()];
+
+    render(false);
+    expect(childCancelled).toContain(firstId);
+    expect(mainCancelRaf).not.toHaveBeenCalled();
+  });
+
+  it('밖에서 받은 ref로도 자식 창 프레임을 쓴다', () => {
+    renderShared(false);
+    expect(host().hasAttribute('data-dmn-instant')).toBe(false);
+
+    renderShared(true);
+    expect(host().hasAttribute('data-dmn-instant')).toBe(true);
+    expect(childRaf).toHaveBeenCalled();
+    expect(mainRaf).not.toHaveBeenCalled();
+
+    flushChildRaf();
+    flushChildRaf();
+    expect(host().hasAttribute('data-dmn-instant')).toBe(false);
+    expect(mainRaf).not.toHaveBeenCalled();
+  });
+
+  it('언마운트 정리도 자식 창 프레임을 취소한다', () => {
+    render(false);
+    render(true);
+    const [pendingId] = [...childRafCallbacks.keys()];
+
+    unmount();
+
+    expect(childCancelled).toContain(pendingId);
+    expect(mainCancelRaf).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/hooks/usePressGatedSwap.ts
+++ b/src/renderer/hooks/usePressGatedSwap.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import type React from 'react';
 
 // 클릭 → 상태 반영까지 허용하는 지연 (비동기 커맨드 왕복 포함)
 const PRESS_WINDOW_MS = 300;
@@ -12,13 +13,31 @@ const INTERACTIVE_SELECTOR =
 // CSS transition을 전역 규칙(main.css)으로 차단.
 // WAAPI 기반 컴포넌트는 isInstant()로 분기해 정적 상태를 바로 커밋.
 // 시간창 휴리스틱의 한계: 300ms를 넘는 비동기 반영은 클릭이어도 즉시 전환,
-// 클릭 직후 300ms 안의 외부 변경은 애니메이션 — 둘 다 미용적 실패라 수용
-export const usePressGatedSwap = <T extends Element>(value: unknown) => {
-  const ref = useRef<T>(null);
+// 클릭 직후 300ms 안의 외부 변경은 애니메이션 - 둘 다 미용적 실패라 수용.
+//
+// 요소가 분리 패널 자식 창에 있으면 그 창의 프레임을 쓴다.
+// 메인 창이 가려져 메인 rAF가 멈춰도 표식 제거가 밀리지 않게.
+//
+// hostRef를 주면 그 ref를 그대로 쓴다. 같은 요소를 다른 훅과 나눠 써야 하는데
+// 훅 호출 순서상 여기서 만든 ref를 먼저 넘길 수 없는 소비자용
+export const usePressGatedSwap = <T extends Element>(
+  value: unknown,
+  hostRef?: React.RefObject<T | null>,
+) => {
+  const ownRef = useRef<T>(null);
+  const ref = hostRef ?? ownRef;
   const lastPressRef = useRef(Number.NEGATIVE_INFINITY);
   const instantRef = useRef(false);
   const prevValueRef = useRef(value);
-  const rafRef = useRef(0);
+  // 프레임은 예약한 창과 함께 들고 있어야 그 창에서 취소된다
+  const rafRef = useRef<{ win: Window; id: number } | null>(null);
+
+  const cancelFrame = useCallback(() => {
+    const frame = rafRef.current;
+    if (!frame) return;
+    rafRef.current = null;
+    frame.win.cancelAnimationFrame(frame.id);
+  }, []);
 
   useEffect(() => {
     const el = ref.current;
@@ -46,7 +65,7 @@ export const usePressGatedSwap = <T extends Element>(value: unknown) => {
         host.removeEventListener('click', mark);
       });
     };
-  }, []);
+  }, [ref]);
 
   // 훅이 소비자보다 먼저 선언되므로 소비자 layout effect 시점엔 판정 완료
   useLayoutEffect(() => {
@@ -57,22 +76,30 @@ export const usePressGatedSwap = <T extends Element>(value: unknown) => {
 
     const el = ref.current;
     if (!el) return;
-    cancelAnimationFrame(rafRef.current);
+    cancelFrame();
     if (!instantRef.current) {
       el.removeAttribute('data-dmn-instant');
       return;
     }
 
-    // 페인트에 한 번 반영된 뒤 제거 (더블 rAF) — 이후 클릭 전환은 다시 애니메이션
+    // 페인트에 한 번 반영된 뒤 제거 (더블 rAF), 이후 클릭 전환은 다시 애니메이션
     el.setAttribute('data-dmn-instant', '');
-    rafRef.current = requestAnimationFrame(() => {
-      rafRef.current = requestAnimationFrame(() => {
-        el.removeAttribute('data-dmn-instant');
-      });
-    });
-  }, [value]);
+    const win = el.ownerDocument.defaultView ?? window;
+    rafRef.current = {
+      win,
+      id: win.requestAnimationFrame(() => {
+        rafRef.current = {
+          win,
+          id: win.requestAnimationFrame(() => {
+            rafRef.current = null;
+            el.removeAttribute('data-dmn-instant');
+          }),
+        };
+      }),
+    };
+  }, [value, cancelFrame, ref]);
 
-  useEffect(() => () => cancelAnimationFrame(rafRef.current), []);
+  useEffect(() => () => cancelFrame(), [cancelFrame]);
 
   const isInstant = useCallback(() => instantRef.current, []);
 

--- a/src/renderer/hooks/useSwitchDrag.ts
+++ b/src/renderer/hooks/useSwitchDrag.ts
@@ -27,6 +27,9 @@ interface DragSession {
   pointerId: number;
   track: HTMLElement;
   thumb: HTMLElement | null;
+  // 노브가 사는 문서와 창. 분리 패널 자식 창에 그려지면 메인의 것과 다르다
+  ownerDocument: Document;
+  ownerWindow: Window;
   travel: number;
   startX: number;
   // 누른 순간의 값. 강등 판정 기준이라 손 밑에서 바뀌는 현재 값과 따로 둔다
@@ -38,6 +41,10 @@ interface DragSession {
   maxAbsDx: number;
   intent: DragIntent;
   displayed: boolean;
+  // 이 세션이 자기 창에 건 취소용 blur를 걷는다
+  releaseBlur: () => void;
+  // 노브 인라인 위치를 자기 창 프레임에 실어 보낸다
+  scheduler: ReturnType<typeof createRafLatestScheduler<number>>;
 }
 
 interface UseSwitchDragOptions {
@@ -53,14 +60,15 @@ const clamp = (value: number, min: number, max: number) =>
 
 // 포인터 캡처는 네이티브 텍스트 선택을 막지 않는다. 노브가 실제로 움직인 뒤에만
 // 잠가 단순 클릭의 선택 동작은 건드리지 않는다 (useDraggable과 같은 관례)
-const lockTextSelection = (locked: boolean) => {
-  document.body.style.userSelect = locked ? 'none' : '';
+const lockTextSelection = (doc: Document, locked: boolean) => {
+  doc.body.style.userSelect = locked ? 'none' : '';
 };
 
 // 이동 폭은 토큰이 소유한다. 토큰을 못 읽는 환경에서는 실측 사각형으로 대체
 const readTravel = (track: HTMLElement, thumb: HTMLElement | null) => {
+  const view = track.ownerDocument.defaultView ?? window;
   const fromToken = Number.parseFloat(
-    getComputedStyle(track).getPropertyValue('--ui-toggle-travel'),
+    view.getComputedStyle(track).getPropertyValue('--ui-toggle-travel'),
   );
   if (Number.isFinite(fromToken) && fromToken > 0) return fromToken;
   if (!thumb) return 0;
@@ -98,6 +106,9 @@ const handBack = (session: DragSession) => {
  *   이미 그쪽 끝이라 노브가 안 움직인 무동작(켜진 걸 켜는 쪽으로)도 드래그로 남는다
  * - 속도와 방향은 안 쓴다
  *
+ * 리스너·rAF·선택 잠금·스타일 계산은 노브가 사는 창 기준이다. 토글이 분리 패널
+ * 자식 창 문서에 그려질 수 있어서다. 전역 window는 폴백으로만 쓴다.
+ *
  * 노브는 누른 지점 기준 상대 델타로 움직인다. 커서 절대 좌표에 매핑하면
  * 트랙 아무 데나 눌러도 노브가 커서로 점프한다.
  *
@@ -119,35 +130,45 @@ export const useSwitchDrag = ({
 }: UseSwitchDragOptions) => {
   const sessionRef = useRef<DragSession | null>(null);
   const disarmSwallowRef = useRef<(() => void) | null>(null);
-  const handBackFrameRef = useRef(0);
+  // 정산 프레임은 예약한 창과 함께 들고 있어야 그 창에서 취소된다
+  const handBackFrameRef = useRef<{ win: Window; id: number } | null>(null);
   // 다음 프레임에 CSS로 돌려줄 세션. 그 프레임 안에 새 드래그가 시작되면 먼저 정산해야
   // 뒤늦게 도는 handBack이 새 세션의 표식과 인라인 위치를 걷어가지 않는다
   const pendingHandBackRef = useRef<DragSession | null>(null);
   const [dragValue, setDragValue] = useState<boolean | null>(null);
 
+  const cancelHandBackFrame = useCallback(() => {
+    const frame = handBackFrameRef.current;
+    if (!frame) return;
+    handBackFrameRef.current = null;
+    frame.win.cancelAnimationFrame(frame.id);
+  }, []);
+
   // 드래그 뒤에 오는 click 한 번을 창 캡처 단계에서 삼킨다.
   // 트랙은 28px인데 이동 폭이 12px이라 노브를 끝까지 끌면 손이 트랙 밖에서 떨어진다.
   // 그러면 click이 트랙이 아니라 공통 조상에 꽂혀 컨트롤 자신의 핸들러로는 못 막고,
   // 설정 행처럼 조상이 행 버튼인 표면에서는 거기서 한 번 더 뒤집힌다.
+  // 무장은 노브가 사는 창에 건다. 메인에 걸면 자식 창에서 뜬 click을 못 잡는다.
   // 해제는 click이 오거나 다음 입력(pointerdown·keydown)이 시작될 때. 먼저 오는 쪽이다 -
   // 타이머로 풀면 click과 경합하고, 안 풀면 엉뚱한 클릭을 삼킨다. 드래그가 click 없이
   // 끝난 뒤 키보드로 누른 버튼의 합성 click에는 pointerdown이 없어 keydown도 해제 조건이다
-  const armClickSwallow = useCallback(() => {
+  const armClickSwallow = useCallback((win: Window) => {
     disarmSwallowRef.current?.();
     const swallow = (event: MouseEvent) => {
       event.stopPropagation();
       event.preventDefault();
       disarm();
     };
+    // 무장한 그 창에서 걷는다. 해제가 엉뚱한 창을 보지 않는다
     const disarm = () => {
-      window.removeEventListener('click', swallow, true);
-      window.removeEventListener('pointerdown', disarm, true);
-      window.removeEventListener('keydown', disarm, true);
+      win.removeEventListener('click', swallow, true);
+      win.removeEventListener('pointerdown', disarm, true);
+      win.removeEventListener('keydown', disarm, true);
       disarmSwallowRef.current = null;
     };
-    window.addEventListener('click', swallow, true);
-    window.addEventListener('pointerdown', disarm, true);
-    window.addEventListener('keydown', disarm, true);
+    win.addEventListener('click', swallow, true);
+    win.addEventListener('pointerdown', disarm, true);
+    win.addEventListener('keydown', disarm, true);
     disarmSwallowRef.current = disarm;
   }, []);
 
@@ -160,17 +181,14 @@ export const useSwitchDrag = ({
     markPressRef.current = markPress;
   }, [checked, onFlip, markPress]);
 
-  const schedulerRef = useRef<ReturnType<
-    typeof createRafLatestScheduler<number>
-  > | null>(null);
-
   const endSession = useCallback(
     (commit: boolean) => {
       const session = sessionRef.current;
       if (!session) return;
       // 소유권을 먼저 내려놓아 커밋이 부르는 blur·캡처 상실로 재진입하지 못하게 한다
       sessionRef.current = null;
-      schedulerRef.current?.cancel();
+      session.releaseBlur();
+      session.scheduler.cancel();
       if (session.track.hasPointerCapture?.(session.pointerId)) {
         session.track.releasePointerCapture(session.pointerId);
       }
@@ -182,7 +200,7 @@ export const useSwitchDrag = ({
         return;
       }
 
-      lockTextSelection(false);
+      lockTextSelection(session.ownerDocument, false);
       // 노브 중심이 중앙선을 넘었는지만 본다. 원위치로 돌아왔으면 시작값과 같아져 취소된다.
       // 취소는 지금 값으로 돌려준다 - 끄는 사이 외부에서 바뀌었을 수 있다
       const target = commit
@@ -205,7 +223,7 @@ export const useSwitchDrag = ({
         return;
       }
       // 취소로 끝난 제스처는 click이 따라오지 않는다
-      if (commit) armClickSwallow();
+      if (commit) armClickSwallow(session.ownerWindow);
 
       // 표시값을 목표로 먼저 고정한다. 이 렌더가 끝나야 CSS의 정착 지점이 목표가 되고,
       // 그때 인라인을 걷어야 노브가 손끝에서 목표까지 한 번에 간다
@@ -214,42 +232,39 @@ export const useSwitchDrag = ({
         markPressRef.current();
         onFlipRef.current();
       }
-      cancelAnimationFrame(handBackFrameRef.current);
+      cancelHandBackFrame();
       pendingHandBackRef.current = session;
-      handBackFrameRef.current = requestAnimationFrame(() => {
-        handBackFrameRef.current = 0;
-        pendingHandBackRef.current = null;
-        setDragValue(null);
-        handBack(session);
-      });
+      // 정산 프레임은 지금 노브가 사는 창에 건다. 세션 도중 호스트가 옮겨지면
+      // 떠나온 창은 숨겨져 프레임이 멈춘다
+      const frameWindow =
+        session.track.ownerDocument.defaultView ?? session.ownerWindow;
+      handBackFrameRef.current = {
+        win: frameWindow,
+        id: frameWindow.requestAnimationFrame(() => {
+          handBackFrameRef.current = null;
+          pendingHandBackRef.current = null;
+          setDragValue(null);
+          handBack(session);
+        }),
+      };
     },
-    [armClickSwallow],
+    [armClickSwallow, cancelHandBackFrame],
   );
 
   // 아직 프레임을 기다리는 이전 세션의 정산을 지금 끝낸다
   const flushPendingHandBack = () => {
     const pending = pendingHandBackRef.current;
     if (!pending) return;
-    cancelAnimationFrame(handBackFrameRef.current);
-    handBackFrameRef.current = 0;
+    cancelHandBackFrame();
     pendingHandBackRef.current = null;
     setDragValue(null);
     handBack(pending);
   };
 
-  useEffect(() => {
-    const scheduler = createRafLatestScheduler<number>((offset) => {
-      const thumb = sessionRef.current?.thumb;
-      if (thumb) thumb.style.translate = `${offset}px 0`;
-    });
-    schedulerRef.current = scheduler;
-    const cancel = () => endSession(false);
-    window.addEventListener('blur', cancel);
-    return () => {
-      window.removeEventListener('blur', cancel);
-      scheduler.cancel();
-      schedulerRef.current = null;
-      cancelAnimationFrame(handBackFrameRef.current);
+  // 언마운트 정리. 남은 세션이 자기 창에 걸어둔 리스너·프레임·선택 잠금까지 걷는다
+  useEffect(
+    () => () => {
+      cancelHandBackFrame();
       const pending = pendingHandBackRef.current;
       pendingHandBackRef.current = null;
       if (pending) handBack(pending);
@@ -257,11 +272,16 @@ export const useSwitchDrag = ({
       const session = sessionRef.current;
       sessionRef.current = null;
       if (session) {
+        session.releaseBlur();
+        session.scheduler.cancel();
         handBack(session);
-        if (session.intent === 'drag') lockTextSelection(false);
+        if (session.intent === 'drag') {
+          lockTextSelection(session.ownerDocument, false);
+        }
       }
-    };
-  }, [endSession]);
+    },
+    [cancelHandBackFrame],
+  );
 
   const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     if (event.button !== 0 || !event.isPrimary || sessionRef.current) return;
@@ -273,10 +293,18 @@ export const useSwitchDrag = ({
     if (travel <= 0) return;
     flushPendingHandBack();
     track.setPointerCapture?.(event.pointerId);
+    const ownerDocument = track.ownerDocument;
+    const ownerWindow = ownerDocument.defaultView ?? window;
+    // 자식 창에 그려진 토글은 자기 창의 blur만 취소 사유다. 메인 창 blur는 자식이
+    // 포커스를 가져갈 때도 뜬다
+    const cancelOnBlur = () => endSession(false);
+    ownerWindow.addEventListener('blur', cancelOnBlur);
     sessionRef.current = {
       pointerId: event.pointerId,
       track,
       thumb,
+      ownerDocument,
+      ownerWindow,
       travel,
       startX: event.clientX,
       startValue: checkedRef.current,
@@ -285,6 +313,15 @@ export const useSwitchDrag = ({
       maxAbsDx: 0,
       intent: 'undecided',
       displayed: checkedRef.current,
+      releaseBlur: () => ownerWindow.removeEventListener('blur', cancelOnBlur),
+      scheduler: createRafLatestScheduler<number>(
+        (offset) => {
+          const node = sessionRef.current?.thumb;
+          if (node) node.style.translate = `${offset}px 0`;
+        },
+        'frame',
+        ownerWindow,
+      ),
     };
   };
 
@@ -298,10 +335,10 @@ export const useSwitchDrag = ({
       // 표식은 여기서 붙인다. 누르자마자 붙이면 단순 클릭에도 전환 규칙이 갈려
       // 기존 누름 감각을 건드린다
       session.track.setAttribute(DRAG_ATTR, '');
-      lockTextSelection(true);
+      lockTextSelection(session.ownerDocument, true);
     }
     session.offset = clamp(session.startOffset + dx, 0, session.travel);
-    schedulerRef.current?.push(session.offset);
+    session.scheduler.push(session.offset);
     const next = session.offset >= session.travel / 2;
     if (next === session.displayed) return;
     session.displayed = next;

--- a/src/renderer/hooks/useSwitchDrag.ts
+++ b/src/renderer/hooks/useSwitchDrag.ts
@@ -29,15 +29,15 @@ interface DragSession {
   thumb: HTMLElement | null;
   travel: number;
   startX: number;
+  // 누른 순간의 값. 강등 판정 기준이라 손 밑에서 바뀌는 현재 값과 따로 둔다
   startValue: boolean;
   startOffset: number;
   offset: number;
-  // 마지막 포인터 이동량. clamp된 offset과 달리 끝에서 바깥으로 민 거리도 남는다
-  dx: number;
+  // 세션 동안 본 최대 이동량 절댓값. 이동 폭만큼 끌어본 적이 있는지 가른다.
+  // clamp된 offset과 달리 끝에서 바깥으로 민 거리도 남는다
+  maxAbsDx: number;
   intent: DragIntent;
   displayed: boolean;
-  // 노브가 한 번이라도 중앙선을 넘어 반대편에 닿았는지
-  crossed: boolean;
 }
 
 interface UseSwitchDragOptions {
@@ -70,6 +70,14 @@ const readTravel = (track: HTMLElement, thumb: HTMLElement | null) => {
   return Math.max(0, trackRect.width - thumbRect.width - inset * 2);
 };
 
+// 포인터 위치를 세션에 접어 넣는다. 뗄 때 좌표가 마지막 이동보다 앞서 오는 경우가 있어
+// 손을 떼는 순간에도 한 번 더 반영해야 빠른 플릭이 짧게 잡히지 않는다
+const foldPointer = (session: DragSession, clientX: number) => {
+  const dx = clientX - session.startX;
+  session.maxAbsDx = Math.max(session.maxAbsDx, Math.abs(dx));
+  return dx;
+};
+
 // 인라인 위치를 CSS에 돌려준다. 전환을 되살린 상태를 리플로우로 한 번 확정시켜야
 // 시작값이 손끝 위치로 잡힌다. 같은 재계산에 둘을 넣으면 전환이 안 걸린다
 const handBack = (session: DragSession) => {
@@ -83,11 +91,11 @@ const handBack = (session: DragSession) => {
  * 토글 노브를 잡고 좌우로 끌어 상태를 정하는 제스처. 데스크톱 스위치의 관례를 따른다.
  * - 분류: 이동 슬롭을 넘겨야 드래그. 못 넘기면 탭이고 뒤따르는 click이 뒤집는다
  * - 판정: 손을 뗀 순간 노브 중심이 중앙선을 넘었는지. 손가락 위치가 아니라 노브 위치다
- * - 강등: 슬롭은 넘겼지만 중앙선에 닿은 적 없이 이동량이 반 폭 미만이면 탭으로 되돌린다.
- *   이동 폭이 12px뿐이라 슬롭(3)과 중앙선(6) 사이가 클릭 중 손 떨림 범위와 겹친다 -
+ * - 강등: 이동 폭만큼 끌어본 적 없는 제스처가 값 그대로 끝나면 탭으로 되돌린다.
+ *   이동 폭이 12px뿐이라 슬롭(3)과 이동 폭(12) 사이가 클릭 중 손 떨림 범위와 겹친다 -
  *   여기서 "값 그대로 + click 삼킴"으로 끝내면 눌렀는데 아무 반응이 없는 구간이 생긴다.
- *   반 폭 이상 끌었는데 안 넘은 건 이미 그쪽 끝이라 안 움직인 경우다(켜진 걸 켜는 쪽으로) -
- *   그건 그대로 두고, 중앙선을 넘었다 되돌아온 취소도 그대로 취소다(넘은 적이 있으므로)
+ *   한 번이라도 이동 폭만큼 끌었으면 의도한 드래그다. 이동 폭을 채우고 되돌아온 취소도,
+ *   이미 그쪽 끝이라 노브가 안 움직인 무동작(켜진 걸 켜는 쪽으로)도 드래그로 남는다
  * - 속도와 방향은 안 쓴다
  *
  * 노브는 누른 지점 기준 상대 델타로 움직인다. 커서 절대 좌표에 매핑하면
@@ -96,8 +104,9 @@ const handBack = (session: DragSession) => {
  * 짧게 누른 프레스를 이동량과 무관하게 탭으로 구제하는 시간 게이트는 안 쓴다.
  * 되돌려 취소하는 동작과 빠른 플릭이 구분되지 않는다.
  *
- * 끌었다가 원위치로 되돌리면 노브 위치가 시작값과 같아져 자연히 취소된다.
- * 별도 분기가 아니라 위치 판정의 결과다.
+ * 되돌려 취소하는 길은 노브를 이동 폭만큼 끌고 난 뒤에 열린다. 그 아래에서 시작점으로
+ * 돌아온 제스처는 흔들린 클릭으로 본다. 이동 폭이 12px뿐이라 짧게 나갔다 온 왕복은
+ * 손 떨림과 구분되지 않고, 애매하면 탭이 이긴다.
  *
  * 위치는 CSS가 translate로 소유하므로 드래그 중에만 인라인 translate로 덮고
  * 놓을 때 되돌려준다. transform으로 쓰면 CSS translate와 합성돼 켜짐 상태에서
@@ -174,14 +183,22 @@ export const useSwitchDrag = ({
       }
 
       lockTextSelection(false);
-      // 슬롭은 넘겼지만 중앙선에 닿은 적 없이 반 폭도 못 간 건 흔들린 클릭이다 - 탭으로 되돌린다.
+      // 노브 중심이 중앙선을 넘었는지만 본다. 원위치로 돌아왔으면 시작값과 같아져 취소된다.
+      // 취소는 지금 값으로 돌려준다 - 끄는 사이 외부에서 바뀌었을 수 있다
+      const target = commit
+        ? session.offset >= session.travel / 2
+        : checkedRef.current;
+
+      // 이동 폭만큼 끌어본 적 없이 값까지 그대로면 흔들린 클릭이다 - 탭으로 되돌린다.
       // 노브를 제자리로 돌려주고 click은 삼키지 않아 평소처럼 뒤집히게 둔다.
+      // 기준은 세션 시작값이다 - 끄는 사이 외부에서 값이 바뀌면 현재 값과는 우연히
+      // 같아질 수 있고, 그걸 흔들림으로 보면 뒤따르는 click이 남의 변경을 되돌린다.
       // 세로는 보지 않는다 - 세로로 트랙을 벗어나 뗀 click은 조상에 꽂히며, 그건 평범한 클릭이
       // 트랙 밖에서 끝났을 때와 같은 결과다(설정 행은 행 버튼이 받아 뒤집고, 맨 트랙은 무반응)
       if (
         commit &&
-        !session.crossed &&
-        Math.abs(session.dx) < session.travel / 2
+        target === session.startValue &&
+        session.maxAbsDx < session.travel
       ) {
         setDragValue(null);
         handBack(session);
@@ -189,11 +206,6 @@ export const useSwitchDrag = ({
       }
       // 취소로 끝난 제스처는 click이 따라오지 않는다
       if (commit) armClickSwallow();
-      // 노브 중심이 중앙선을 넘었는지만 본다. 원위치로 돌아왔으면 시작값과 같아져 취소된다.
-      // 취소는 지금 값으로 돌려준다 - 끄는 사이 외부에서 바뀌었을 수 있다
-      const target = commit
-        ? session.offset >= session.travel / 2
-        : checkedRef.current;
 
       // 표시값을 목표로 먼저 고정한다. 이 렌더가 끝나야 CSS의 정착 지점이 목표가 되고,
       // 그때 인라인을 걷어야 노브가 손끝에서 목표까지 한 번에 간다
@@ -270,17 +282,16 @@ export const useSwitchDrag = ({
       startValue: checkedRef.current,
       startOffset: checkedRef.current ? travel : 0,
       offset: checkedRef.current ? travel : 0,
-      dx: 0,
+      maxAbsDx: 0,
       intent: 'undecided',
       displayed: checkedRef.current,
-      crossed: false,
     };
   };
 
   const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
     const session = sessionRef.current;
     if (!session || session.pointerId !== event.pointerId) return;
-    const dx = event.clientX - session.startX;
+    const dx = foldPointer(session, event.clientX);
     if (session.intent === 'undecided') {
       if (Math.abs(dx) < DRAG_SLOP_PX) return;
       session.intent = 'drag';
@@ -289,18 +300,22 @@ export const useSwitchDrag = ({
       session.track.setAttribute(DRAG_ATTR, '');
       lockTextSelection(true);
     }
-    session.dx = dx;
     session.offset = clamp(session.startOffset + dx, 0, session.travel);
     schedulerRef.current?.push(session.offset);
     const next = session.offset >= session.travel / 2;
-    if (next !== session.startValue) session.crossed = true;
     if (next === session.displayed) return;
     session.displayed = next;
     setDragValue(next);
   };
 
   const onPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (sessionRef.current?.pointerId !== event.pointerId) return;
+    const session = sessionRef.current;
+    if (!session || session.pointerId !== event.pointerId) return;
+    const dx = foldPointer(session, event.clientX);
+    // 표시값은 건드리지 않는다. 어차피 바로 목표로 확정된다
+    if (session.intent === 'drag') {
+      session.offset = clamp(session.startOffset + dx, 0, session.travel);
+    }
     endSession(true);
   };
 

--- a/src/renderer/utils/animation/rafLatestScheduler.ts
+++ b/src/renderer/utils/animation/rafLatestScheduler.ts
@@ -6,9 +6,17 @@ interface RafLatestScheduler<T> {
   cancel: () => void;
 }
 
+// 프레임을 실어 보낼 창. 분리 패널처럼 다른 창 문서에 그려진 노드는 자기 창의 rAF를
+// 써야 메인이 가려지거나 최소화됐을 때도 프레임이 돈다
+type FrameSource = Pick<
+  Window,
+  'requestAnimationFrame' | 'cancelAnimationFrame'
+>;
+
 export const createRafLatestScheduler = <T>(
   apply: (value: T) => void,
   strategy: ContinuousInputStrategy = 'frame',
+  frames: FrameSource = window,
 ): RafLatestScheduler<T> => {
   let frame: number | null = null;
   let pending: T | null = null;
@@ -20,13 +28,13 @@ export const createRafLatestScheduler = <T>(
   };
 
   const cancel = () => {
-    if (frame !== null) cancelAnimationFrame(frame);
+    if (frame !== null) frames.cancelAnimationFrame(frame);
     frame = null;
     pending = null;
   };
 
   const flush = () => {
-    if (frame !== null) cancelAnimationFrame(frame);
+    if (frame !== null) frames.cancelAnimationFrame(frame);
     frame = null;
     applyPending();
   };
@@ -38,7 +46,7 @@ export const createRafLatestScheduler = <T>(
     }
     pending = value;
     if (frame !== null) return;
-    frame = requestAnimationFrame(() => {
+    frame = frames.requestAnimationFrame(() => {
       frame = null;
       applyPending();
     });


### PR DESCRIPTION
## 개요

클릭 중 몇 px 흔들림을 드래그로 잡아 토글이 안 켜지던 문제를 고치고, 분리 패널이 자식 창 문서로 옮겨갈 때를 대비해 패널 안 훅이 전역 window 대신 요소가 사는 창을 보도록 정리

## 변경 내용

- 이동 폭만큼 끌어본 적 없는 제스처가 값 그대로 끝나면 탭으로 강등, click을 삼키지 않음
- 강등 판정 기준을 세션 시작값으로 고정, 드래그 중 외부 변경이 들어와도 반대로 뒤집히지 않음
- pointerup 좌표를 이동량에 반영, 빠른 플릭이 짧게 잡히던 경로 제거
- 토글 드래그의 click 삼킴·blur 취소·선택 잠금·스타일 계산·프레임을 노브가 사는 창 기준으로 전환
- 정산 프레임은 종료 시점 창에 예약, 세션 도중 호스트가 옮겨져도 숨겨진 창에 남지 않음
- 낙관 커밋 훅 3종에 `frameHostRef` 옵션 추가, 커밋 프레임·타이머를 그 창에 싣고 같은 창에서 취소
- 누름 게이트의 표식 제거 프레임, 색상 트랙의 blur 취소·프리뷰 프레임을 요소 소유 창으로 전환
- Checkbox·TabSwitch·SettingRow·SearchField·ShadowControls·FontStyleButton·TextInput·LayerGroupDisclosure·PanelToggleButton 배선
- `createRafLatestScheduler`에 프레임을 실을 창 인자 추가

## 검증

- `npx tsc --noEmit` / `npm run lint` 오류 0, 경고는 base와 동일 / `npm run format`
- vitest 237 files, 3,232 tests 통과, 신규 30건은 수정 전 코드에서 실패 확인
- 실제 Chromium에서 window.open 자식 창에 포털로 그린 토글·색상 트랙을 마우스로 구동, 수정 전 이중 반전·메인 blur 세션 취소·메인 rAF 정지 시 커밋 실종 재현, 수정 후 전부 정상
- 실기 macOS: 토글 클릭·드래그 확인. Rust 변경 없음

## 참고

- 12px 토글에서 중앙선을 넘었다 되돌아온 짧은 왕복은 손 떨림과 구분이 안 돼 취소가 아니라 탭으로 처리, 이동 폭을 채운 뒤 되돌아온 취소는 유지
- 창 기준 정리는 지금 master의 분리 패널에서는 동작 차이가 없고 분리 패널을 window.open 자식 창으로 바꾸는 작업과 합쳐질 때 의미가 생김
- 자식 창 문서에 포털로 그린 요소는 이벤트가 그 창에서 끝나고 rAF도 창마다 따로 돌므로, 패널 안에서 전역 window·document·requestAnimationFrame을 잡는 코드는 전부 요소의 `ownerDocument`·`defaultView` 기준으로 바꿔야 함
- NumberInput·OptionalNumberInput의 after-paint 커밋은 `useFrameCoalescer`·`useDigitPop`까지 같이 옮겨야 해서 제외

## shared-context-panel 반영 필요

`feature/shared-context-panel`이 수정한 파일은 여기서 건드리지 않아 충돌은 없고, 아래는 그 브랜치에서 이어서 처리할 항목

- Dropdown·ListPopup·FloatingPopup의 낙관 커밋 훅에 `frameHostRef`(루트 요소 ref) 전달, useLayerDnD 스케줄러 두 곳과 LayerTabContent의 rAF·타이머에 창 주입. 누락 시 메인이 가려진 상태에서 패널 안 커밋·이동 반영이 메인 rAF에 묶임
- `PanelHostContext`가 있으므로 커밋 훅이 `usePanelHost().window`를 기본값으로 읽으면 배선 누락이 원천 차단됨. 이 브랜치엔 컨텍스트가 없어 ref로 넘기는 형태
- `settleEditsBeforeMove`가 편집만 정산하고 대기 중 낙관 커밋은 비우지 않음. 토글 직후 한 프레임 안에 도킹하면 자식 창 rAF에 걸린 커밋이 창 숨김과 함께 정지
- about:blank 자식 문서가 quirks mode(DOCTYPE 없음), 레이아웃 차이 확인 필요
- Windows 확인 필요: about:blank origin의 tauri.localhost 자산 로딩 거부 보고(tauri#14852), opener가 자식 document에 동기로 쓸 때 크래시 회귀(WebView2Feedback#3491)
- PropertiesPanelHost의 `requestAnimationFrame(sync)`와 캔버스 프리뷰 DPR이 메인 창 기준
- Linux는 NewWindowFeatures가 항상 None, GTK 팝업 패닉(wry#1663) 미해결
- 도달 불가가 된 panel authority 경로 정리: `isPanelWindow`, PropertiesPanel의 panel 분기, `patchElementPropertyViaAuthority`, `panelModelSync` push, detachedContracts 테스트
- usePanelHeaderDrag 테스트 부재

## 리뷰 포인트

- 커밋 단위 리뷰 권장. 강등 규칙이 앞, 창 기준 정리가 뒤
- Windows 실기 미확인. 마우스에서 강등 임계가 과하게 느껴지는지 확인 필요
