### PR TITLE
fix: 웹 폰트 편집 CSS 소실과 그래프 표시 구간 수정

### DIFF
--- a/scripts/run-interaction-webview-macos.mjs
+++ b/scripts/run-interaction-webview-macos.mjs
@@ -146,6 +146,7 @@ await writeFile(
         windows: [
           {
             label: 'main',
+            create: false,
             title: 'DM Note WKWebView Benchmark',
             width: 902,
             height: 488,

--- a/scripts/run-interaction-webview-matrix-macos.mjs
+++ b/scripts/run-interaction-webview-matrix-macos.mjs
@@ -200,6 +200,7 @@ await writeFile(
         windows: [
           {
             label: 'main',
+            create: false,
             title: 'DM Note WKWebView Interaction Matrix',
             width: 902,
             height: 620,

--- a/src/renderer/__tests__/overlayCommitBudget.test.tsx
+++ b/src/renderer/__tests__/overlayCommitBudget.test.tsx
@@ -9,9 +9,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import CountDisplay from '@components/overlay/counters/CountDisplay';
 import OverlayGraphItem from '@components/overlay/counters/OverlayGraphItem';
 
+const graphProbe = vi.hoisted(() => ({ history: [] as number[] }));
+
 // 그래프 렌더 자체가 아니라 커밋 횟수만 측정 — 무거운 자식은 스텁
 vi.mock('@components/shared/GraphPanel', () => ({
-  default: () => null,
+  default: ({ history = [] }: { history?: number[] }) => {
+    graphProbe.history = history;
+    return null;
+  },
 }));
 
 // 테스트가 신호 값을 직접 제어
@@ -52,6 +57,7 @@ beforeEach(() => {
   });
   commits = 0;
   mockStatSignal.value = 0;
+  graphProbe.history = [];
 });
 
 afterEach(() => {
@@ -264,5 +270,20 @@ describe('OverlayGraphItem 유휴 커밋 예산', () => {
     commits = 0;
     advanceInSteps(5_000, 50);
     expect(commits).toBeLessThanOrEqual(2);
+  });
+
+  it('1000ms 속도는 입력 샘플을 약 1000ms 동안 유지', () => {
+    renderGraph();
+    advanceInSteps(200, 100);
+
+    mockStatSignal.value = 5;
+    advanceInSteps(100, 100);
+    mockStatSignal.value = 0;
+
+    advanceInSteps(900, 100);
+    expect(graphProbe.history.some((value) => value !== 0)).toBe(true);
+
+    advanceInSteps(100, 100);
+    expect(graphProbe.history.every((value) => value === 0)).toBe(true);
   });
 });

--- a/src/renderer/components/main/Modal/content/dialogs/UpdateModal.test.tsx
+++ b/src/renderer/components/main/Modal/content/dialogs/UpdateModal.test.tsx
@@ -1,0 +1,64 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { I18nContext } from '@contexts/I18nContextDef';
+import {
+  settleDeferredContent,
+  stubAnimationFrame,
+} from '@src/renderer/__tests__/deferredContentHarness';
+import UpdateModal from './UpdateModal';
+
+const updateInfo = {
+  currentVersion: '2.0.1',
+  latestVersion: '2.0.1',
+  releaseUrl: 'https://example.test/release',
+  releaseName: '2.0.1',
+  releaseNotes: 'bug fixes',
+  publishedAt: '2026-08-29T00:00:00Z',
+};
+
+describe('UpdateModal 접근성 이름', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    stubAnimationFrame();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    [false, 'update.title'],
+    [true, 'update.latestAlready'],
+  ])('화면 종류에 맞는 이름을 제공한다', async (isLatestVersion, expected) => {
+    await act(async () => {
+      root.render(
+        <I18nContext.Provider
+          value={{ locale: 'ko', setLocale: () => undefined, t: (key) => key }}
+        >
+          <UpdateModal
+            isOpen
+            updateInfo={updateInfo}
+            onClose={() => undefined}
+            onSkipVersion={() => undefined}
+            isLatestVersion={isLatestVersion}
+          />
+        </I18nContext.Provider>,
+      );
+    });
+    await settleDeferredContent();
+
+    expect(
+      document.querySelector('[role="dialog"]')?.getAttribute('aria-label'),
+    ).toBe(expected);
+  });
+});

--- a/src/renderer/components/main/Modal/content/dialogs/UpdateModal.tsx
+++ b/src/renderer/components/main/Modal/content/dialogs/UpdateModal.tsx
@@ -93,7 +93,7 @@ const UpdateModal = ({
     <Modal
       motionState={motionState}
       onClick={handleClose}
-      ariaLabel={t('update.title')}
+      ariaLabel={t(isLatestVersion ? 'update.latestAlready' : 'update.title')}
       contentMountStrategy="after-paint"
     >
       <div

--- a/src/renderer/components/main/Modal/content/pickers/WebFontEditorSheet.test.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/WebFontEditorSheet.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   submitWebFont: vi.fn<() => boolean>(),
   alert: vi.fn<() => Promise<void>>(),
   submitFromEditor: null as null | ((css: string, name: string) => void),
+  initialCss: null as string | null,
   customFonts: [] as { id: string; type: string; cssContent: string }[],
 }));
 
@@ -28,13 +29,16 @@ vi.mock('@hooks/useFontLibrary', () => ({
 vi.mock('./WebFontInputModal', () => ({
   default: ({
     onSubmit,
+    initialCss,
   }: {
     onSubmit: (css: string, displayName: string) => void;
+    initialCss?: string;
   }) => {
     if (mocks.editorBroken) {
       throw new TypeError('Importing a module script failed.');
     }
     mocks.submitFromEditor = onSubmit;
+    mocks.initialCss = initialCss ?? null;
     return <div data-testid="web-font-editor">editor</div>;
   },
 }));
@@ -65,6 +69,7 @@ describe('WebFontEditorSheet', () => {
     onDone = vi.fn<(outcome: string) => void>();
     mocks.editorBroken = false;
     mocks.submitFromEditor = null;
+    mocks.initialCss = null;
     mocks.customFonts = [];
     // 테스트마다 import 프라미스를 새로 - 이미 이행된 프라미스를 새 lazy가 다시 쓰면
     // act()의 동기 flush가 재시도를 무한 반복한다(실제 스케줄러에서는 정상, act 한정 특성)
@@ -116,6 +121,25 @@ describe('WebFontEditorSheet', () => {
     });
     expect(onDone).toHaveBeenCalledWith('failed');
     expect(mocks.submitWebFont).not.toHaveBeenCalled();
+  });
+
+  it('편집 중 다른 창이 대상을 지워도 쓰던 CSS를 걷어가지 않는다', async () => {
+    mocks.customFonts = [{ id: 'f1', type: 'web', cssContent: 'css' }];
+    await act(async () => {
+      root.render(<WebFontEditorSheet editingId="f1" onDone={onDone} />);
+    });
+    await flush();
+    expect(mocks.initialCss).toBe('css');
+
+    // 다른 창이 폰트를 지운 뒤 이 창이 다시 그려진다
+    mocks.customFonts = [];
+    await act(async () => {
+      root.render(<WebFontEditorSheet editingId="f1" onDone={onDone} />);
+    });
+    await flush();
+
+    expect(mocks.initialCss).toBe('css');
+    expect(onDone).not.toHaveBeenCalled();
   });
 
   it('편집 대상이 있으면 그 id로 편집 모드로 연다', async () => {

--- a/src/renderer/components/main/Modal/content/pickers/WebFontEditorSheet.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/WebFontEditorSheet.tsx
@@ -41,6 +41,14 @@ const WebFontEditorSheet = ({ editingId, onDone }: WebFontEditorSheetProps) => {
   const [editingTargetMissing] = useState(
     () => editingId != null && editingWebFont === null,
   );
+  // 대상이 지워져도 쓰던 CSS를 걷어가지 않는다 - 편집 대상이 바뀔 때만 다시 읽는다
+  const [cssSnapshot, setCssSnapshot] = useState(() => ({
+    id: editingId,
+    css: editingWebFont?.cssContent || '',
+  }));
+  if (cssSnapshot.id !== editingId) {
+    setCssSnapshot({ id: editingId, css: editingWebFont?.cssContent || '' });
+  }
 
   const failToOpen = (message: string, notice: string, error?: unknown) => {
     console.error(message, error);
@@ -86,8 +94,8 @@ const WebFontEditorSheet = ({ editingId, onDone }: WebFontEditorSheetProps) => {
           isOpen
           onClose={() => onDone('cancelled')}
           onSubmit={handleSubmit}
-          initialCss={editingWebFont?.cssContent || ''}
-          mode={editingWebFont ? 'edit' : 'add'}
+          initialCss={cssSnapshot.css}
+          mode={editingId ? 'edit' : 'add'}
           isDuplicateFontFamily={(fontFamily) =>
             fontLibrary.isDuplicateFontFamily(fontFamily, {
               excludeId: editingId,

--- a/src/renderer/components/main/Modal/content/pickers/WebFontEditorSheet.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/WebFontEditorSheet.tsx
@@ -72,7 +72,9 @@ const WebFontEditorSheet = ({ editingId, onDone }: WebFontEditorSheetProps) => {
   }, [editingTargetMissing]);
 
   const handleSubmit = (css: string, displayName: string) => {
-    if (fontLibrary.submitWebFont(css, displayName, editingId)) onDone('saved');
+    const saved = fontLibrary.submitWebFont(css, displayName, editingId);
+    if (saved) onDone('saved');
+    return saved;
   };
 
   if (editingTargetMissing) return null;

--- a/src/renderer/components/main/Modal/content/pickers/WebFontInputModal.test.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/WebFontInputModal.test.tsx
@@ -33,7 +33,7 @@ describe('WebFontInputModal 편집기 마운트', () => {
         <WebFontInputModal
           isOpen
           onClose={() => undefined}
-          onSubmit={() => undefined}
+          onSubmit={() => true}
           initialCss={initialCss}
           t={(key: string) => key}
         />,
@@ -80,11 +80,92 @@ describe('WebFontInputModal 편집기 마운트', () => {
         <WebFontInputModal
           isOpen={false}
           onClose={() => undefined}
-          onSubmit={() => undefined}
+          onSubmit={() => true}
           t={(key: string) => key}
         />,
       );
     });
     expect(document.querySelector('.cm-editor')).toBeNull();
+  });
+});
+
+describe('WebFontInputModal 저장 거절', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+  let originalRangeRects: (() => DOMRectList) | undefined;
+
+  const VALID_CSS = "@font-face { font-family: 'Demo'; src: url(demo.woff2); }";
+
+  // jsdom에는 Range 측정이 없어서 CodeMirror measure가 던진다
+  const rangeProto = Range.prototype as unknown as {
+    getClientRects?: () => DOMRectList;
+  };
+  const emptyRectList = () =>
+    Object.assign([], {
+      item: () => null,
+    }) as unknown as DOMRectList;
+
+  beforeEach(() => {
+    originalRangeRects = rangeProto.getClientRects;
+    rangeProto.getClientRects = emptyRectList;
+    stubAnimationFrame();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    host.remove();
+    document.body.innerHTML = '';
+    rangeProto.getClientRects = originalRangeRects;
+    vi.unstubAllGlobals();
+  });
+
+  const renderWithOutcome = async (saved: boolean) => {
+    await act(async () => {
+      root.render(
+        <WebFontInputModal
+          isOpen
+          onClose={() => undefined}
+          onSubmit={() => saved}
+          initialCss={VALID_CSS}
+          t={(key: string) => key}
+        />,
+      );
+    });
+    await settleDeferredContent();
+  };
+
+  const editorText = () =>
+    document.querySelector('.cm-editor')?.querySelector('.cm-content')
+      ?.textContent ?? '';
+
+  const pressSubmit = async () => {
+    const submit = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent === 'webFontInput.submit',
+    );
+    expect(submit?.disabled).toBe(false);
+    await act(async () => {
+      submit?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+  };
+
+  it('저장이 거절되면 편집 중이던 CSS를 그대로 남긴다', async () => {
+    await renderWithOutcome(false);
+    expect(editorText()).toContain("font-family: 'Demo'");
+
+    await pressSubmit();
+
+    expect(editorText()).toContain("font-family: 'Demo'");
+  });
+
+  it('저장에 성공하면 편집기를 비운다', async () => {
+    await renderWithOutcome(true);
+
+    await pressSubmit();
+
+    // 비면 자리표시자 예시가 대신 보이므로 원본이 사라졌는지로 판정한다
+    expect(editorText()).not.toContain("font-family: 'Demo'");
   });
 });

--- a/src/renderer/components/main/Modal/content/pickers/WebFontInputModal.tsx
+++ b/src/renderer/components/main/Modal/content/pickers/WebFontInputModal.tsx
@@ -32,7 +32,8 @@ import type { CSSProperties } from 'react';
 interface WebFontInputModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (css: string, displayName: string) => void;
+  // 저장 성공 여부를 돌려준다 - 거절되면 편집 중이던 내용을 지우지 않는다
+  onSubmit: (css: string, displayName: string) => boolean;
   initialCss?: string;
   isDuplicateFontFamily?: (fontFamily: string) => boolean;
   /** 시트 제목 분기 — 추가/수정 */
@@ -224,7 +225,7 @@ const WebFontInputModal = ({
       return;
     }
 
-    onSubmit(trimmedCSS, extractedFontFamily || '');
+    if (!onSubmit(trimmedCSS, extractedFontFamily || '')) return;
     resetEditorContent('');
   };
 

--- a/src/renderer/components/overlay/counters/OverlayGraphItem.tsx
+++ b/src/renderer/components/overlay/counters/OverlayGraphItem.tsx
@@ -6,7 +6,6 @@ import GraphPanel from '@components/shared/GraphPanel';
 import { resolveImageSource } from '@utils/core/imageSource';
 
 const GRAPH_UPDATE_MS = 100;
-const GRAPH_TICK_MS = 50;
 
 interface GraphPosition {
   hidden?: boolean;
@@ -164,7 +163,7 @@ const OverlayGraphItem = ({ position, index = 0 }: OverlayGraphItemProps) => {
         avg,
         maxval: Math.max(maxValueRef.current, 1),
       });
-    }, GRAPH_TICK_MS);
+    }, GRAPH_UPDATE_MS);
 
     return () => clearInterval(interval);
   }, [statSignal]);

--- a/src/renderer/hooks/useFontLibrary.addLocalFont.test.tsx
+++ b/src/renderer/hooks/useFontLibrary.addLocalFont.test.tsx
@@ -175,6 +175,22 @@ describe('useFontLibrary 로컬 폰트 추가', () => {
     );
   });
 
+  it('편집 대상이 사라졌으면 저장 성공으로 처리하지 않는다', () => {
+    useFontStore.setState({ customFonts: [] });
+
+    const saved = submitWebFont(
+      "@font-face { font-family: 'Gone'; src: url(gone.woff2); }",
+      'Gone',
+      'web-font',
+    );
+
+    expect(saved).toBe(false);
+    expect(mocks.settingsUpdate).not.toHaveBeenCalled();
+    expect(mocks.alert).toHaveBeenCalledWith('fontPicker.editTargetMissing', {
+      confirmText: 'common.ok',
+    });
+  });
+
   it('font-family를 유지하면 웹 폰트 CSS를 수정할 수 있다', () => {
     useFontStore.setState({
       customFonts: [

--- a/src/renderer/hooks/useFontLibrary.addLocalFont.test.tsx
+++ b/src/renderer/hooks/useFontLibrary.addLocalFont.test.tsx
@@ -47,6 +47,11 @@ describe('useFontLibrary 로컬 폰트 추가', () => {
   let container: HTMLDivElement;
   let root: Root;
   let addLocalFont: () => Promise<void>;
+  let submitWebFont: (
+    css: string,
+    displayName: string,
+    editingWebFontId: string | null,
+  ) => boolean;
 
   const mount = () => {
     const Probe = (): null => {
@@ -54,6 +59,7 @@ describe('useFontLibrary 로컬 폰트 추가', () => {
       // 렌더 중 외부 변수 재할당은 금지 - 커밋 이후에 꺼낸다
       useEffect(() => {
         addLocalFont = library.addLocalFont;
+        submitWebFont = library.submitWebFont;
       });
       return null;
     };
@@ -136,5 +142,66 @@ describe('useFontLibrary 로컬 폰트 추가', () => {
 
     expect(localFonts()).toHaveLength(0);
     expect(mocks.alert).not.toHaveBeenCalled();
+  });
+
+  it('사용 중인 웹 폰트의 font-family 이름 변경은 저장하지 않는다', () => {
+    useFontStore.setState({
+      customFonts: [
+        {
+          id: 'web-font',
+          type: 'web',
+          name: 'Stable Family',
+          displayName: 'Stable Family',
+          enabled: true,
+          cssContent:
+            "@font-face { font-family: 'Stable Family'; src: url(old.woff2); }",
+          weightRanges: [{ min: 400, max: 400 }],
+        },
+      ],
+    });
+
+    const saved = submitWebFont(
+      "@font-face { font-family: 'Changed Family'; src: url(new.woff2); }",
+      'Changed Family',
+      'web-font',
+    );
+
+    expect(saved).toBe(false);
+    expect(useFontStore.getState().customFonts[0]?.name).toBe('Stable Family');
+    expect(mocks.settingsUpdate).not.toHaveBeenCalled();
+    expect(mocks.alert).toHaveBeenCalledWith(
+      'webFontInput.familyChangeNotAllowed',
+      { confirmText: 'common.ok' },
+    );
+  });
+
+  it('font-family를 유지하면 웹 폰트 CSS를 수정할 수 있다', () => {
+    useFontStore.setState({
+      customFonts: [
+        {
+          id: 'web-font',
+          type: 'web',
+          name: 'Stable Family',
+          displayName: 'Stable Family',
+          enabled: true,
+          cssContent:
+            "@font-face { font-family: 'Stable Family'; src: url(old.woff2); }",
+          weightRanges: [{ min: 400, max: 400 }],
+        },
+      ],
+    });
+
+    const saved = submitWebFont(
+      "@font-face { font-family: 'Stable Family'; src: url(new.woff2); font-weight: 700; }",
+      'Stable Family',
+      'web-font',
+    );
+
+    expect(saved).toBe(true);
+    expect(useFontStore.getState().customFonts[0]).toMatchObject({
+      id: 'web-font',
+      name: 'Stable Family',
+      weightRanges: [{ min: 700, max: 700 }],
+    });
   });
 });

--- a/src/renderer/hooks/useFontLibrary.addLocalFont.test.tsx
+++ b/src/renderer/hooks/useFontLibrary.addLocalFont.test.tsx
@@ -220,4 +220,36 @@ describe('useFontLibrary 로컬 폰트 추가', () => {
       weightRanges: [{ min: 700, max: 700 }],
     });
   });
+
+  it('대소문자만 다른 font-family는 기존 참조 이름을 유지하며 수정한다', () => {
+    useFontStore.setState({
+      customFonts: [
+        {
+          id: 'web-font',
+          type: 'web',
+          name: 'Stable Family',
+          displayName: 'Stable Family',
+          enabled: true,
+          cssContent:
+            "@font-face { font-family: 'Stable Family'; src: url(old.woff2); }",
+          weightRanges: [{ min: 400, max: 400 }],
+        },
+      ],
+    });
+
+    const saved = submitWebFont(
+      "@font-face { font-family: 'stable family'; src: url(new.woff2); }",
+      'stable family',
+      'web-font',
+    );
+
+    expect(saved).toBe(true);
+    expect(useFontStore.getState().customFonts[0]).toMatchObject({
+      id: 'web-font',
+      name: 'Stable Family',
+      cssContent:
+        "@font-face { font-family: 'stable family'; src: url(new.woff2); }",
+    });
+    expect(mocks.alert).not.toHaveBeenCalled();
+  });
 });

--- a/src/renderer/hooks/useFontLibrary.ts
+++ b/src/renderer/hooks/useFontLibrary.ts
@@ -101,6 +101,16 @@ export const useFontLibrary = () => {
       });
   };
 
+  const showEditTargetMissingAlert = () => {
+    void window.api.ui.dialog
+      .alert(t('fontPicker.editTargetMissing'), {
+        confirmText: t('common.ok') || '확인',
+      })
+      .catch((error) => {
+        console.error('Failed to open missing edit target alert:', error);
+      });
+  };
+
   const showFontFamilyChangeAlert = () => {
     void window.api.ui.dialog
       .alert(t('webFontInput.familyChangeNotAllowed'), {
@@ -206,6 +216,11 @@ export const useFontLibrary = () => {
           (font) => font.id === editingWebFontId && font.type === 'web',
         )
       : null;
+    // 편집 중 다른 창이 대상을 지웠다 - 아무것도 못 바꾸면서 저장 성공으로 닫으면 안 된다
+    if (editingWebFontId && !editingWebFont) {
+      showEditTargetMissingAlert();
+      return false;
+    }
     if (editingWebFont && editingWebFont.name !== fontFamily) {
       showFontFamilyChangeAlert();
       return false;

--- a/src/renderer/hooks/useFontLibrary.ts
+++ b/src/renderer/hooks/useFontLibrary.ts
@@ -101,6 +101,16 @@ export const useFontLibrary = () => {
       });
   };
 
+  const showFontFamilyChangeAlert = () => {
+    void window.api.ui.dialog
+      .alert(t('webFontInput.familyChangeNotAllowed'), {
+        confirmText: t('common.ok') || '확인',
+      })
+      .catch((error) => {
+        console.error('Failed to open font-family change alert:', error);
+      });
+  };
+
   const addLocalFont = async () => {
     if (isAddingRef.current) return;
     isAddingRef.current = true;
@@ -191,6 +201,15 @@ export const useFontLibrary = () => {
     }
 
     const currentCustomFonts = useFontStore.getState().customFonts;
+    const editingWebFont = editingWebFontId
+      ? currentCustomFonts.find(
+          (font) => font.id === editingWebFontId && font.type === 'web',
+        )
+      : null;
+    if (editingWebFont && editingWebFont.name !== fontFamily) {
+      showFontFamilyChangeAlert();
+      return false;
+    }
     const newWebFont: CustomFont = {
       id: generateFontId(),
       type: 'web',

--- a/src/renderer/hooks/useFontLibrary.ts
+++ b/src/renderer/hooks/useFontLibrary.ts
@@ -221,14 +221,20 @@ export const useFontLibrary = () => {
       showEditTargetMissingAlert();
       return false;
     }
-    if (editingWebFont && editingWebFont.name !== fontFamily) {
+    if (
+      editingWebFont &&
+      normalizeFontFamilyName(editingWebFont.name) !==
+        normalizeFontFamilyName(fontFamily)
+    ) {
       showFontFamilyChangeAlert();
       return false;
     }
+    // 대소문자만 다른 CSS 이름은 같은 family다 - 저장된 참조 문자열은 그대로 유지한다
+    const storedFontFamily = editingWebFont?.name ?? fontFamily;
     const newWebFont: CustomFont = {
       id: generateFontId(),
       type: 'web',
-      name: fontFamily,
+      name: storedFontFamily,
       displayName: displayName || fontFamily,
       enabled: true,
       cssContent: css,
@@ -240,7 +246,7 @@ export const useFontLibrary = () => {
           font.id === editingWebFontId
             ? {
                 ...font,
-                name: fontFamily,
+                name: storedFontFamily,
                 displayName: displayName || fontFamily,
                 cssContent: css,
                 weightRanges: validation.detectedWeights,

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -680,6 +680,7 @@
     "availabilityDuplicateFontFamily": "Already registered font-family",
     "availabilityMultipleFamilies": "Multiple fonts detected",
     "duplicateFontFamilyAlert": "\"{{name}}\" font is already registered.",
+    "familyChangeNotAllowed": "The font-family name cannot be changed because existing elements may use it.",
     "titleAdd": "Add web font",
     "titleEdit": "Edit web font",
     "previewLabel": "Preview",

--- a/src/renderer/locales/ko.json
+++ b/src/renderer/locales/ko.json
@@ -680,6 +680,7 @@
     "availabilityDuplicateFontFamily": "이미 등록된 font-family",
     "availabilityMultipleFamilies": "다중 폰트 감지",
     "duplicateFontFamilyAlert": "\"{{name}}\" 폰트가 이미 등록되어 있습니다.",
+    "familyChangeNotAllowed": "사용 중인 폰트가 깨질 수 있어 font-family 이름은 수정할 수 없습니다.",
     "titleAdd": "웹 폰트 추가",
     "titleEdit": "웹 폰트 수정",
     "previewLabel": "미리보기",

--- a/src/renderer/locales/ru.json
+++ b/src/renderer/locales/ru.json
@@ -680,6 +680,7 @@
     "availabilityDuplicateFontFamily": "font-family уже есть",
     "availabilityMultipleFamilies": "Несколько шрифтов",
     "duplicateFontFamilyAlert": "Шрифт \"{{name}}\" уже добавлен.",
+    "familyChangeNotAllowed": "Нельзя изменить имя font-family, потому что его могут использовать существующие элементы.",
     "titleAdd": "Добавить веб-шрифт",
     "titleEdit": "Изменить веб-шрифт",
     "previewLabel": "Предпросмотр",

--- a/src/renderer/locales/zh-Hant.json
+++ b/src/renderer/locales/zh-Hant.json
@@ -680,6 +680,7 @@
     "availabilityDuplicateFontFamily": "已註冊的 font-family",
     "availabilityMultipleFamilies": "偵測到多個字體",
     "duplicateFontFamilyAlert": "\"{{name}}\" 字體已註冊。",
+    "familyChangeNotAllowed": "現有元素可能正在使用此字體，因此無法變更 font-family 名稱。",
     "titleAdd": "新增網頁字體",
     "titleEdit": "編輯網頁字體",
     "previewLabel": "預覽",

--- a/src/renderer/locales/zh-cn.json
+++ b/src/renderer/locales/zh-cn.json
@@ -680,6 +680,7 @@
     "availabilityDuplicateFontFamily": "已注册的 font-family",
     "availabilityMultipleFamilies": "检测到多个字体",
     "duplicateFontFamilyAlert": "\"{{name}}\" 字体已注册。",
+    "familyChangeNotAllowed": "现有元素可能正在使用此字体，因此无法更改 font-family 名称。",
     "titleAdd": "添加网页字体",
     "titleEdit": "编辑网页字体",
     "previewLabel": "预览",

--- a/tests/tauri-config-contract.test.ts
+++ b/tests/tauri-config-contract.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const TAURI_ROOT = join(__dirname, '..', 'src-tauri');
+const PROJECT_ROOT = join(__dirname, '..');
 
 const readConfig = (name: string) =>
   JSON.parse(readFileSync(join(TAURI_ROOT, name), 'utf8')) as {
@@ -21,4 +22,20 @@ describe('Tauri global API contract', () => {
       expect(readConfig(name).app?.withGlobalTauri, name).not.toBe(true);
     }
   });
+});
+
+describe('macOS WKWebView benchmark window contract', () => {
+  it.each([
+    'run-interaction-webview-macos.mjs',
+    'run-interaction-webview-matrix-macos.mjs',
+  ])(
+    '%s는 Rust에서 생성하는 main 윈도우를 설정에서 중복 생성하지 않는다',
+    (name) => {
+      const source = readFileSync(join(PROJECT_ROOT, 'scripts', name), 'utf8');
+
+      expect(source).toMatch(
+        /label:\s*['"]main['"][\s\S]{0,120}create:\s*false/,
+      );
+    },
+  );
 });


### PR DESCRIPTION
## 개요

2.0.1 배포 뒤 하드 테스트에서 확정한 결함 6건 수정. 가장 큰 축은 웹 폰트 편집 시트로, 저장이 거절되면 작성 중이던 CSS를 그대로 버리고 편집 대상이 사라져도 저장 성공으로 닫히던 문제를 하나의 보존 계약으로 정리함. 나머지는 그래프 표시 구간, 업데이트 모달 접근성 이름, macOS 벤치마크 창 중복의 독립 수정. 웹 폰트 이름 변경과 그래프 표시 구간은 1.6.1에도 있던 결함

## 변경 내용

**웹 폰트 편집**

- 저장 결과와 무관하게 편집기를 비우던 문제. `onSubmit`을 저장 성공 여부 반환으로 바꿔 성공한 경우에만 초기화. 특정 거절 사유가 아니라 거절 경로 전체에 걸리는 계약이라 이후 추가되는 사유도 함께 보호
- font-family 이름을 바꾸면 그 이름을 참조하던 기존 요소가 폴백으로 떨어지던 문제. 참조가 이름 문자열로 저장되고 사용자 CSS·되돌리기 기록·프리셋 파일에도 남아 일괄 치환이 불가능하므로 편집에서 이름 변경을 차단. 표시 이름은 기존 이름 바꾸기로 계속 변경 가능
- 다른 창이 편집 대상을 지우면 아무것도 바꾸지 못한 채 저장 성공으로 닫히던 문제. 제출 시점에 대상을 재확인해 없으면 거절. 대상이 사라질 때 `initialCss`가 빈 값으로 내려가 편집기가 먼저 비워지던 것도 함께 수정, 편집 대상이 바뀔 때만 다시 읽음

**그래프**

- 버퍼 크기는 속도를 100ms로 나눠 잡는데 표본은 50ms마다 넣고 있어 1000ms 설정이 500ms 구간만 표시하던 문제. 표본 주기를 버퍼 계산과 일치시킴

**업데이트 모달**

- 최신 상태를 알리는 화면인데 접근성 이름은 업데이트 있음 제목으로 읽히던 문제. 화면에 보이는 제목과 일치시킴

**벤치마크 스크립트**

- 넘기는 설정이 창 배열을 통째로 교체하면서 `create: false`가 빠져 Tauri 자동 생성 창과 Rust가 만드는 창이 겹치던 문제

## 검증

- Vitest 3,155 통과, 18 스킵, 실패 0
- Rust lib 936 통과, 6 스킵, 실패 0
- 커밋 6개 각각 타입 검사 통과
- 결함마다 변이 테스트로 확인. 수정을 되돌리면 해당 테스트가 실패
- TypeScript, ESLint, Prettier 통과

## 알려진 한계

- `tests/tauri-config-contract.test.ts`의 정규식 계약은 인접한 다른 창 설정을 통과시킬 여지가 있음. 두 스크립트의 창 설정을 공용 모듈로 분리해 객체 단언으로 바꾸는 편이 나으나 이번 범위에서 제외
- Windows 실기와 실제 마우스 클릭 경로는 이 브랜치에서 검증하지 않음
